### PR TITLE
chore: minor updates and ignore comments for golangci-lint 2.x

### DIFF
--- a/cmd/play/main.go
+++ b/cmd/play/main.go
@@ -73,7 +73,7 @@ func main() {
 	} else {
 		prettyProgram := syn.Pretty[syn.Name](program)
 
-		os.WriteFile(filename, []byte(prettyProgram), 0644)
+		_ = os.WriteFile(filename, []byte(prettyProgram), 0644)
 
 		fmt.Println("done.")
 	}

--- a/pkg/syn/bimap.go
+++ b/pkg/syn/bimap.go
@@ -20,6 +20,7 @@ func (b *biMap) getByUnique(unique Unique) (uint, bool) {
 	return level, ok
 }
 
+//nolint:unused
 func (b *biMap) getByLevel(level uint) (Unique, bool) {
 	unique, ok := b.right[level]
 	return unique, ok

--- a/pkg/syn/conversions.go
+++ b/pkg/syn/conversions.go
@@ -197,6 +197,7 @@ func (c *converter) getIndex(name *Name) (DeBruijn, error) {
 	return 0, errors.New("FreeUnique")
 }
 
+//nolint:unused
 // getUnique finds the Unique identifier for a given DeBruijn index
 func (c *converter) getUnique(index DeBruijn) (Unique, error) {
 	for i := len(c.levels) - 1; i >= 0; i-- {
@@ -227,6 +228,7 @@ func (c *converter) removeUnique(unique Unique) {
 	scope.remove(unique, c.currentLevel)
 }
 
+//nolint:unused
 // declareBinder declares a new binder in the current scope
 func (c *converter) declareBinder() {
 	scope := &c.levels[c.currentLevel]

--- a/pkg/syn/lex/lexer.go
+++ b/pkg/syn/lex/lexer.go
@@ -194,7 +194,12 @@ func (l *Lexer) NextToken() Token {
 
 		for i := 0; i < len(literal); i += 2 {
 			var val uint8
-			fmt.Sscanf(literal[i:i+2], "%x", &val)
+			_, err = fmt.Sscanf(literal[i:i+2], "%x", &val)
+			if err != nil {
+				tok.Type = TokenError
+				tok.Literal = err.Error()
+				return tok
+			}
 			bytes[i/2] = val
 		}
 

--- a/pkg/syn/parser.go
+++ b/pkg/syn/parser.go
@@ -380,11 +380,12 @@ func (p *Parser) parseConstant() (Term[Name], error) {
 
 			var b bool
 
-			if p.curToken.Type == lex.TokenTrue {
+			switch p.curToken.Type {
+			case lex.TokenTrue:
 				b = true
-			} else if p.curToken.Type == lex.TokenFalse {
+			case lex.TokenFalse:
 				b = false
-			} else {
+			default:
 				return nil, fmt.Errorf("expected bool value, got %v at position %d", p.curToken.Type, p.curToken.Position)
 			}
 

--- a/pkg/syn/pretty.go
+++ b/pkg/syn/pretty.go
@@ -160,7 +160,7 @@ func printTerm[T Binder](pp *PrettyPrinter, term Term[T], isTopLevel bool) {
 	case *Builtin:
 		pp.write("(builtin ")
 
-		pp.write(t.DefaultFunction.String()) // Assumes DefaultFunction has a String method
+		pp.write(t.String()) // Assumes DefaultFunction has a String method
 
 		pp.write(")")
 	case *Constr[T]:

--- a/tests/conformance_test.go
+++ b/tests/conformance_test.go
@@ -13,12 +13,6 @@ import (
 	"github.com/blinklabs-io/plutigo/pkg/syn"
 )
 
-// Debug configuration
-const (
-	debugEnabled = true
-	debugLevel   = 2 // 1=basic, 2=verbose, 3=trace
-)
-
 // ==================== Test Cases ====================
 
 func TestParse(t *testing.T) {
@@ -271,6 +265,7 @@ func TestConformance(t *testing.T) {
 
 // ==================== Test Helpers ====================
 
+//nolint:unused
 func alphaEquivalent(a syn.Term[syn.NamedDeBruijn], b syn.Term[syn.NamedDeBruijn]) bool {
 	switch aTerm := a.(type) {
 	case syn.Var[syn.NamedDeBruijn]:


### PR DESCRIPTION
These fixes cover what's necessary for golangci-lint 2.x to pass checks except for this one:

```
pkg/syn/lex/lexer.go:137:6: QF1001: could apply De Morgan's law (staticcheck)
		if !((l.ch >= '0' && l.ch <= '9') || (l.ch >= 'a' && l.ch <= 'f') || (l.ch >= 'A' && l.ch <= 'F')) {
		   ^
1 issues:
* staticcheck: 1
```