### PR TITLE
fix: make copy of data for ByteString

### DIFF
--- a/data/data.go
+++ b/data/data.go
@@ -116,10 +116,9 @@ func (b ByteString) String() string {
 
 // NewByteString creates a new ByteString variant.
 func NewByteString(value []byte) PlutusData {
-	if value == nil {
-		value = make([]byte, 0)
-	}
-	return &ByteString{value}
+	tmpVal := make([]byte, len(value))
+	copy(tmpVal, value)
+	return &ByteString{tmpVal}
 }
 
 // List


### PR DESCRIPTION
Using the original byte slice can cause problems if it's modified elsewhere