### PR TITLE
refactor: merge IndefList into List

### DIFF
--- a/data/data.go
+++ b/data/data.go
@@ -121,24 +121,8 @@ func (l List) String() string {
 
 // NewList creates a new List variant.
 func NewList(items ...PlutusData) PlutusData {
-	return &List{items}
-}
-
-// IndefList
-
-type IndefList struct {
-	Items []PlutusData
-}
-
-func (IndefList) isPlutusData() {}
-
-func (l IndefList) String() string {
-	return fmt.Sprintf("IndefList%v", l.Items)
-}
-
-// NewIndefList creates a new IndefList
-func NewIndefList(items ...PlutusData) PlutusData {
-	return &IndefList{
-		Items: items,
+	if items == nil {
+		items = make([]PlutusData, 0)
 	}
+	return &List{items}
 }

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -24,7 +24,11 @@ var testDefs = []struct {
 			NewInteger(big.NewInt(123)),
 			NewInteger(big.NewInt(456)),
 		),
-		CborHex: "82187b1901c8",
+		CborHex: "9f187b1901c8ff",
+	},
+	{
+		Data:    NewList(),
+		CborHex: "80",
 	},
 	{
 		Data: NewConstr(
@@ -42,19 +46,8 @@ var testDefs = []struct {
 			NewInteger(big.NewInt(1)),
 			NewInteger(big.NewInt(2)),
 		),
-		CborHex: "820102",
+		CborHex: "9f0102ff",
 	},
-	// TODO: figure out how to not fail this
-	// It works fine for encode, but we don't have a good way to capture an indef-length list on decode
-	/*
-		{
-			Data: NewIndefList(
-				NewInteger(big.NewInt(1)),
-				NewInteger(big.NewInt(2)),
-			),
-			CborHex: "9f0102ff",
-		},
-	*/
 }
 
 func TestPlutusDataEncode(t *testing.T) {

--- a/data/encode.go
+++ b/data/encode.go
@@ -32,8 +32,6 @@ func encodeToRaw(pd PlutusData) (any, error) {
 		return encodeByteString(v)
 	case *List:
 		return encodeList(v)
-	case *IndefList:
-		return encodeIndefList(v)
 	default:
 		return nil, fmt.Errorf("unknown PlutusData type: %T", pd)
 	}
@@ -158,21 +156,10 @@ func encodeByteString(bs *ByteString) (any, error) {
 
 // encodeList encodes a List to CBOR array format.
 func encodeList(l *List) (any, error) {
-	result := make([]any, len(l.Items))
-
-	for i, item := range l.Items {
-		encoded, err := encodeToRaw(item)
-		if err != nil {
-			return nil, fmt.Errorf("failed to encode list item %d: %w", i, err)
-		}
-		result[i] = encoded
+	if len(l.Items) == 0 {
+		ret := make([]any, 0)
+		return ret, nil
 	}
-
-	return result, nil
-}
-
-// encodeIndefList encodes an IndefList to CBOR format
-func encodeIndefList(l *IndefList) (any, error) {
 	tmpData := []byte{
 		// Start an indefinite-length list
 		0x9F,


### PR DESCRIPTION
The data.List type will generate a definite-length or indefinite-length list depending on the number of items in the list