### PR TITLE
fix: use indef-length list encoding for Constr fields

### DIFF
--- a/pkg/data/data.go
+++ b/pkg/data/data.go
@@ -46,7 +46,10 @@ func (c Constr) String() string {
 }
 
 // NewConstr creates a new Constr variant.
-func NewConstr(tag uint, fields []PlutusData) PlutusData {
+func NewConstr(tag uint, fields ...PlutusData) PlutusData {
+	if fields == nil {
+		fields = make([]PlutusData, 0)
+	}
 	return &Constr{tag, fields}
 }
 
@@ -114,6 +117,25 @@ func (l List) String() string {
 }
 
 // NewList creates a new List variant.
-func NewList(items []PlutusData) PlutusData {
+func NewList(items ...PlutusData) PlutusData {
 	return &List{items}
+}
+
+// IndefList
+
+type IndefList struct {
+	Items []PlutusData
+}
+
+func (IndefList) isPlutusData() {}
+
+func (l IndefList) String() string {
+	return fmt.Sprintf("IndefList%v", l.Items)
+}
+
+// NewIndefList creates a new IndefList
+func NewIndefList(items ...PlutusData) PlutusData {
+	return &IndefList{
+		Items: items,
+	}
 }

--- a/pkg/data/data_test.go
+++ b/pkg/data/data_test.go
@@ -21,22 +21,40 @@ var testDefs = []struct {
 	},
 	{
 		Data: NewList(
-			[]PlutusData{
-				NewInteger(big.NewInt(123)),
-				NewInteger(big.NewInt(456)),
-			},
+			NewInteger(big.NewInt(123)),
+			NewInteger(big.NewInt(456)),
 		),
 		CborHex: "82187b1901c8",
 	},
 	{
 		Data: NewConstr(
 			1,
-			[]PlutusData{
-				NewByteString([]byte{0xab, 0xcd}),
-			},
+			NewByteString([]byte{0xab, 0xcd}),
 		),
-		CborHex: "d87a8142abcd",
+		CborHex: "d87a9f42abcdff",
 	},
+	{
+		Data:    NewConstr(0),
+		CborHex: "d87980",
+	},
+	{
+		Data: NewList(
+			NewInteger(big.NewInt(1)),
+			NewInteger(big.NewInt(2)),
+		),
+		CborHex: "820102",
+	},
+	// TODO: figure out how to not fail this
+	// It works fine for encode, but we don't have a good way to capture an indef-length list on decode
+	/*
+		{
+			Data: NewIndefList(
+				NewInteger(big.NewInt(1)),
+				NewInteger(big.NewInt(2)),
+			),
+			CborHex: "9f0102ff",
+		},
+	*/
 }
 
 func TestPlutusDataEncode(t *testing.T) {

--- a/pkg/data/decode.go
+++ b/pkg/data/decode.go
@@ -76,7 +76,7 @@ func decodeRaw(v any) (PlutusData, error) {
 			items[i] = pd
 		}
 
-		return NewList(items), nil
+		return NewList(items...), nil
 
 	// Handle Map.
 	case map[any]any:
@@ -137,7 +137,7 @@ func decodeConstr(tag uint64, content any) (PlutusData, error) {
 		fields[i] = pd
 	}
 
-	return NewConstr(uint(tag), fields), nil
+	return NewConstr(uint(tag), fields...), nil
 }
 
 // decodeBignum decodes a big integer from CBOR tag content (expected to be bytes).

--- a/pkg/syn/parser.go
+++ b/pkg/syn/parser.go
@@ -831,7 +831,7 @@ func (p *Parser) parsePlutusData() (data.PlutusData, error) {
 			return nil, err
 		}
 
-		return data.NewList(items), nil
+		return data.NewList(items...), nil
 	case lex.TokenMap:
 		p.nextToken()
 
@@ -928,7 +928,7 @@ func (p *Parser) parsePlutusData() (data.PlutusData, error) {
 			return nil, err
 		}
 
-		return data.NewConstr(tag, fields), nil
+		return data.NewConstr(tag, fields...), nil
 	default:
 		return nil, fmt.Errorf(
 			"expected PlutusData constructor (I, B, List, Map, Constr), got %v at position %d",


### PR DESCRIPTION
When encoding a Constructor to CBOR, we should be using a definite-length list when there are zero fields, and an indefinite-length list for non-zero fields.

This also does the following:

* creates an IndefList type for explicit encoding
* switches to variadic parameters when creating List/Constr

Fixes #91