### PR TITLE
feat: implement complete flat encoding and fix linting issues

### DIFF
--- a/data/data.go
+++ b/data/data.go
@@ -88,7 +88,11 @@ func NewConstr(tag uint, fields ...PlutusData) PlutusData {
 }
 
 // NewConstrDefIndef creates a Constr with the ability to specify whether it should use definite- or indefinite-length encoding
-func NewConstrDefIndef(useIndef bool, tag uint, fields ...PlutusData) PlutusData {
+func NewConstrDefIndef(
+	useIndef bool,
+	tag uint,
+	fields ...PlutusData,
+) PlutusData {
 	tmpFields := make([]PlutusData, len(fields))
 	copy(tmpFields, fields)
 	return &Constr{Tag: tag, Fields: tmpFields, useIndef: &useIndef}

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -236,7 +236,11 @@ func TestPlutusDataEncode(t *testing.T) {
 			t.Fatalf("unexpected error: %s", err)
 		}
 		if hex.EncodeToString(tmpCbor) != testDef.CborHex {
-			t.Errorf("did not get expected CBOR\n     got: %x\n  wanted: %s", tmpCbor, testDef.CborHex)
+			t.Errorf(
+				"did not get expected CBOR\n     got: %x\n  wanted: %s",
+				tmpCbor,
+				testDef.CborHex,
+			)
 		}
 	}
 }
@@ -252,7 +256,11 @@ func TestPlutusDataDecode(t *testing.T) {
 			t.Fatalf("unexpected error: %s", err)
 		}
 		if !reflect.DeepEqual(tmpData.Data, testDef.Data) {
-			t.Errorf("did not get expected data\n     got: %#v\n  wanted: %#v", tmpData.Data, testDef.Data)
+			t.Errorf(
+				"did not get expected data\n     got: %#v\n  wanted: %#v",
+				tmpData.Data,
+				testDef.Data,
+			)
 		}
 	}
 }

--- a/data/decode.go
+++ b/data/decode.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -47,6 +48,9 @@ func cborUnmarshal(dataBytes []byte, dest any) error {
 // This is needed because cbor.Tag with a slice as the content (such as in a Constr) is
 // not hashable and cannot be used as a map key
 func decodeCborRaw(data []byte) (any, error) {
+	if len(data) == 0 {
+		return nil, errors.New("empty data")
+	}
 	cborType := data[0] & CborTypeMask
 	switch cborType {
 	case CborTypeByteString:
@@ -284,7 +288,10 @@ func decodeRawTag(tag cbor.RawTag) (PlutusData, error) {
 		}
 		ret, retErr = decodeConstr(tmpData.Alternative, tmpData.FieldsRaw)
 	default:
-		return nil, fmt.Errorf("unknown CBOR tag for PlutusData: %d", tag.Number)
+		return nil, fmt.Errorf(
+			"unknown CBOR tag for PlutusData: %d",
+			tag.Number,
+		)
 	}
 	return ret, retErr
 }

--- a/data/encode.go
+++ b/data/encode.go
@@ -66,11 +66,19 @@ func encodeConstr(c *Constr) (any, error) {
 		for i, item := range c.Fields {
 			encoded, err := encodeToRaw(item)
 			if err != nil {
-				return nil, fmt.Errorf("failed to encode Constr field %d: %w", i, err)
+				return nil, fmt.Errorf(
+					"failed to encode Constr field %d: %w",
+					i,
+					err,
+				)
 			}
 			encodedCbor, err := cborMarshal(encoded)
 			if err != nil {
-				return nil, fmt.Errorf("failed to encode Constr field item %d: %w", i, err)
+				return nil, fmt.Errorf(
+					"failed to encode Constr field item %d: %w",
+					i,
+					err,
+				)
 			}
 			tmpFields[i] = cbor.RawMessage(encodedCbor)
 		}
@@ -244,11 +252,19 @@ func encodeList(l *List) (any, error) {
 	for i, item := range l.Items {
 		encoded, err := encodeToRaw(item)
 		if err != nil {
-			return nil, fmt.Errorf("failed to encode indef-length list item %d: %w", i, err)
+			return nil, fmt.Errorf(
+				"failed to encode indef-length list item %d: %w",
+				i,
+				err,
+			)
 		}
 		encodedCbor, err := cborMarshal(encoded)
 		if err != nil {
-			return nil, fmt.Errorf("failed to encode indef-length list item %d: %w", i, err)
+			return nil, fmt.Errorf(
+				"failed to encode indef-length list item %d: %w",
+				i,
+				err,
+			)
 		}
 		tmpData = slices.Concat(tmpData, encodedCbor)
 	}

--- a/syn/encode_test.go
+++ b/syn/encode_test.go
@@ -1,0 +1,197 @@
+package syn
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/blinklabs-io/plutigo/builtin"
+)
+
+func TestEncodeDecodeConstant(t *testing.T) {
+	// Simple test first
+	constant := &Integer{Inner: big.NewInt(42)}
+	term := &Constant{Con: constant}
+
+	// Encode the term
+	encoded, err := Encode[DeBruijn](&Program[DeBruijn]{
+		Version: [3]uint32{1, 0, 0},
+		Term:    term,
+	})
+	if err != nil {
+		t.Fatalf("Encode failed: %v", err)
+	}
+
+	t.Logf("Encoded bytes: %x", encoded)
+
+	// Decode the program
+	program, err := Decode[DeBruijn](encoded)
+	if err != nil {
+		t.Fatalf("Decode failed: %v", err)
+	}
+
+	// Check if it's a constant term
+	constantTerm, ok := program.Term.(*Constant)
+	if !ok {
+		t.Fatalf("Decoded term is not a Constant: %T", program.Term)
+	}
+
+	// Compare constants
+	if constant.Inner.Cmp(constantTerm.Con.(*Integer).Inner) != 0 {
+		t.Errorf(
+			"Constants not equal: got %v, want %v",
+			constantTerm.Con.(*Integer).Inner,
+			constant.Inner,
+		)
+	}
+}
+
+func TestEncodeDecodeBuiltin(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   builtin.DefaultFunction
+	}{
+		{"AddInteger", builtin.AddInteger},
+		{"Sha2_256", builtin.Sha2_256},
+		{"Sha3_256", builtin.Sha3_256},
+		{"Blake2b_256", builtin.Blake2b_256},
+		{"Keccak_256", builtin.Keccak_256},
+		{"IfThenElse", builtin.IfThenElse},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := &Builtin{DefaultFunction: tt.fn}
+
+			// Encode the builtin term
+			encoded, err := Encode[DeBruijn](&Program[DeBruijn]{
+				Version: [3]uint32{1, 0, 0},
+				Term:    original,
+			})
+			if err != nil {
+				t.Fatalf("Encode failed: %v", err)
+			}
+
+			// Decode the program
+			program, err := Decode[DeBruijn](encoded)
+			if err != nil {
+				t.Fatalf("Decode failed: %v", err)
+			}
+
+			// Check if it's a builtin
+			builtinTerm, ok := program.Term.(*Builtin)
+			if !ok {
+				t.Fatalf("Decoded term is not a Builtin: %T", program.Term)
+			}
+
+			// Compare
+			if builtinTerm.DefaultFunction != tt.fn {
+				t.Errorf(
+					"Builtin functions not equal: got %v, want %v",
+					builtinTerm.DefaultFunction,
+					tt.fn,
+				)
+			}
+		})
+	}
+}
+
+func TestEncodeDecodeConstantTerm(t *testing.T) {
+	tests := []struct {
+		name     string
+		constant IConstant
+	}{
+		{
+			name:     "constant_integer",
+			constant: &Integer{Inner: big.NewInt(99)},
+		},
+		{
+			name:     "constant_string",
+			constant: &String{Inner: "hello"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := &Constant{Con: tt.constant}
+
+			// Encode the constant term
+			encoded, err := Encode[DeBruijn](&Program[DeBruijn]{
+				Version: [3]uint32{1, 0, 0},
+				Term:    original,
+			})
+			if err != nil {
+				t.Fatalf("Encode failed: %v", err)
+			}
+
+			// Decode the program
+			program, err := Decode[DeBruijn](encoded)
+			if err != nil {
+				t.Fatalf("Decode failed: %v", err)
+			}
+
+			// Check if it's a constant
+			constantTerm, ok := program.Term.(*Constant)
+			if !ok {
+				t.Fatalf("Decoded term is not a Constant: %T", program.Term)
+			}
+
+			// Compare constants
+			if !constantsEqual(tt.constant, constantTerm.Con) {
+				t.Errorf("Constants not equal after encode/decode")
+				t.Errorf("Original: %+v", tt.constant)
+				t.Errorf("Decoded: %+v", constantTerm.Con)
+			}
+		})
+	}
+}
+
+// Helper function to compare constants for equality
+func constantsEqual(a, b IConstant) bool {
+	switch va := a.(type) {
+	case *Integer:
+		if vb, ok := b.(*Integer); ok {
+			return va.Inner.Cmp(vb.Inner) == 0
+		}
+	case *ByteString:
+		if vb, ok := b.(*ByteString); ok {
+			if len(va.Inner) != len(vb.Inner) {
+				return false
+			}
+			for i := range va.Inner {
+				if va.Inner[i] != vb.Inner[i] {
+					return false
+				}
+			}
+			return true
+		}
+	case *String:
+		if vb, ok := b.(*String); ok {
+			return va.Inner == vb.Inner
+		}
+	case *Unit:
+		if _, ok := b.(*Unit); ok {
+			return true
+		}
+	case *Bool:
+		if vb, ok := b.(*Bool); ok {
+			return va.Inner == vb.Inner
+		}
+	case *ProtoList:
+		if vb, ok := b.(*ProtoList); ok {
+			if len(va.List) != len(vb.List) {
+				return false
+			}
+			for i := range va.List {
+				if !constantsEqual(va.List[i], vb.List[i]) {
+					return false
+				}
+			}
+			return true
+		}
+	case *ProtoPair:
+		if vb, ok := b.(*ProtoPair); ok {
+			return constantsEqual(va.First, vb.First) && constantsEqual(va.Second, vb.Second)
+		}
+	}
+	return false
+}

--- a/tests/crypto_bench_test.go
+++ b/tests/crypto_bench_test.go
@@ -1,0 +1,68 @@
+package tests
+
+import (
+	"crypto/ed25519"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
+	bls "github.com/consensys/gnark-crypto/ecc/bls12-381"
+	"github.com/ethereum/go-ethereum/crypto"
+	sha256 "github.com/minio/sha256-simd"
+	"golang.org/x/crypto/blake2b"
+)
+
+func BenchmarkDirectCrypto(b *testing.B) {
+	message := []byte("test message for hashing and signing")
+	hash := make([]byte, 32)
+	dst := []byte("BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_")
+
+	b.Run("SHA256_minio", func(b *testing.B) {
+		for b.Loop() {
+			sha256.Sum256(message)
+		}
+	})
+
+	b.Run("Keccak_256", func(b *testing.B) {
+		for b.Loop() {
+			crypto.Keccak256(message)
+		}
+	})
+
+	b.Run("Blake2b_256", func(b *testing.B) {
+		for b.Loop() {
+			blake2b.Sum256(message)
+		}
+	})
+
+	b.Run("Keccak_256_Hash", func(b *testing.B) {
+		for b.Loop() {
+			crypto.Keccak256Hash(message)
+		}
+	})
+
+	b.Run("Ed25519_Verify", func(b *testing.B) {
+		// Use a valid key for testing
+		pub, priv, _ := ed25519.GenerateKey(nil)
+		sig := ed25519.Sign(priv, message)
+		b.ResetTimer()
+		for b.Loop() {
+			ed25519.Verify(pub, message, sig)
+		}
+	})
+
+	b.Run("ECDSA_Verify", func(b *testing.B) {
+		priv, _ := btcec.NewPrivateKey()
+		sig := ecdsa.SignCompact(priv, hash, false)
+		b.ResetTimer()
+		for b.Loop() {
+			ecdsa.RecoverCompact(sig, hash)
+		}
+	})
+
+	b.Run("BLS_HashToG1", func(b *testing.B) {
+		for b.Loop() {
+			bls.HashToG1(message, dst)
+		}
+	})
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Complete flat encoding for Plutus terms (constants and builtins), with tests and CEK machine safety fixes. Adds crypto benchmarks and cleans up lint warnings.

- **New Features**
  - Implement flat encoding for Constant and Builtin terms, covering type tags and values (integer, bytes, string, unit, bool, list, pair, data via CBOR).
  - Add encode/decode tests for constants and builtins with a constant equality helper.
  - Add direct crypto benchmarks (SHA256, Keccak-256, Blake2b-256, Ed25519, ECDSA, BLS hash-to-G1).

- **Bug Fixes**
  - Harden CEK machine: nil-state checks and early error returns in compute/returnCompute.
  - Guard against empty CBOR input and improve error messages in data decode/encode.
  - Lint and formatting fixes across data and machine code.

<sup>Written for commit 5373f3eaff26f54f95df570d1f4051a948924fde. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened error handling for state transitions with explicit nil-state validation.
  * Added validation to prevent processing of empty data inputs.

* **New Features**
  * Added support for encoding and decoding constants and builtin functions.

* **Tests**
  * Introduced comprehensive encode/decode round-trip tests for type integrity.
  * Added cryptographic performance benchmarks for hash and signature operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->