### PR TITLE
chore: run format and golines

### DIFF
--- a/pkg/cek/context.go
+++ b/pkg/cek/context.go
@@ -30,7 +30,12 @@ type FrameAwaitFunTerm[T syn.Eval] struct {
 }
 
 func (f FrameAwaitFunTerm[T]) String() string {
-	return fmt.Sprintf("FrameAwaitFunTerm(env=%v, term=%v, ctx=%v)", f.Env, f.Term, f.Ctx)
+	return fmt.Sprintf(
+		"FrameAwaitFunTerm(env=%v, term=%v, ctx=%v)",
+		f.Env,
+		f.Term,
+		f.Ctx,
+	)
 }
 
 func (f FrameAwaitFunTerm[T]) isMachineContext() {}
@@ -65,7 +70,14 @@ type FrameConstr[T syn.Eval] struct {
 }
 
 func (f FrameConstr[T]) String() string {
-	return fmt.Sprintf("FrameConstr(env=%v, tag=%v, fields=%v, resolvedFields=%v, ctx=%v)", f.Env, f.Tag, f.Fields, f.ResolvedFields, f.Ctx)
+	return fmt.Sprintf(
+		"FrameConstr(env=%v, tag=%v, fields=%v, resolvedFields=%v, ctx=%v)",
+		f.Env,
+		f.Tag,
+		f.Fields,
+		f.ResolvedFields,
+		f.Ctx,
+	)
 }
 
 func (f FrameConstr[T]) isMachineContext() {}
@@ -77,7 +89,12 @@ type FrameCases[T syn.Eval] struct {
 }
 
 func (f FrameCases[T]) String() string {
-	return fmt.Sprintf("FrameCases(env=%v, branches=%v, ctx=%v)", f.Env, f.Branches, f.Ctx)
+	return fmt.Sprintf(
+		"FrameCases(env=%v, branches=%v, ctx=%v)",
+		f.Env,
+		f.Branches,
+		f.Ctx,
+	)
 }
 
 func (f FrameCases[T]) isMachineContext() {}

--- a/pkg/cek/cost_model.go
+++ b/pkg/cek/cost_model.go
@@ -170,7 +170,10 @@ func dataExMem(x data.PlutusData) func() ExMem {
 // like script context vs a Data of bytearray of 0 bytes. In this case the cpu ExBudget would far underestimate
 // the cost for calculating the ExMem for the entire script context thus causing a lot of free work to be done
 // by the node
-func equalsDataExMem(x data.PlutusData, y data.PlutusData) (func() ExMem, func() ExMem) {
+func equalsDataExMem(
+	x data.PlutusData,
+	y data.PlutusData,
+) (func() ExMem, func() ExMem) {
 
 	var xAcc ExMem
 	var yAcc ExMem

--- a/pkg/cek/cost_model_builtins.go
+++ b/pkg/cek/cost_model_builtins.go
@@ -453,7 +453,10 @@ func CostPair[T TwoArgument](cf CostingFunc[T], x, y func() ExMem) ExBudget {
 }
 
 // Function to cost ThreeArguments
-func CostTriple[T ThreeArgument](cf CostingFunc[T], x, y, z func() ExMem) ExBudget {
+func CostTriple[T ThreeArgument](
+	cf CostingFunc[T],
+	x, y, z func() ExMem,
+) ExBudget {
 	memConstants := cf.mem.HasConstants()
 	cpuConstants := cf.cpu.HasConstants()
 
@@ -484,7 +487,10 @@ func CostTriple[T ThreeArgument](cf CostingFunc[T], x, y, z func() ExMem) ExBudg
 }
 
 // Function to cost SixArguments
-func CostSextuple[T SixArgument](cf CostingFunc[T], a, b, c, d, e, f func() ExMem) ExBudget {
+func CostSextuple[T SixArgument](
+	cf CostingFunc[T],
+	a, b, c, d, e, f func() ExMem,
+) ExBudget {
 	memConstants := cf.mem.HasConstants()
 	cpuConstants := cf.cpu.HasConstants()
 

--- a/pkg/cek/machine.go
+++ b/pkg/cek/machine.go
@@ -217,7 +217,10 @@ func (m *Machine[T]) compute(
 	return state, nil
 }
 
-func (m *Machine[T]) returnCompute(context MachineContext[T], value Value[T]) (MachineState[T], error) {
+func (m *Machine[T]) returnCompute(
+	context MachineContext[T],
+	value Value[T],
+) (MachineState[T], error) {
 	var state MachineState[T]
 	var err error
 
@@ -314,7 +317,10 @@ func (m *Machine[T]) returnCompute(context MachineContext[T], value Value[T]) (M
 	return state, nil
 }
 
-func (m *Machine[T]) forceEvaluate(context MachineContext[T], value Value[T]) (MachineState[T], error) {
+func (m *Machine[T]) forceEvaluate(
+	context MachineContext[T],
+	value Value[T],
+) (MachineState[T], error) {
 	var state MachineState[T]
 
 	switch v := value.(type) {
@@ -356,7 +362,11 @@ func (m *Machine[T]) forceEvaluate(context MachineContext[T], value Value[T]) (M
 	return state, nil
 }
 
-func (m *Machine[T]) applyEvaluate(context MachineContext[T], function Value[T], arg Value[T]) (MachineState[T], error) {
+func (m *Machine[T]) applyEvaluate(
+	context MachineContext[T],
+	function Value[T],
+	arg Value[T],
+) (MachineState[T], error) {
 	var state MachineState[T]
 
 	switch f := function.(type) {
@@ -404,7 +414,10 @@ func (m *Machine[T]) applyEvaluate(context MachineContext[T], function Value[T],
 	return state, nil
 }
 
-func transferArgStack[T syn.Eval](fields []Value[T], ctx MachineContext[T]) MachineContext[T] {
+func transferArgStack[T syn.Eval](
+	fields []Value[T],
+	ctx MachineContext[T],
+) MachineContext[T] {
 	c := ctx
 
 	for arg := len(fields) - 1; arg >= 0; arg-- {

--- a/pkg/cek/runtime.go
+++ b/pkg/cek/runtime.go
@@ -33,7 +33,10 @@ func (m *Machine[T]) CostOne(b *builtin.DefaultFunction, x func() ExMem) error {
 	return err
 }
 
-func (m *Machine[T]) CostTwo(b *builtin.DefaultFunction, x, y func() ExMem) error {
+func (m *Machine[T]) CostTwo(
+	b *builtin.DefaultFunction,
+	x, y func() ExMem,
+) error {
 	model := m.costs.builtinCosts[*b]
 
 	mem, _ := model.mem.(TwoArgument)
@@ -49,7 +52,10 @@ func (m *Machine[T]) CostTwo(b *builtin.DefaultFunction, x, y func() ExMem) erro
 	return err
 }
 
-func (m *Machine[T]) CostThree(b *builtin.DefaultFunction, x, y, z func() ExMem) error {
+func (m *Machine[T]) CostThree(
+	b *builtin.DefaultFunction,
+	x, y, z func() ExMem,
+) error {
 	model := m.costs.builtinCosts[*b]
 
 	mem, _ := model.mem.(ThreeArgument)
@@ -65,7 +71,10 @@ func (m *Machine[T]) CostThree(b *builtin.DefaultFunction, x, y, z func() ExMem)
 	return err
 }
 
-func (m *Machine[T]) Costsix(b *builtin.DefaultFunction, x, y, z, xx, yy, zz func() ExMem) error {
+func (m *Machine[T]) Costsix(
+	b *builtin.DefaultFunction,
+	x, y, z, xx, yy, zz func() ExMem,
+) error {
 	model := m.costs.builtinCosts[*b]
 
 	mem, _ := model.mem.(SixArgument)
@@ -215,7 +224,10 @@ func (m *Machine[T]) evalBuiltinApp(b *Builtin[T]) (Value[T], error) {
 
 		var newInt big.Int
 
-		newInt.Quo(arg1, arg2) // Floor division (rounds toward negative infinity)
+		newInt.Quo(
+			arg1,
+			arg2,
+		) // Floor division (rounds toward negative infinity)
 
 		evalValue = &Constant{
 			Constant: &syn.Integer{
@@ -246,7 +258,10 @@ func (m *Machine[T]) evalBuiltinApp(b *Builtin[T]) (Value[T], error) {
 
 		var newInt big.Int
 
-		newInt.Rem(arg1, arg2) // Remainder (consistent with Div, can be negative)
+		newInt.Rem(
+			arg1,
+			arg2,
+		) // Remainder (consistent with Div, can be negative)
 
 		evalValue = &Constant{
 			Constant: &syn.Integer{
@@ -436,7 +451,12 @@ func (m *Machine[T]) evalBuiltinApp(b *Builtin[T]) (Value[T], error) {
 			return nil, err
 		}
 
-		err = m.CostThree(&b.Func, bigIntExMem(arg1), bigIntExMem(arg2), byteArrayExMem(arg3))
+		err = m.CostThree(
+			&b.Func,
+			bigIntExMem(arg1),
+			bigIntExMem(arg2),
+			byteArrayExMem(arg3),
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -676,17 +696,28 @@ func (m *Machine[T]) evalBuiltinApp(b *Builtin[T]) (Value[T], error) {
 			return nil, err
 		}
 
-		err = m.CostThree(&b.Func, byteArrayExMem(publicKey), byteArrayExMem(message), byteArrayExMem(signature))
+		err = m.CostThree(
+			&b.Func,
+			byteArrayExMem(publicKey),
+			byteArrayExMem(message),
+			byteArrayExMem(signature),
+		)
 		if err != nil {
 			return nil, err
 		}
 
 		if len(publicKey) != ed25519.PublicKeySize { // 32 bytes
-			return nil, fmt.Errorf("invalid public key length: got %d, expected 32", len(publicKey))
+			return nil, fmt.Errorf(
+				"invalid public key length: got %d, expected 32",
+				len(publicKey),
+			)
 		}
 
 		if len(signature) != ed25519.SignatureSize { // 64 bytes
-			return nil, fmt.Errorf("invalid signature length: got %d, expected 64", len(signature))
+			return nil, fmt.Errorf(
+				"invalid signature length: got %d, expected 64",
+				len(signature),
+			)
 		}
 
 		res := ed25519.Verify(publicKey, message, signature)
@@ -805,7 +836,12 @@ func (m *Machine[T]) evalBuiltinApp(b *Builtin[T]) (Value[T], error) {
 		arg2 := b.Args[1]
 		arg3 := b.Args[2]
 
-		err = m.CostThree(&b.Func, boolExMem(arg1), valueExMem[T](arg2), valueExMem[T](arg3))
+		err = m.CostThree(
+			&b.Func,
+			boolExMem(arg1),
+			valueExMem[T](arg2),
+			valueExMem[T](arg3),
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -882,7 +918,12 @@ func (m *Machine[T]) evalBuiltinApp(b *Builtin[T]) (Value[T], error) {
 
 		branchOtherwise := b.Args[2]
 
-		err = m.CostThree(&b.Func, listExMem(l.List), valueExMem[T](branchEmpty), valueExMem[T](branchOtherwise))
+		err = m.CostThree(
+			&b.Func,
+			listExMem(l.List),
+			valueExMem[T](branchEmpty),
+			valueExMem[T](branchOtherwise),
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -1283,7 +1324,10 @@ func unwrapUnit[T syn.Eval](value Value[T]) error {
 	}
 }
 
-func unwrapList[T syn.Eval](typ syn.Typ, value Value[T]) (*syn.ProtoList, error) {
+func unwrapList[T syn.Eval](
+	typ syn.Typ,
+	value Value[T],
+) (*syn.ProtoList, error) {
 	var i *syn.ProtoList
 
 	switch v := value.(type) {
@@ -1304,7 +1348,9 @@ func unwrapList[T syn.Eval](typ syn.Typ, value Value[T]) (*syn.ProtoList, error)
 	return i, nil
 }
 
-func unwrapPair[T syn.Eval](value Value[T]) (syn.IConstant, syn.IConstant, error) {
+func unwrapPair[T syn.Eval](
+	value Value[T],
+) (syn.IConstant, syn.IConstant, error) {
 	var i syn.IConstant
 	var j syn.IConstant
 

--- a/pkg/data/decode.go
+++ b/pkg/data/decode.go
@@ -114,7 +114,11 @@ func decodeRaw(v interface{}) (PlutusData, error) {
 func decodeConstr(tag uint64, content interface{}) (PlutusData, error) {
 	arr, ok := content.([]interface{})
 	if !ok {
-		return nil, fmt.Errorf("expected array for Constr tag %d, got %T", tag, content)
+		return nil, fmt.Errorf(
+			"expected array for Constr tag %d, got %T",
+			tag,
+			content,
+		)
 	}
 
 	fields := make([]PlutusData, len(arr))
@@ -122,7 +126,11 @@ func decodeConstr(tag uint64, content interface{}) (PlutusData, error) {
 	for i, item := range arr {
 		pd, err := decodeRaw(item)
 		if err != nil {
-			return nil, fmt.Errorf("failed to decode Constr field %d: %w", i, err)
+			return nil, fmt.Errorf(
+				"failed to decode Constr field %d: %w",
+				i,
+				err,
+			)
 		}
 
 		fields[i] = pd

--- a/pkg/syn/conversions.go
+++ b/pkg/syn/conversions.go
@@ -8,12 +8,16 @@ import (
 func NameToNamedDeBruijn(p *Program[Name]) (*Program[NamedDeBruijn], error) {
 	converter := newConverter()
 
-	t, err := nameToIndex(converter, p.Term, func(s string, d DeBruijn) NamedDeBruijn {
-		return NamedDeBruijn{
-			Text:  s,
-			Index: d,
-		}
-	})
+	t, err := nameToIndex(
+		converter,
+		p.Term,
+		func(s string, d DeBruijn) NamedDeBruijn {
+			return NamedDeBruijn{
+				Text:  s,
+				Index: d,
+			}
+		},
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -29,9 +33,13 @@ func NameToNamedDeBruijn(p *Program[Name]) (*Program[NamedDeBruijn], error) {
 func NameToDeBruijn(p *Program[Name]) (*Program[DeBruijn], error) {
 	converter := newConverter()
 
-	t, err := nameToIndex(converter, p.Term, func(s string, d DeBruijn) DeBruijn {
-		return DeBruijn(d)
-	})
+	t, err := nameToIndex(
+		converter,
+		p.Term,
+		func(s string, d DeBruijn) DeBruijn {
+			return DeBruijn(d)
+		},
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +71,11 @@ func newConverter() *converter {
 	}
 }
 
-func nameToIndex[T any](c *converter, term Term[Name], converter func(string, DeBruijn) T) (Term[T], error) {
+func nameToIndex[T any](
+	c *converter,
+	term Term[Name],
+	converter func(string, DeBruijn) T,
+) (Term[T], error) {
 	var converted Term[T]
 
 	switch t := term.(type) {
@@ -197,8 +209,9 @@ func (c *converter) getIndex(name *Name) (DeBruijn, error) {
 	return 0, errors.New("FreeUnique")
 }
 
-//nolint:unused
 // getUnique finds the Unique identifier for a given DeBruijn index
+//
+//nolint:unused
 func (c *converter) getUnique(index DeBruijn) (Unique, error) {
 	for i := len(c.levels) - 1; i >= 0; i-- {
 		indexVal := uint(index)
@@ -228,8 +241,9 @@ func (c *converter) removeUnique(unique Unique) {
 	scope.remove(unique, c.currentLevel)
 }
 
-//nolint:unused
 // declareBinder declares a new binder in the current scope
+//
+//nolint:unused
 func (c *converter) declareBinder() {
 	scope := &c.levels[c.currentLevel]
 	scope.insert(c.currentUnique, c.currentLevel)

--- a/pkg/syn/flat_decode.go
+++ b/pkg/syn/flat_decode.go
@@ -66,7 +66,11 @@ func DecodeTerm[T Binder](d *decoder) (Term[T], error) {
 
 		name, ok := binder.(T) // Assign returned Binder to t
 		if !ok {
-			return nil, fmt.Errorf("VarDecode returned wrong type: got %T, want %T", binder, name)
+			return nil, fmt.Errorf(
+				"VarDecode returned wrong type: got %T, want %T",
+				binder,
+				name,
+			)
 		}
 
 		term = &Var[T]{Name: name}
@@ -88,7 +92,11 @@ func DecodeTerm[T Binder](d *decoder) (Term[T], error) {
 
 		name, ok := binder.(T) // Assign returned Binder to t
 		if !ok {
-			return nil, fmt.Errorf("ParameterDecode returned wrong type: got %T, want %T", binder, name)
+			return nil, fmt.Errorf(
+				"ParameterDecode returned wrong type: got %T, want %T",
+				binder,
+				name,
+			)
 		}
 
 		t, err := DecodeTerm[T](d)
@@ -271,7 +279,10 @@ func decodeConstantTag(d *decoder) (byte, error) {
 // Otherwise we decode an item in the list with the decoder function passed
 // in. Then decode the next bit in the buffer and repeat above.
 // Returns a list of items decoded with the decoder function.
-func DecodeList[T any](d *decoder, decoderFunc func(*decoder) (T, error)) ([]T, error) {
+func DecodeList[T any](
+	d *decoder,
+	decoderFunc func(*decoder) (T, error),
+) ([]T, error) {
 	result := make([]T, 0)
 
 	for {

--- a/pkg/syn/flat_encode.go
+++ b/pkg/syn/flat_encode.go
@@ -134,7 +134,11 @@ func EncodeTerm[T Binder](e *encoder, term Term[T]) error {
 	return nil
 }
 
-func EncodeList[T any](e *encoder, items []T, itemEncoder func(*encoder, T) error) error {
+func EncodeList[T any](
+	e *encoder,
+	items []T,
+	itemEncoder func(*encoder, T) error,
+) error {
 	for _, item := range items {
 		e.one()
 
@@ -175,7 +179,11 @@ func (e *encoder) encodeTermTag(tag byte) error {
 
 func (e *encoder) safeEncodeBits(numBits byte, val byte) error {
 	if 2<<numBits <= val {
-		return fmt.Errorf("overflow detected, cannot fit %d in %d bits", val, numBits)
+		return fmt.Errorf(
+			"overflow detected, cannot fit %d in %d bits",
+			val,
+			numBits,
+		)
 	}
 
 	e.bits(numBits, val)

--- a/pkg/syn/lex/lexer.go
+++ b/pkg/syn/lex/lexer.go
@@ -128,19 +128,33 @@ func (l *Lexer) readByteString() (string, error) {
 		l.readChar()
 
 		switch {
-		case l.ch == 0, unicode.IsSpace(l.ch), l.ch == ')', l.ch == ']', l.ch == ',':
+		case l.ch == 0,
+			unicode.IsSpace(l.ch),
+			l.ch == ')',
+			l.ch == ']',
+			l.ch == ',':
 			literal := l.input[start:l.pos]
 
 			if len(literal)%2 != 0 {
-				return "", fmt.Errorf("bytestring #%s has odd length at position %d", literal, start-1)
+				return "", fmt.Errorf(
+					"bytestring #%s has odd length at position %d",
+					literal,
+					start-1,
+				)
 			}
 
 			return literal, nil
-		case (l.ch >= '0' && l.ch <= '9'), (l.ch >= 'a' && l.ch <= 'f'), (l.ch >= 'A' && l.ch <= 'F'):
+		case (l.ch >= '0' && l.ch <= '9'),
+			(l.ch >= 'a' && l.ch <= 'f'),
+			(l.ch >= 'A' && l.ch <= 'F'):
 			// All good, continue
 			continue
 		default:
-			return "", fmt.Errorf("invalid bytestring character %c at position %d", l.ch, l.pos)
+			return "", fmt.Errorf(
+				"invalid bytestring character %c at position %d",
+				l.ch,
+				l.pos,
+			)
 		}
 	}
 }

--- a/pkg/syn/parser.go
+++ b/pkg/syn/parser.go
@@ -40,7 +40,12 @@ func (p *Parser) nextToken() {
 
 func (p *Parser) expect(typ lex.TokenType) error {
 	if p.curToken.Type != typ {
-		return fmt.Errorf("expected %v, got %v at position %d", typ, p.curToken.Type, p.curToken.Position)
+		return fmt.Errorf(
+			"expected %v, got %v at position %d",
+			typ,
+			p.curToken.Type,
+			p.curToken.Position,
+		)
 	}
 
 	p.nextToken()
@@ -81,13 +86,22 @@ func (p *Parser) ParseProgram() (*Program[Name], error) {
 
 	for i := 0; i < 3; i++ {
 		if p.curToken.Type != lex.TokenNumber {
-			return nil, fmt.Errorf("expected version number, got %v at position %d", p.curToken.Type, p.curToken.Position)
+			return nil, fmt.Errorf(
+				"expected version number, got %v at position %d",
+				p.curToken.Type,
+				p.curToken.Position,
+			)
 		}
 
 		n, err := strconv.ParseUint(p.curToken.Literal, 10, 32)
 
 		if err != nil {
-			return nil, fmt.Errorf("invalid version number %s at position %d: %v", p.curToken.Literal, p.curToken.Position, err)
+			return nil, fmt.Errorf(
+				"invalid version number %s at position %d: %v",
+				p.curToken.Literal,
+				p.curToken.Position,
+				err,
+			)
 		}
 
 		version[i] = uint32(n)
@@ -112,7 +126,11 @@ func (p *Parser) ParseProgram() (*Program[Name], error) {
 	}
 
 	if p.curToken.Type != lex.TokenEOF {
-		return nil, fmt.Errorf("unexpected token %v after program at position %d", p.curToken.Type, p.curToken.Position)
+		return nil, fmt.Errorf(
+			"unexpected token %v after program at position %d",
+			p.curToken.Type,
+			p.curToken.Position,
+		)
 	}
 
 	return &Program[Name]{Version: version, Term: term}, nil
@@ -152,12 +170,20 @@ func (p *Parser) ParseTerm() (Term[Name], error) {
 
 			return &Error{}, nil
 		default:
-			return nil, fmt.Errorf("unexpected token %v in term at position %d", p.curToken.Type, p.curToken.Position)
+			return nil, fmt.Errorf(
+				"unexpected token %v in term at position %d",
+				p.curToken.Type,
+				p.curToken.Position,
+			)
 		}
 	case lex.TokenLBracket:
 		return p.parseApply()
 	default:
-		return nil, fmt.Errorf("unexpected token %v in term at position %d", p.curToken.Type, p.curToken.Position)
+		return nil, fmt.Errorf(
+			"unexpected token %v in term at position %d",
+			p.curToken.Type,
+			p.curToken.Position,
+		)
 	}
 }
 
@@ -167,7 +193,11 @@ func (p *Parser) parseLambda() (Term[Name], error) {
 	}
 
 	if p.curToken.Type != lex.TokenIdentifier {
-		return nil, fmt.Errorf("expected identifier, got %v at position %d", p.curToken.Type, p.curToken.Position)
+		return nil, fmt.Errorf(
+			"expected identifier, got %v at position %d",
+			p.curToken.Type,
+			p.curToken.Position,
+		)
 	}
 
 	name := p.internName(p.curToken.Literal)
@@ -229,7 +259,11 @@ func (p *Parser) parseBuiltin() (Term[Name], error) {
 	}
 
 	if p.curToken.Type != lex.TokenIdentifier {
-		return nil, fmt.Errorf("expected builtin name, got %v at position %d", p.curToken.Type, p.curToken.Position)
+		return nil, fmt.Errorf(
+			"expected builtin name, got %v at position %d",
+			p.curToken.Type,
+			p.curToken.Position,
+		)
 	}
 
 	name := p.curToken.Literal
@@ -237,7 +271,11 @@ func (p *Parser) parseBuiltin() (Term[Name], error) {
 	fn, ok := builtin.Builtins[name]
 
 	if !ok {
-		return nil, fmt.Errorf("unknown builtin function %s at position %d", name, p.curToken.Position)
+		return nil, fmt.Errorf(
+			"unknown builtin function %s at position %d",
+			name,
+			p.curToken.Position,
+		)
 	}
 
 	p.nextToken()
@@ -255,12 +293,21 @@ func (p *Parser) parseConstr() (Term[Name], error) {
 	}
 
 	if p.curToken.Type != lex.TokenNumber {
-		return nil, fmt.Errorf("expected tag number, got %v at position %d", p.curToken.Type, p.curToken.Position)
+		return nil, fmt.Errorf(
+			"expected tag number, got %v at position %d",
+			p.curToken.Type,
+			p.curToken.Position,
+		)
 	}
 
 	n, err := strconv.Atoi(p.curToken.Literal)
 	if err != nil {
-		return nil, fmt.Errorf("invalid constr tag %s at position %d: %v", p.curToken.Literal, p.curToken.Position, err)
+		return nil, fmt.Errorf(
+			"invalid constr tag %s at position %d: %v",
+			p.curToken.Literal,
+			p.curToken.Position,
+			err,
+		)
 	}
 
 	tag := n
@@ -647,12 +694,20 @@ func (p *Parser) parsePlutusData() (data.PlutusData, error) {
 		p.nextToken()
 
 		if p.curToken.Type != lex.TokenNumber {
-			return nil, fmt.Errorf("expected integer value for I, got %v at position %d", p.curToken.Type, p.curToken.Position)
+			return nil, fmt.Errorf(
+				"expected integer value for I, got %v at position %d",
+				p.curToken.Type,
+				p.curToken.Position,
+			)
 		}
 
 		n, ok := p.curToken.Value.(*big.Int)
 		if !ok {
-			return nil, fmt.Errorf("invalid integer value %s at position %d", p.curToken.Literal, p.curToken.Position)
+			return nil, fmt.Errorf(
+				"invalid integer value %s at position %d",
+				p.curToken.Literal,
+				p.curToken.Position,
+			)
 		}
 
 		p.nextToken()
@@ -662,12 +717,20 @@ func (p *Parser) parsePlutusData() (data.PlutusData, error) {
 		p.nextToken()
 
 		if p.curToken.Type != lex.TokenByteString {
-			return nil, fmt.Errorf("expected bytestring value for B, got %v at position %d", p.curToken.Type, p.curToken.Position)
+			return nil, fmt.Errorf(
+				"expected bytestring value for B, got %v at position %d",
+				p.curToken.Type,
+				p.curToken.Position,
+			)
 		}
 
 		b, ok := p.curToken.Value.([]byte)
 		if !ok {
-			return nil, fmt.Errorf("invalid bytestring value %s at position %d", p.curToken.Literal, p.curToken.Position)
+			return nil, fmt.Errorf(
+				"invalid bytestring value %s at position %d",
+				p.curToken.Literal,
+				p.curToken.Position,
+			)
 		}
 
 		p.nextToken()
@@ -753,12 +816,21 @@ func (p *Parser) parsePlutusData() (data.PlutusData, error) {
 		p.nextToken()
 
 		if p.curToken.Type != lex.TokenNumber {
-			return nil, fmt.Errorf("expected tag number for Constr, got %v at position %d", p.curToken.Type, p.curToken.Position)
+			return nil, fmt.Errorf(
+				"expected tag number for Constr, got %v at position %d",
+				p.curToken.Type,
+				p.curToken.Position,
+			)
 		}
 
 		n, err := strconv.Atoi(p.curToken.Literal)
 		if err != nil {
-			return nil, fmt.Errorf("invalid constr tag %s at position %d: %v", p.curToken.Literal, p.curToken.Position, err)
+			return nil, fmt.Errorf(
+				"invalid constr tag %s at position %d: %v",
+				p.curToken.Literal,
+				p.curToken.Position,
+				err,
+			)
 		}
 
 		tag := uint(n)
@@ -792,15 +864,24 @@ func (p *Parser) parsePlutusData() (data.PlutusData, error) {
 
 		return data.NewConstr(tag, fields), nil
 	default:
-		return nil, fmt.Errorf("expected PlutusData constructor (I, B, List, Map, Constr), got %v at position %d", p.curToken.Type, p.curToken.Position)
+		return nil, fmt.Errorf(
+			"expected PlutusData constructor (I, B, List, Map, Constr), got %v at position %d",
+			p.curToken.Type,
+			p.curToken.Position,
+		)
 	}
 }
 
 func (p *Parser) parseTypeSpec() (Typ, error) {
 	// Check for invalid bare list or pair
 	if p.curToken.Type == lex.TokenList || p.curToken.Type == lex.TokenPair {
-		return nil, fmt.Errorf("expected left parenthesis for %d type, got %v (literal: %s) at position %d",
-			p.curToken.Type, p.curToken.Type, p.curToken.Literal, p.curToken.Position)
+		return nil, fmt.Errorf(
+			"expected left parenthesis for %d type, got %v (literal: %s) at position %d",
+			p.curToken.Type,
+			p.curToken.Type,
+			p.curToken.Literal,
+			p.curToken.Position,
+		)
 	}
 
 	// Handle parenthesized type specs (e.g., (list data), (pair integer bool))
@@ -814,7 +895,12 @@ func (p *Parser) parseTypeSpec() (Typ, error) {
 		}
 
 		if p.curToken.Type != lex.TokenRParen {
-			return nil, fmt.Errorf("expected right parenthesis after type spec, got %v (literal: %s) at position %d", p.curToken.Type, p.curToken.Literal, p.curToken.Position)
+			return nil, fmt.Errorf(
+				"expected right parenthesis after type spec, got %v (literal: %s) at position %d",
+				p.curToken.Type,
+				p.curToken.Literal,
+				p.curToken.Position,
+			)
 		}
 
 		p.nextToken()
@@ -847,7 +933,11 @@ func (p *Parser) parseInnerTypeSpec() (Typ, error) {
 		case "data":
 			return &TData{}, nil
 		default:
-			return nil, fmt.Errorf("unknown type %s at position %d", typName, p.curToken.Position)
+			return nil, fmt.Errorf(
+				"unknown type %s at position %d",
+				typName,
+				p.curToken.Position,
+			)
 		}
 	case lex.TokenList:
 		p.nextToken()
@@ -875,7 +965,12 @@ func (p *Parser) parseInnerTypeSpec() (Typ, error) {
 
 		return &TPair{First: firstType, Second: secondType}, nil
 	default:
-		return nil, fmt.Errorf("expected type identifier, list, or pair, got %v (literal: %s) at position %d", p.curToken.Type, p.curToken.Literal, p.curToken.Position)
+		return nil, fmt.Errorf(
+			"expected type identifier, list, or pair, got %v (literal: %s) at position %d",
+			p.curToken.Type,
+			p.curToken.Literal,
+			p.curToken.Position,
+		)
 	}
 }
 
@@ -895,7 +990,11 @@ func (p *Parser) parseApply() (Term[Name], error) {
 	}
 
 	if len(terms) < 2 {
-		return nil, fmt.Errorf("application requires at least two terms, got %d at position %d", len(terms), p.curToken.Position)
+		return nil, fmt.Errorf(
+			"application requires at least two terms, got %d at position %d",
+			len(terms),
+			p.curToken.Position,
+		)
 	}
 
 	if err := p.expect(lex.TokenRBracket); err != nil {

--- a/pkg/syn/pretty.go
+++ b/pkg/syn/pretty.go
@@ -75,7 +75,14 @@ func prettyPrintProgram[T Binder](pp *PrettyPrinter, prog *Program[T]) string {
 func printProgram[T Binder](pp *PrettyPrinter, prog *Program[T]) {
 	pp.write("(program ")
 
-	pp.write(fmt.Sprintf("%d.%d.%d", prog.Version[0], prog.Version[1], prog.Version[2]))
+	pp.write(
+		fmt.Sprintf(
+			"%d.%d.%d",
+			prog.Version[0],
+			prog.Version[1],
+			prog.Version[2],
+		),
+	)
 
 	pp.write("\n")
 


### PR DESCRIPTION
Formatting only changes.

```
go fmt ./...
gofmt -s -w $(find . -name '*.go')
golines -w --ignore-generated --chain-split-dots --max-len=80 --reformat-tags .
```