### PR TITLE
refactor: replace panic() calls with error return

### DIFF
--- a/cek/builtins.go
+++ b/cek/builtins.go
@@ -3512,35 +3512,35 @@ func expModInteger[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 func caseList[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 	b.Args.Extract(&m.argHolder, b.ArgCount)
 
-	panic("implement caseList")
+	return nil, errors.New("unimplemented: caseList")
 }
 
 func caseData[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 	b.Args.Extract(&m.argHolder, b.ArgCount)
 
-	panic("implement caseData")
+	return nil, errors.New("unimplemented: caseData")
 }
 
 func dropList[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 	b.Args.Extract(&m.argHolder, b.ArgCount)
 
-	panic("implement dropList")
+	return nil, errors.New("unimplemented: dropList")
 }
 
 func lengthOfArray[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 	b.Args.Extract(&m.argHolder, b.ArgCount)
 
-	panic("implement lengthOfArray")
+	return nil, errors.New("unimplemented: lengthOfArray")
 }
 
 func listToArray[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 	b.Args.Extract(&m.argHolder, b.ArgCount)
 
-	panic("implement listToArray")
+	return nil, errors.New("unimplemented: listToArray")
 }
 
 func indexArray[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 	b.Args.Extract(&m.argHolder, b.ArgCount)
 
-	panic("implement indexArray")
+	return nil, errors.New("unimplemented: indexArray")
 }

--- a/cek/cost_model.go
+++ b/cek/cost_model.go
@@ -1,6 +1,7 @@
 package cek
 
 import (
+	"fmt"
 	"math/big"
 
 	"github.com/blinklabs-io/plutigo/data"
@@ -53,7 +54,7 @@ func iconstantExMem(c syn.IConstant) func() ExMem {
 		case *syn.ProtoPair:
 			ex = pairExMem(x.First, x.Second)
 		default:
-			panic("Oh no!")
+			panic(fmt.Sprintf("invalid constant type: %T", c))
 		}
 
 		return ex()

--- a/cek/machine.go
+++ b/cek/machine.go
@@ -54,7 +54,7 @@ func (m *Machine[T]) Run(term syn.Term[T]) (syn.Term[T], error) {
 		case *Done[T]:
 			return v.term, nil
 		default:
-			panic("unknown machine state")
+			panic(fmt.Sprintf("unknown machine state: %T", state))
 		}
 		if err != nil {
 			return nil, err
@@ -213,7 +213,7 @@ func (m *Machine[T]) compute(
 			Term: t.Constr,
 		}
 	default:
-		panic(fmt.Sprintf("unknown term: %v", term))
+		panic(fmt.Sprintf("unknown term: %T: %v", term, term))
 	}
 
 	return state, nil

--- a/syn/conversions.go
+++ b/syn/conversions.go
@@ -188,8 +188,7 @@ func nameToIndex[T any](
 			Branches: branches,
 		}
 	default:
-		fmt.Printf("%#v", t)
-		panic("HOW THE FUCK")
+		panic(fmt.Sprintf("unknown Term type: %T", term))
 	}
 
 	return converted, nil

--- a/syn/flat_decode.go
+++ b/syn/flat_decode.go
@@ -236,12 +236,12 @@ func DecodeConstant(d *decoder) (IConstant, error) {
 	// ProtoList
 	case len(tags) >= 2 && tags[0] == ProtoListOneTag && tags[1] == ProtoListTwoTag:
 		// Handle PROTO_LIST_ONE, PROTO_LIST_TWO, rest...
-		panic("unimplemented: PROTO_LIST")
+		return nil, errors.New("unimplemented: PROTO_LIST")
 
 	// ProtoPair
 	case len(tags) >= 3 && tags[0] == ProtoPairOneTag && tags[1] == ProtoPairTwoTag && tags[2] == ProtoPairThreeTag:
 		// Handle PROTO_PAIR_ONE, PROTO_PAIR_TWO, PROTO_PAIR_THREE, rest...
-		panic("unimplemented: PROTO_PAIR")
+		return nil, errors.New("unimplemented: PROTO_PAIR")
 
 	// Data
 	case len(tags) == 1 && tags[0] == DataTag:

--- a/syn/pretty.go
+++ b/syn/pretty.go
@@ -2,7 +2,6 @@ package syn
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 
 	"github.com/blinklabs-io/plutigo/data"
@@ -227,8 +226,7 @@ func printTerm[T Binder](pp *PrettyPrinter, term Term[T], isTopLevel bool) {
 	case *Constant:
 		pp.printConstant(t, false)
 	default:
-		fmt.Println(reflect.TypeOf(t))
-		panic(fmt.Sprintf("unknown term: %v", t))
+		panic(fmt.Sprintf("unknown term: %T: %v", t, t))
 	}
 }
 


### PR DESCRIPTION
We replace panic() with an error return in places where something is unimplemented. Anything that indicates a bug in the code was left as a panic, but with additional context added.

Fixes #117