### PR TITLE
more stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 
 # Go workspace file
 go.work
+
+test.uplc

--- a/cmd/play/main.go
+++ b/cmd/play/main.go
@@ -17,35 +17,19 @@ func main() {
 
 	filename := os.Args[1]
 
-	content, err := os.ReadFile(filename)
-	if err != nil {
-		fmt.Printf("Error reading file: %v\n", err)
-		os.Exit(1)
-	}
+	content, _ := os.ReadFile(filename)
 
 	input := string(content)
 
-	program, err := syn.Parse(input)
+	program, _ := syn.Parse(input)
 
-	if err != nil {
-		fmt.Printf("Error parsing file: %v\n", err)
-
-		os.Exit(1)
-	}
-
-	dProgram, err := program.ToEval()
-
-	if err != nil {
-		fmt.Printf("Error converting program: %v\n", err)
-
-		os.Exit(1)
-	}
+	dProgram, _ := syn.NameToNamedDeBruijn(program)
 
 	mach := machine.NewMachine(200)
 
-	term, err := mach.Run(dProgram.Term)
+	term, _ := machine.Run[syn.NamedDeBruijn](mach, dProgram.Term)
 
-	prettyTerm := syn.PrettyTerm[syn.Eval](term)
+	prettyTerm := syn.PrettyTerm[syn.NamedDeBruijn](term)
 
 	fmt.Println(prettyTerm)
 }

--- a/cmd/play/main.go
+++ b/cmd/play/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/blinklabs-io/plutigo/pkg/machine"
+	"github.com/blinklabs-io/plutigo/pkg/syn"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Error: Please provide a file name as argument")
+
+		os.Exit(1)
+	}
+
+	filename := os.Args[1]
+
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		fmt.Printf("Error reading file: %v\n", err)
+		os.Exit(1)
+	}
+
+	input := string(content)
+
+	program, err := syn.Parse(input)
+
+	if err != nil {
+		fmt.Printf("Error parsing file: %v\n", err)
+
+		os.Exit(1)
+	}
+
+	dProgram, err := program.ToEval()
+
+	if err != nil {
+		fmt.Printf("Error converting program: %v\n", err)
+
+		os.Exit(1)
+	}
+
+	mach := machine.NewMachine(200)
+
+	term, err := mach.Run(dProgram.Term)
+
+	prettyTerm := syn.PrettyTerm[syn.Eval](term)
+
+	fmt.Println(prettyTerm)
+}

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/builtin/default_function.go
+++ b/pkg/builtin/default_function.go
@@ -415,3 +415,135 @@ func (f DefaultFunction) Arity() int {
 		panic("WTF")
 	}
 }
+
+func (f DefaultFunction) String() string {
+	switch f {
+	// Integer functions
+	case AddInteger:
+		return "addInteger"
+	case SubtractInteger:
+		return "subtractInteger"
+	case MultiplyInteger:
+		return "multiplyInteger"
+	case DivideInteger:
+		return "divideInteger"
+	case QuotientInteger:
+		return "quotientInteger"
+	case RemainderInteger:
+		return "remainderInteger"
+	case ModInteger:
+		return "modInteger"
+	case EqualsInteger:
+		return "equalsInteger"
+	case LessThanInteger:
+		return "lessThanInteger"
+	case LessThanEqualsInteger:
+		return "lessThanEqualsInteger"
+	// ByteString functions
+	case AppendByteString:
+		return "appendByteString"
+	case ConsByteString:
+		return "consByteString"
+	case SliceByteString:
+		return "sliceByteString"
+	case LengthOfByteString:
+		return "lengthOfByteString"
+	case IndexByteString:
+		return "indexByteString"
+	case EqualsByteString:
+		return "equalsByteString"
+	case LessThanByteString:
+		return "lessThanByteString"
+	case LessThanEqualsByteString:
+		return "lessThanEqualsByteString"
+	// Cryptography and hash functions
+	case Sha2_256:
+		return "sha2256"
+	case Sha3_256:
+		return "sha3256"
+	case Blake2b_256:
+		return "blake2B256"
+	case VerifyEd25519Signature:
+		return "verifyEd25519Signature"
+	case VerifyEcdsaSecp256k1Signature:
+		return "verifyEcdsaSecp256K1Signature"
+	case VerifySchnorrSecp256k1Signature:
+		return "verifySchnorrSecp256K1Signature"
+	// String functions
+	case AppendString:
+		return "appendString"
+	case EqualsString:
+		return "equalsString"
+	case EncodeUtf8:
+		return "encodeUtf8"
+	case DecodeUtf8:
+		return "decodeUtf8"
+	// Bool function
+	case IfThenElse:
+		return "ifThenElse"
+	// Unit function
+	case ChooseUnit:
+		return "chooseUnit"
+	// Tracing function
+	case Trace:
+		return "trace"
+	// Pairs functions
+	case FstPair:
+		return "fstPair"
+	case SndPair:
+		return "sndPair"
+	// List functions
+	case ChooseList:
+		return "chooseList"
+	case MkCons:
+		return "mkCons"
+	case HeadList:
+		return "headList"
+	case TailList:
+		return "tailList"
+	case NullList:
+		return "nullList"
+	// Data functions
+	// It is convenient to have a "choosing" function for a data type that has more than two
+	// constructors to get pattern matching over it and we may end up having multiple such data
+	// types hence we include the name of the data type as a suffix.
+	case ChooseData:
+		return "chooseData"
+	case ConstrData:
+		return "constrData"
+	case MapData:
+		return "mapData"
+	case ListData:
+		return "listData"
+	case IData:
+		return "iData"
+	case BData:
+		return "bData"
+	case UnConstrData:
+		return "unConstrData"
+	case UnMapData:
+		return "unMapData"
+	case UnListData:
+		return "unListData"
+	case UnIData:
+		return "unIData"
+	case UnBData:
+		return "unBData"
+	case EqualsData:
+		return "equalsData"
+	case SerialiseData:
+		return "serialiseData"
+	// Misc constructors
+	// Constructors that we need for constructing e.g. Data. Polymorphic builtin
+	// constructors are often problematic (See note [Representable built-in
+	// functions over polymorphic built-in types])
+	case MkPairData:
+		return "mkPairData"
+	case MkNilData:
+		return "mkNilData"
+	case MkNilPairData:
+		return "mkNilPairData"
+	default:
+		panic("unknown builtin")
+	}
+}

--- a/pkg/machine/context.go
+++ b/pkg/machine/context.go
@@ -6,80 +6,81 @@ import (
 	"github.com/blinklabs-io/plutigo/pkg/syn"
 )
 
-type MachineContext interface {
+type MachineContext[T syn.Eval] interface {
 	fmt.Stringer
+
 	isMachineContext()
 }
 
-type FrameAwaitArg struct {
-	Value Value
-	Ctx   MachineContext
+type FrameAwaitArg[T syn.Eval] struct {
+	Value Value[T]
+	Ctx   MachineContext[T]
 }
 
-func (f FrameAwaitArg) String() string {
+func (f FrameAwaitArg[T]) String() string {
 	return fmt.Sprintf("FrameAwaitArg(value=%v, ctx=%v)", f.Value, f.Ctx)
 }
 
-func (f FrameAwaitArg) isMachineContext() {}
+func (f FrameAwaitArg[T]) isMachineContext() {}
 
-type FrameAwaitFunTerm struct {
-	Env  Env
-	Term syn.Term[syn.Eval]
-	Ctx  MachineContext
+type FrameAwaitFunTerm[T syn.Eval] struct {
+	Env  Env[T]
+	Term syn.Term[T]
+	Ctx  MachineContext[T]
 }
 
-func (f FrameAwaitFunTerm) String() string {
+func (f FrameAwaitFunTerm[T]) String() string {
 	return fmt.Sprintf("FrameAwaitFunTerm(env=%v, term=%v, ctx=%v)", f.Env, f.Term, f.Ctx)
 }
 
-func (f FrameAwaitFunTerm) isMachineContext() {}
+func (f FrameAwaitFunTerm[T]) isMachineContext() {}
 
-type FrameAwaitFunValue struct {
-	Value Value
-	Ctx   MachineContext
+type FrameAwaitFunValue[T syn.Eval] struct {
+	Value Value[T]
+	Ctx   MachineContext[T]
 }
 
-func (f FrameAwaitFunValue) String() string {
+func (f FrameAwaitFunValue[T]) String() string {
 	return fmt.Sprintf("FrameAwaitFunValue(value=%v, ctx=%v)", f.Value, f.Ctx)
 }
 
-func (f FrameAwaitFunValue) isMachineContext() {}
+func (f FrameAwaitFunValue[T]) isMachineContext() {}
 
-type FrameForce struct {
-	Ctx MachineContext
+type FrameForce[T syn.Eval] struct {
+	Ctx MachineContext[T]
 }
 
-func (f FrameForce) String() string {
+func (f FrameForce[T]) String() string {
 	return fmt.Sprintf("FrameForce(ctx=%v)", f.Ctx)
 }
 
-func (f FrameForce) isMachineContext() {}
+func (f FrameForce[T]) isMachineContext() {}
 
-type FrameConstr struct {
-	Env            Env
+type FrameConstr[T syn.Eval] struct {
+	Env            Env[T]
 	Tag            uint
-	Fields         []syn.Term[syn.Eval]
-	ResolvedFields []Value
-	Ctx            MachineContext
+	Fields         []syn.Term[T]
+	ResolvedFields []Value[T]
+	Ctx            MachineContext[T]
 }
 
-func (f FrameConstr) String() string {
+func (f FrameConstr[T]) String() string {
 	return fmt.Sprintf("FrameConstr(env=%v, tag=%v, fields=%v, resolvedFields=%v, ctx=%v)", f.Env, f.Tag, f.Fields, f.ResolvedFields, f.Ctx)
 }
 
-func (f FrameConstr) isMachineContext() {}
+func (f FrameConstr[T]) isMachineContext() {}
 
-type FrameCases struct {
-	Env      Env
-	Branches []syn.Term[syn.Eval]
-	Ctx      MachineContext
+type FrameCases[T syn.Eval] struct {
+	Env      Env[T]
+	Branches []syn.Term[T]
+	Ctx      MachineContext[T]
 }
 
-func (f FrameCases) String() string {
+func (f FrameCases[T]) String() string {
 	return fmt.Sprintf("FrameCases(env=%v, branches=%v, ctx=%v)", f.Env, f.Branches, f.Ctx)
 }
 
-func (f FrameCases) isMachineContext() {}
+func (f FrameCases[T]) isMachineContext() {}
 
 type NoFrame struct{}
 

--- a/pkg/machine/env.go
+++ b/pkg/machine/env.go
@@ -1,8 +1,10 @@
 package machine
 
-type Env []Value
+import "github.com/blinklabs-io/plutigo/pkg/syn"
 
-func (e *Env) lookup(name uint) (*Value, bool) {
+type Env[T syn.Eval] []Value[T]
+
+func lookup[T syn.Eval](e *Env[T], name uint) (*Value[T], bool) {
 	idx := len(*e) - int(name)
 
 	if !indexExists(*e, idx) {

--- a/pkg/machine/runtime.go
+++ b/pkg/machine/runtime.go
@@ -8,18 +8,18 @@ import (
 	"github.com/blinklabs-io/plutigo/pkg/syn"
 )
 
-func (m *Machine) evalBuiltinApp(b Builtin) (Value, error) {
+func evalBuiltinApp[T syn.Eval](m *Machine, b Builtin[T]) (Value[T], error) {
 	// Budgeting
-	var evalValue Value
+	var evalValue Value[T]
 
 	switch b.Func {
 	case builtin.AddInteger:
-		arg1, err := unwrapInteger(b.Args[0])
+		arg1, err := unwrapInteger[T](b.Args[0])
 		if err != nil {
 			return nil, err
 		}
 
-		arg2, err := unwrapInteger(b.Args[1])
+		arg2, err := unwrapInteger[T](b.Args[1])
 		if err != nil {
 			return nil, err
 		}
@@ -31,18 +31,18 @@ func (m *Machine) evalBuiltinApp(b Builtin) (Value, error) {
 		newInt.Add(arg1, arg2)
 
 		evalValue = Constant{
-			Constant: syn.Integer{
+			Constant: &syn.Integer{
 				Inner: &newInt,
 			},
 		}
 
 	case builtin.SubtractInteger:
-		arg1, err := unwrapInteger(b.Args[0])
+		arg1, err := unwrapInteger[T](b.Args[0])
 		if err != nil {
 			return nil, err
 		}
 
-		arg2, err := unwrapInteger(b.Args[1])
+		arg2, err := unwrapInteger[T](b.Args[1])
 		if err != nil {
 			return nil, err
 		}
@@ -54,7 +54,7 @@ func (m *Machine) evalBuiltinApp(b Builtin) (Value, error) {
 		newInt.Sub(arg1, arg2)
 
 		evalValue = Constant{
-			Constant: syn.Integer{
+			Constant: &syn.Integer{
 				Inner: &newInt,
 			},
 		}
@@ -64,7 +64,7 @@ func (m *Machine) evalBuiltinApp(b Builtin) (Value, error) {
 	return evalValue, nil
 }
 
-func unwrapInteger(value Value) (*big.Int, error) {
+func unwrapInteger[T syn.Eval](value Value[T]) (*big.Int, error) {
 
 	var i *big.Int
 

--- a/pkg/machine/state.go
+++ b/pkg/machine/state.go
@@ -2,33 +2,27 @@ package machine
 
 import "github.com/blinklabs-io/plutigo/pkg/syn"
 
-type MachineState interface {
-	isDone() bool
+type MachineState[T syn.Eval] interface {
+	isMachineState()
 }
 
-type Return struct {
-	Ctx   MachineContext
-	Value Value
+type Return[T syn.Eval] struct {
+	Ctx   MachineContext[T]
+	Value Value[T]
 }
 
-func (r Return) isDone() bool {
-	return false
+func (r Return[T]) isMachineState() {}
+
+type Compute[T syn.Eval] struct {
+	Ctx  MachineContext[T]
+	Env  Env[T]
+	Term syn.Term[T]
 }
 
-type Compute struct {
-	Ctx  MachineContext
-	Env  Env
-	Term syn.Term[syn.Eval]
+func (c Compute[T]) isMachineState() {}
+
+type Done[T syn.Eval] struct {
+	term syn.Term[T]
 }
 
-func (c Compute) isDone() bool {
-	return false
-}
-
-type Done struct {
-	term syn.Term[syn.Eval]
-}
-
-func (d Done) isDone() bool {
-	return true
-}
+func (d Done[T]) isMachineState() {}

--- a/pkg/syn/binder.go
+++ b/pkg/syn/binder.go
@@ -12,10 +12,12 @@ type Binder interface {
 	BinderDecode(d any) (*Binder, error)
 	// TODO: maybe use String interface
 	TextName() string
+
 	fmt.Stringer
 }
 
 type Eval interface {
+	Binder
 	LookupIndex() uint64
 }
 

--- a/pkg/syn/constant.go
+++ b/pkg/syn/constant.go
@@ -16,9 +16,6 @@ type Integer struct {
 }
 
 func (Integer) isConstant() {}
-func (v Integer) String() string {
-	return fmt.Sprintf("Integer: %v", v.Inner)
-}
 
 // (con bytestring #aaBB)
 type ByteString struct {
@@ -26,9 +23,6 @@ type ByteString struct {
 }
 
 func (ByteString) isConstant() {}
-func (v ByteString) String() string {
-	return fmt.Sprintf("ByteString: %v", v.Inner)
-}
 
 // (con string "hello world")
 type String struct {
@@ -36,17 +30,11 @@ type String struct {
 }
 
 func (String) isConstant() {}
-func (v String) String() string {
-	return fmt.Sprintf("String: %v", v.Inner)
-}
 
 // (con unit ())
 type Unit struct{}
 
 func (Unit) isConstant() {}
-func (v Unit) String() string {
-	return fmt.Sprintf("Unit")
-}
 
 // (con bool True)
 type Bool struct {
@@ -54,9 +42,5 @@ type Bool struct {
 }
 
 func (Bool) isConstant() {}
-func (v Bool) String() string {
-	return fmt.Sprintf("Bool: %v", v.Inner)
-}
 
-type ProtoList struct {
-}
+type ProtoList struct{}

--- a/pkg/syn/conversions.go
+++ b/pkg/syn/conversions.go
@@ -26,10 +26,10 @@ func (p *Program[Name]) ToEval() (*Program[Eval], error) {
 	return program, nil
 }
 
-func (p *Program[Name]) NamedDeBruijn() (*Program[NamedDeBruijn], error) {
-	var converter converter
+func NameToNamedDeBruijn(p *Program[Name]) (*Program[NamedDeBruijn], error) {
+	converter := newConverter()
 
-	t, err := nameToIndex(&converter, p.Term, func(s string, d DeBruijn) NamedDeBruijn {
+	t, err := nameToIndex(converter, p.Term, func(s string, d DeBruijn) NamedDeBruijn {
 		return NamedDeBruijn{
 			Text:  s,
 			Index: d,
@@ -47,10 +47,10 @@ func (p *Program[Name]) NamedDeBruijn() (*Program[NamedDeBruijn], error) {
 	return program, nil
 }
 
-func (p *Program[Name]) DeBruijn() (*Program[DeBruijn], error) {
-	var converter converter
+func NameToDeBruijn(p *Program[Name]) (*Program[DeBruijn], error) {
+	converter := newConverter()
 
-	t, err := nameToIndex(&converter, p.Term, func(s string, d DeBruijn) DeBruijn {
+	t, err := nameToIndex(converter, p.Term, func(s string, d DeBruijn) DeBruijn {
 		return DeBruijn(d)
 	})
 	if err != nil {
@@ -69,6 +69,19 @@ type converter struct {
 	currentLevel  uint
 	currentUnique Unique
 	levels        []biMap
+}
+
+func newConverter() *converter {
+	return &converter{
+		currentLevel:  0,
+		currentUnique: 0,
+		levels: []biMap{
+			biMap{
+				left:  make(map[Unique]uint),
+				right: make(map[uint]Unique),
+			},
+		},
+	}
 }
 
 func nameToIndex[T any](c *converter, term Term[Name], converter func(string, DeBruijn) T) (Term[T], error) {

--- a/pkg/syn/pretty.go
+++ b/pkg/syn/pretty.go
@@ -1,0 +1,254 @@
+package syn
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Pretty Print a Program
+func Pretty[T Binder](p *Program[T]) string {
+	pp := NewPrettyPrinter(2)
+
+	return prettyPrintProgram(pp, p)
+}
+
+// Pretty Print a Program
+func PrettyTerm[T Binder](t Term[T]) string {
+	pp := NewPrettyPrinter(2)
+
+	return prettyPrintTerm[T](pp, t)
+}
+
+// PrettyPrinter manages the state for pretty-printing AST nodes
+type PrettyPrinter struct {
+	builder    strings.Builder
+	indent     int
+	indentSize int
+}
+
+// NewPrettyPrinter creates a new PrettyPrinter with the specified indent size
+func NewPrettyPrinter(indentSize int) *PrettyPrinter {
+	return &PrettyPrinter{
+		indentSize: indentSize,
+	}
+}
+
+// write writes a string to the builder
+func (pp *PrettyPrinter) write(s string) {
+	pp.builder.WriteString(s)
+}
+
+// writeIndent writes the current indentation
+func (pp *PrettyPrinter) writeIndent() {
+	pp.write(strings.Repeat(" ", pp.indent*pp.indentSize))
+}
+
+// increaseIndent increases the indentation level
+func (pp *PrettyPrinter) increaseIndent() {
+	pp.indent++
+}
+
+// decreaseIndent decreases the indentation level
+func (pp *PrettyPrinter) decreaseIndent() {
+	if pp.indent > 0 {
+		pp.indent--
+	}
+}
+
+// PrettyPrintTerm formats a Term[Name] to a string
+func prettyPrintTerm[T Binder](pp *PrettyPrinter, term Term[T]) string {
+	printTerm[T](pp, term)
+
+	return pp.builder.String()
+}
+
+func prettyPrintProgram[T Binder](pp *PrettyPrinter, prog *Program[T]) string {
+	printProgram(pp, prog)
+
+	return pp.builder.String()
+}
+
+// printProgram formats the Program node
+func printProgram[T Binder](pp *PrettyPrinter, prog *Program[T]) {
+	pp.write("(program ")
+
+	pp.write(fmt.Sprintf("%d.%d.%d", prog.Version[0], prog.Version[1], prog.Version[2]))
+
+	pp.write(" ")
+
+	printTerm[T](pp, prog.Term)
+
+	pp.write(")")
+}
+
+// printTerm dispatches to the appropriate term printing method
+func printTerm[T Binder](pp *PrettyPrinter, term Term[T]) {
+	switch t := term.(type) {
+	case *Var[T]:
+		pp.write(t.Name.TextName())
+	case *Lambda[T]:
+		pp.write("(lam ")
+
+		pp.write(t.ParameterName.TextName())
+
+		pp.write(" ")
+
+		printTerm[T](pp, t.Body)
+
+		pp.write(")")
+	case *Delay[T]:
+		pp.write("(delay ")
+
+		printTerm[T](pp, t.Term)
+
+		pp.write(")")
+	case *Force[Name]:
+		pp.write("(force ")
+
+		printTerm[T](pp, t.Term)
+
+		pp.write(")")
+	case *Apply[Name]:
+		pp.write("[")
+
+		printTerm[T](pp, t.Function)
+
+		pp.write(" ")
+
+		printTerm[T](pp, t.Argument)
+
+		pp.write("]")
+	case *Builtin:
+		pp.write("(builtin ")
+
+		pp.write(t.DefaultFunction.String()) // Assumes DefaultFunction has a String method
+
+		pp.write(")")
+	case *Constr[Name]:
+		pp.write(fmt.Sprintf("(constr %d", t.Tag))
+
+		for _, field := range *t.Fields {
+			pp.write(" ")
+
+			printTerm[T](pp, field)
+		}
+
+		pp.write(")")
+	case *Case[Name]:
+		pp.write("(case ")
+
+		printTerm[T](pp, t.Constr)
+
+		for _, branch := range *t.Branches {
+			pp.write(" ")
+
+			printTerm[T](pp, branch)
+		}
+		pp.write(")")
+	case *Error:
+		pp.write("(error)")
+	case Constant:
+		pp.printConstant(t)
+	default:
+		pp.write(fmt.Sprintf("unknown term: %v", t))
+	}
+}
+
+// printConstant formats a Constant node
+func (pp *PrettyPrinter) printConstant(c Constant) {
+	pp.write("(con ")
+
+	switch con := c.Con.(type) {
+	case Integer:
+		pp.write("integer ")
+
+		pp.write(con.Inner.String())
+	case ByteString:
+		pp.write("bytestring #")
+
+		for _, b := range con.Inner {
+			pp.builder.WriteString(fmt.Sprintf("%02x", b))
+		}
+	case String:
+		pp.write("string \"")
+
+		pp.write(escapeString(con.Inner))
+
+		pp.write("\"")
+	case Unit:
+		pp.write("unit ()")
+	case Bool:
+		pp.write("bool ")
+
+		if con.Inner {
+			pp.write("True")
+		} else {
+			pp.write("False")
+		}
+	default:
+		pp.write(fmt.Sprintf("unknown constant: %v", c))
+	}
+
+	pp.write(")")
+}
+
+// escapeString escapes special characters in a string for printing
+func escapeString(s string) string {
+	var builder strings.Builder
+
+	for _, r := range s {
+		switch r {
+		case '"':
+			builder.WriteString("\\\"")
+		case '\\':
+			builder.WriteString("\\\\")
+		case '\n':
+			builder.WriteString("\\n")
+		case '\t':
+			builder.WriteString("\\t")
+		default:
+			builder.WriteRune(r)
+		}
+	}
+
+	return builder.String()
+}
+
+// Updated AST types with String methods and modified fields
+
+// Integer implements String
+func (i Integer) String() string {
+	return i.Inner.String()
+}
+
+// ByteString implements String
+func (b ByteString) String() string {
+	pp := NewPrettyPrinter(2)
+
+	pp.write("#")
+
+	for _, byteVal := range b.Inner {
+		pp.builder.WriteString(fmt.Sprintf("%02x", byteVal))
+	}
+
+	return pp.builder.String()
+}
+
+// String implements String
+func (s String) String() string {
+	return fmt.Sprintf("\"%s\"", escapeString(s.Inner))
+}
+
+// Unit implements String
+func (u Unit) String() string {
+	return "()"
+}
+
+// Bool implements String
+func (b Bool) String() string {
+	if b.Inner {
+		return "True"
+	}
+
+	return "False"
+}

--- a/pkg/syn/pretty.go
+++ b/pkg/syn/pretty.go
@@ -147,7 +147,7 @@ func printTerm[T Binder](pp *PrettyPrinter, term Term[T]) {
 		pp.write(")")
 	case *Error:
 		pp.write("(error)")
-	case Constant:
+	case *Constant:
 		pp.printConstant(t)
 	default:
 		pp.write(fmt.Sprintf("unknown term: %v", t))
@@ -155,29 +155,29 @@ func printTerm[T Binder](pp *PrettyPrinter, term Term[T]) {
 }
 
 // printConstant formats a Constant node
-func (pp *PrettyPrinter) printConstant(c Constant) {
+func (pp *PrettyPrinter) printConstant(c *Constant) {
 	pp.write("(con ")
 
 	switch con := c.Con.(type) {
-	case Integer:
+	case *Integer:
 		pp.write("integer ")
 
 		pp.write(con.Inner.String())
-	case ByteString:
+	case *ByteString:
 		pp.write("bytestring #")
 
 		for _, b := range con.Inner {
 			pp.builder.WriteString(fmt.Sprintf("%02x", b))
 		}
-	case String:
+	case *String:
 		pp.write("string \"")
 
 		pp.write(escapeString(con.Inner))
 
 		pp.write("\"")
-	case Unit:
+	case *Unit:
 		pp.write("unit ()")
-	case Bool:
+	case *Bool:
 		pp.write("bool ")
 
 		if con.Inner {

--- a/pkg/syn/term.go
+++ b/pkg/syn/term.go
@@ -1,13 +1,10 @@
 package syn
 
 import (
-	"fmt"
-
 	"github.com/blinklabs-io/plutigo/pkg/builtin"
 )
 
 type Term[T any] interface {
-	fmt.Stringer
 	isTerm()
 }
 
@@ -17,9 +14,6 @@ type Var[T any] struct {
 }
 
 func (Var[T]) isTerm() {}
-func (v Var[T]) String() string {
-	return fmt.Sprintf("Var: %v", v.Name)
-}
 
 // (delay x)
 type Delay[T any] struct {
@@ -27,9 +21,6 @@ type Delay[T any] struct {
 }
 
 func (Delay[T]) isTerm() {}
-func (v Delay[T]) String() string {
-	return fmt.Sprintf("Delay: %v", v.Term)
-}
 
 // (force x)
 type Force[T any] struct {
@@ -37,9 +28,6 @@ type Force[T any] struct {
 }
 
 func (Force[T]) isTerm() {}
-func (v Force[T]) String() string {
-	return fmt.Sprintf("Force: %v", v.Term)
-}
 
 // (lam x x)
 type Lambda[T any] struct {
@@ -48,9 +36,6 @@ type Lambda[T any] struct {
 }
 
 func (Lambda[T]) isTerm() {}
-func (v Lambda[T]) String() string {
-	return fmt.Sprintf("Lambda: %v %v", v.ParameterName, v.Body)
-}
 
 // [ (lam x x) (con integer 1) ]
 type Apply[T any] struct {
@@ -59,9 +44,6 @@ type Apply[T any] struct {
 }
 
 func (Apply[T]) isTerm() {}
-func (v Apply[T]) String() string {
-	return fmt.Sprintf("Apply: %v %v", v.Function, v.Argument)
-}
 
 // (builtin addInteger)
 type Builtin struct {
@@ -69,9 +51,6 @@ type Builtin struct {
 }
 
 func (Builtin) isTerm() {}
-func (v Builtin) String() string {
-	return fmt.Sprintf("Builtin: %v", v.DefaultFunction)
-}
 
 // (constr 0 (con integer 1) (con string "1234"))
 type Constr[T any] struct {
@@ -80,9 +59,6 @@ type Constr[T any] struct {
 }
 
 func (Constr[T]) isTerm() {}
-func (v Constr[T]) String() string {
-	return fmt.Sprintf("Constr: %v %v", v.Tag, v.Fields)
-}
 
 // (case (constr 0) (constr 1 (con integer 1)))
 type Case[T any] struct {
@@ -91,17 +67,11 @@ type Case[T any] struct {
 }
 
 func (Case[T]) isTerm() {}
-func (v Case[T]) String() string {
-	return fmt.Sprintf("Case: %v %v", v.Constr, v.Branches)
-}
 
 // (error )
 type Error struct{}
 
 func (Error) isTerm() {}
-func (v Error) String() string {
-	return fmt.Sprintf("Error")
-}
 
 // (con integer 1)
 type Constant struct {
@@ -109,6 +79,3 @@ type Constant struct {
 }
 
 func (Constant) isTerm() {}
-func (v Constant) String() string {
-	return fmt.Sprintf("Constant: %v", v.Con)
-}

--- a/tests/conformance_test.go
+++ b/tests/conformance_test.go
@@ -239,7 +239,7 @@ func TestConformance(t *testing.T) {
 						debugLog(1, "Evaluation failure expected and encountered")
 						return
 					}
-					t.Fatalf("Evaluation failed: %v\nProgram: %s", errTerm, program.Term.String())
+					t.Fatalf("Evaluation failed: %v\nProgram: %s", errTerm, syn.PrettyTerm[syn.Binder](program.Term))
 				}
 
 				// Parse expected result

--- a/tests/conformance_test.go
+++ b/tests/conformance_test.go
@@ -224,12 +224,12 @@ func TestConformance(t *testing.T) {
 
 				mach := machine.NewMachine(200)
 
-				dProgram, err := program.NamedDeBruijn()
+				dProgram, err := syn.NameToNamedDeBruijn(program)
 				if err != nil {
 					t.Fatalf("Failed to convert program to DeBruijn: %v", err)
 				}
 
-				result, budget := mach.Run(dProgram.Term)
+				result, budget := machine.Run[syn.NamedDeBruijn](mach, dProgram.Term)
 
 				debugLog(2, "Evaluation result: %s", result)
 				debugLog(2, "Remaining budget: %s", budget)
@@ -239,7 +239,7 @@ func TestConformance(t *testing.T) {
 						debugLog(1, "Evaluation failure expected and encountered")
 						return
 					}
-					t.Fatalf("Evaluation failed: %v\nProgram: %s", errTerm, syn.PrettyTerm[syn.Binder](program.Term))
+					t.Fatalf("Evaluation failed: %v\nProgram: %s", errTerm, syn.PrettyTerm[syn.NamedDeBruijn](program.Term))
 				}
 
 				// Parse expected result


### PR DESCRIPTION
We actually need to be able to instantiate the type for Run at the call site and Machine has no concern for the type of Term anyways so we've decided to not make the machine functions be methods on Machine. They are now regular functions with a generic `T` such that `T` is constrained to `syn.Eval` where `syn.Eval` demands a method for looking up Value in the environment.

I've also added the beginning of a pretty printer