### PR TITLE
Potential fix for code scanning alert no. 9: Incorrect conversion between integer types

### DIFF
--- a/pkg/cek/machine.go
+++ b/pkg/cek/machine.go
@@ -3,6 +3,7 @@ package cek
 import (
 	"errors"
 	"fmt"
+	"math"
 
 	"github.com/blinklabs-io/plutigo/pkg/syn"
 )

--- a/pkg/cek/machine.go
+++ b/pkg/cek/machine.go
@@ -282,6 +282,9 @@ func (m *Machine[T]) returnCompute(context MachineContext[T], value Value[T]) (M
 	case FrameCases[T]:
 		switch v := value.(type) {
 		case Constr[T]:
+			if v.Tag > uint32(math.MaxInt) {
+				return nil, errors.New("Tag value exceeds maximum int value")
+			}
 			if indexExists(c.Branches, int(v.Tag)) {
 				state = Compute[T]{
 					Ctx:  transferArgStack(v.Fields, c.Ctx),

--- a/pkg/syn/parser.go
+++ b/pkg/syn/parser.go
@@ -2,6 +2,7 @@ package syn
 
 import (
 	"fmt"
+	"math"
 	"math/big"
 	"strconv"
 

--- a/pkg/syn/parser.go
+++ b/pkg/syn/parser.go
@@ -260,8 +260,11 @@ func (p *Parser) parseConstr() (Term[Name], error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid constr tag %s at position %d: %v", p.curToken.Literal, p.curToken.Position, err)
 	}
+	if n > math.MaxUint32 {
+		return nil, fmt.Errorf("constr tag %s exceeds maximum uint32 value at position %d", p.curToken.Literal, p.curToken.Position)
+	}
 
-	tag := n
+	tag := uint32(n)
 
 	p.nextToken()
 


### PR DESCRIPTION
Potential fix for [https://github.com/blinklabs-io/plutigo/security/code-scanning/9](https://github.com/blinklabs-io/plutigo/security/code-scanning/9)

To fix the issue, we need to ensure that the conversion from `uint32` to `int` is safe. This can be achieved by adding an explicit bounds check before performing the conversion. Specifically:
1. In `pkg/cek/machine.go`, before converting `v.Tag` to an `int` on line 285, check that its value does not exceed the maximum value of the `int` type (`math.MaxInt`) or fall below the minimum value (`math.MinInt`).
2. If the value is out of bounds, return an appropriate error to prevent undefined behavior.

Additionally, the `strconv.ParseUint` call in `pkg/syn/parser.go` should be reviewed to ensure that it correctly parses the value as a `uint32` and that the resulting value is safely propagated.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
