### PR TITLE
feat: plutus v2

### DIFF
--- a/cek/cost_model.go
+++ b/cek/cost_model.go
@@ -19,6 +19,24 @@ var DefaultCostModel = CostModel{
 	builtinCosts: DefaultBuiltinCosts,
 }
 
+var V2CostModel = CostModel{
+	machineCosts: DefaultMachineCosts, // Assuming machine costs are the same
+	builtinCosts: V2BuiltinCosts,
+}
+
+func GetCostModel(version [3]uint32) CostModel {
+	if version[0] == 1 && version[1] == 0 && version[2] == 0 {
+		// V1, but not supported, use V2
+		return V2CostModel
+	} else if version[0] == 1 && version[1] == 1 && version[2] == 0 {
+		// V2
+		return V2CostModel
+	} else {
+		// V3 or later
+		return DefaultCostModel
+	}
+}
+
 const (
 	PairCost = 1
 	ConsCost = 3

--- a/cek/cost_model_builtins.go
+++ b/cek/cost_model_builtins.go
@@ -1328,3 +1328,72 @@ func (l ExpMod) CostThree(aa, ee, mm ExMem) int {
 func (ExpMod) HasConstants() []bool {
 	return []bool{false, false, false}
 }
+
+var V2BuiltinCosts = DefaultBuiltinCosts
+
+func init() {
+	// Modify V2 costs where they differ from V3
+	V2BuiltinCosts[builtin.DivideInteger] = &CostingFunc[Arguments]{
+		mem: &SubtractedSizesModel{SubtractedSizes{
+			intercept: 0,
+			slope:     1,
+			minimum:   1,
+		}},
+		cpu: &ConstAboveDiagonalModel{
+			ConstantOrTwoArguments{
+				constant: 85848,
+				model: &MultipliedSizesModel{MultipliedSizes{
+					intercept: 228465,
+					slope:     122,
+				}},
+			},
+		},
+	}
+	// Similarly for quotientInteger, remainderInteger, modInteger
+	V2BuiltinCosts[builtin.QuotientInteger] = &CostingFunc[Arguments]{
+		mem: &SubtractedSizesModel{SubtractedSizes{
+			intercept: 0,
+			slope:     1,
+			minimum:   1,
+		}},
+		cpu: &ConstAboveDiagonalModel{
+			ConstantOrTwoArguments{
+				constant: 85848,
+				model: &MultipliedSizesModel{MultipliedSizes{
+					intercept: 228465,
+					slope:     122,
+				}},
+			},
+		},
+	}
+	V2BuiltinCosts[builtin.RemainderInteger] = &CostingFunc[Arguments]{
+		mem: &LinearInY{LinearCost{
+			intercept: 0,
+			slope:     1,
+		}},
+		cpu: &ConstAboveDiagonalModel{
+			ConstantOrTwoArguments{
+				constant: 85848,
+				model: &MultipliedSizesModel{MultipliedSizes{
+					intercept: 228465,
+					slope:     122,
+				}},
+			},
+		},
+	}
+	V2BuiltinCosts[builtin.ModInteger] = &CostingFunc[Arguments]{
+		mem: &LinearInY{LinearCost{
+			intercept: 0,
+			slope:     1,
+		}},
+		cpu: &ConstAboveDiagonalModel{
+			ConstantOrTwoArguments{
+				constant: 85848,
+				model: &MultipliedSizesModel{MultipliedSizes{
+					intercept: 228465,
+					slope:     122,
+				}},
+			},
+		},
+	}
+}

--- a/cek/machine.go
+++ b/cek/machine.go
@@ -19,9 +19,15 @@ type Machine[T syn.Eval] struct {
 	unbudgetedSteps [10]uint32
 }
 
-func NewMachine[T syn.Eval](slippage uint32) *Machine[T] {
+func NewMachine[T syn.Eval](slippage uint32, costs ...CostModel) *Machine[T] {
+	var costModel CostModel
+	if len(costs) > 0 {
+		costModel = costs[0]
+	} else {
+		costModel = DefaultCostModel
+	}
 	return &Machine[T]{
-		costs:    DefaultCostModel,
+		costs:    costModel,
 		builtins: newBuiltins[T](),
 		slippage: slippage,
 		ExBudget: DefaultExBudget,

--- a/cmd/play/main.go
+++ b/cmd/play/main.go
@@ -60,7 +60,8 @@ func main() {
 			}
 		}
 
-		machine := cek.NewMachine[syn.DeBruijn](200)
+		costModel := cek.GetCostModel(program.Version)
+		machine := cek.NewMachine[syn.DeBruijn](200, costModel)
 
 		term, err := machine.Run(program.Term)
 		if err != nil {


### PR DESCRIPTION
Prompt:
This code supports Plutus V3. Add support for Plutus V2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced version-aware cost model selection to calculate execution costs appropriately for different protocol versions.
  * Updated cost calculations for integer division operations in protocol V2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->