### PR TITLE
refactor: clean up code after Plutus versioning

### DIFF
--- a/cek/builtins.go
+++ b/cek/builtins.go
@@ -1551,14 +1551,18 @@ func constrData[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 		dataList = append(dataList, itemData.Inner)
 	}
 
-	tag := arg1.Uint64()
-	if tag > math.MaxUint {
+	if arg1.BitLen() > 64 {
 		return nil, errors.New("constructor tag too large")
 	}
+	tag64 := arg1.Uint64()
+	if tag64 > uint64(math.MaxUint) {
+		return nil, errors.New("constructor tag too large")
+	}
+	tag := uint(tag64)
 
 	value := &Constant{&syn.Data{
 		Inner: &data.Constr{
-			Tag:    uint(tag),
+			Tag:    tag,
 			Fields: dataList,
 		},
 	}}

--- a/cek/machine.go
+++ b/cek/machine.go
@@ -20,7 +20,11 @@ type Machine[T syn.Eval] struct {
 	unbudgetedSteps [10]uint32
 }
 
-func NewMachine[T syn.Eval](version [3]uint32, slippage uint32, costs ...CostModel) *Machine[T] {
+func NewMachine[T syn.Eval](
+	version [3]uint32,
+	slippage uint32,
+	costs ...CostModel,
+) *Machine[T] {
 	var costModel CostModel
 	if len(costs) > 0 {
 		costModel = costs[0]
@@ -41,7 +45,10 @@ func NewMachine[T syn.Eval](version [3]uint32, slippage uint32, costs ...CostMod
 }
 
 // NewMachineWithVersionCosts creates a machine with version-appropriate cost models
-func NewMachineWithVersionCosts[T syn.Eval](version [3]uint32, slippage uint32) *Machine[T] {
+func NewMachineWithVersionCosts[T syn.Eval](
+	version [3]uint32,
+	slippage uint32,
+) *Machine[T] {
 	costModel := GetCostModel(version)
 	return NewMachine[T](version, slippage, costModel)
 }

--- a/cmd/play/main.go
+++ b/cmd/play/main.go
@@ -91,7 +91,7 @@ func main() {
 			log.Fatalf("parse error: %v\n\n", err)
 		}
 
-		prettyProgram := syn.Pretty[syn.Name](program)
+		prettyProgram := syn.Pretty(program)
 
 		_ = os.WriteFile(filename, []byte(prettyProgram), 0o600)
 

--- a/syn/encode_test.go
+++ b/syn/encode_test.go
@@ -13,7 +13,7 @@ func TestEncodeDecodeConstant(t *testing.T) {
 	term := &Constant{Con: constant}
 
 	// Encode the term
-	encoded, err := Encode[DeBruijn](&Program[DeBruijn]{
+	encoded, err := Encode(&Program[DeBruijn]{
 		Version: [3]uint32{1, 0, 0},
 		Term:    term,
 	})
@@ -63,7 +63,7 @@ func TestEncodeDecodeBuiltin(t *testing.T) {
 			original := &Builtin{DefaultFunction: tt.fn}
 
 			// Encode the builtin term
-			encoded, err := Encode[DeBruijn](&Program[DeBruijn]{
+			encoded, err := Encode(&Program[DeBruijn]{
 				Version: [3]uint32{1, 0, 0},
 				Term:    original,
 			})
@@ -117,11 +117,11 @@ func TestEncodeDecodeConstantTerm(t *testing.T) {
 			constant: &Unit{},
 		},
 		{
-			name: "constant_bool_true",
+			name:     "constant_bool_true",
 			constant: &Bool{Inner: true},
 		},
 		{
-			name: "constant_bool_false",
+			name:     "constant_bool_false",
 			constant: &Bool{Inner: false},
 		},
 	}

--- a/syn/flat_decode.go
+++ b/syn/flat_decode.go
@@ -35,7 +35,8 @@ func Decode[T Binder](bytes []byte) (*Program[T], error) {
 		return nil, err
 	}
 
-	if major > math.MaxUint32 || minor > math.MaxUint32 || patch > math.MaxUint32 {
+	if major > math.MaxUint32 || minor > math.MaxUint32 ||
+		patch > math.MaxUint32 {
 		return nil, errors.New("version numbers too large")
 	}
 
@@ -535,8 +536,19 @@ func (d *decoder) dropBits(numBits uint) {
 	d.pos += int(allUsedBits / 8)
 }
 
+// Ensures the buffer has the required bits passed in by required_bits.
+// Throws a NotEnoughBits error if there are less bits remaining in the
+// buffer than requiredBits.
+// Throws a BitsOverflow error if bits is more than MaxInt64
 func (d *decoder) ensureBits(requiredBits uint) error {
-	if int64(requiredBits) > int64((len(d.buffer)-d.pos)*8)-d.usedBits { //nolint:gosec
+	if requiredBits > math.MaxInt64 {
+		return fmt.Errorf("BitsOverflow(%d)", requiredBits)
+	}
+	if int64(
+		requiredBits,
+	) > int64(
+		(len(d.buffer)-d.pos)*8,
+	)-d.usedBits { //nolint:gosec
 		return fmt.Errorf("NotEnoughBits(%d)", requiredBits)
 	} else {
 		return nil

--- a/syn/flat_encode.go
+++ b/syn/flat_encode.go
@@ -230,7 +230,7 @@ func (e *encoder) word(c uint) *encoder {
 // number of bits to use is greater than unused bits. Expects that
 // number of bits to use is greater than or equal to required bits by the
 // value. The param num_bits is i64 to match unused_bits type.
-func (e *encoder) bits(numBits byte, val byte) *encoder {
+func (e *encoder) bits(numBits byte, val byte) {
 	if numBits == 1 && val == 0 {
 		e.zero()
 	} else if numBits == 1 && val == 1 {
@@ -264,8 +264,6 @@ func (e *encoder) bits(numBits byte, val byte) *encoder {
 			e.usedBits = used
 		}
 	}
-
-	return e
 }
 
 // A filler amount of end 0's followed by a 1 at the end of a byte.
@@ -306,13 +304,11 @@ func (e *encoder) one() *encoder {
 // Write the current byte out to the buffer and begin next byte to write
 // out. Add current byte to the buffer and set current byte and used
 // bits to 0.
-func (e *encoder) nextWord() *encoder {
+func (e *encoder) nextWord() {
 	e.buffer = append(e.buffer, e.currentByte)
 
 	e.currentByte = 0
 	e.usedBits = 0
-
-	return e
 }
 
 // Encode a string.

--- a/syn/pretty.go
+++ b/syn/pretty.go
@@ -60,8 +60,7 @@ func (pp *PrettyPrinter) decreaseIndent() {
 
 // PrettyPrintTerm formats a Term[Name] to a string
 func prettyPrintTerm[T Binder](pp *PrettyPrinter, term Term[T]) string {
-	printTerm[T](pp, term, true)
-
+	printTerm[T](pp, term)
 	return pp.builder.String()
 }
 
@@ -89,7 +88,7 @@ func printProgram[T Binder](pp *PrettyPrinter, prog *Program[T]) {
 	pp.increaseIndent()
 	pp.writeIndent()
 
-	printTerm[T](pp, prog.Term, false)
+	printTerm[T](pp, prog.Term)
 
 	pp.decreaseIndent()
 	pp.write("\n")
@@ -100,7 +99,7 @@ func printProgram[T Binder](pp *PrettyPrinter, prog *Program[T]) {
 }
 
 // printTerm dispatches to the appropriate term printing method
-func printTerm[T Binder](pp *PrettyPrinter, term Term[T], isTopLevel bool) {
+func printTerm[T Binder](pp *PrettyPrinter, term Term[T]) {
 	switch t := term.(type) {
 	case *Var[T]:
 		pp.write(t.Name.TextName())
@@ -113,7 +112,7 @@ func printTerm[T Binder](pp *PrettyPrinter, term Term[T], isTopLevel bool) {
 		pp.increaseIndent()
 		pp.writeIndent()
 
-		printTerm[T](pp, t.Body, false)
+		printTerm[T](pp, t.Body)
 
 		pp.decreaseIndent()
 		pp.write("\n")
@@ -127,7 +126,7 @@ func printTerm[T Binder](pp *PrettyPrinter, term Term[T], isTopLevel bool) {
 		pp.increaseIndent()
 		pp.writeIndent()
 
-		printTerm[T](pp, t.Term, false)
+		printTerm[T](pp, t.Term)
 
 		pp.decreaseIndent()
 		pp.write("\n")
@@ -141,7 +140,7 @@ func printTerm[T Binder](pp *PrettyPrinter, term Term[T], isTopLevel bool) {
 		pp.increaseIndent()
 		pp.writeIndent()
 
-		printTerm[T](pp, t.Term, false)
+		printTerm[T](pp, t.Term)
 
 		pp.decreaseIndent()
 		pp.write("\n")
@@ -155,12 +154,12 @@ func printTerm[T Binder](pp *PrettyPrinter, term Term[T], isTopLevel bool) {
 		pp.increaseIndent()
 		pp.writeIndent()
 
-		printTerm[T](pp, t.Function, false)
+		printTerm[T](pp, t.Function)
 
 		pp.write("\n")
 		pp.writeIndent()
 
-		printTerm[T](pp, t.Argument, false)
+		printTerm[T](pp, t.Argument)
 
 		pp.decreaseIndent()
 		pp.write("\n")
@@ -183,7 +182,7 @@ func printTerm[T Binder](pp *PrettyPrinter, term Term[T], isTopLevel bool) {
 			for _, field := range t.Fields {
 				pp.writeIndent()
 
-				printTerm[T](pp, field, false)
+				printTerm[T](pp, field)
 
 				pp.write("\n")
 			}
@@ -199,7 +198,7 @@ func printTerm[T Binder](pp *PrettyPrinter, term Term[T], isTopLevel bool) {
 	case *Case[T]:
 		pp.write("(case ")
 
-		printTerm[T](pp, t.Constr, false)
+		printTerm[T](pp, t.Constr)
 
 		if len(t.Branches) > 0 {
 			pp.write("\n")
@@ -208,7 +207,7 @@ func printTerm[T Binder](pp *PrettyPrinter, term Term[T], isTopLevel bool) {
 			for _, branch := range t.Branches {
 				pp.writeIndent()
 
-				printTerm[T](pp, branch, false)
+				printTerm[T](pp, branch)
 
 				pp.write("\n")
 			}

--- a/tests/conformance_test.go
+++ b/tests/conformance_test.go
@@ -221,7 +221,10 @@ func TestConformance(t *testing.T) {
 
 					// Evaluate program
 
-					machine := cek.NewMachine[syn.DeBruijn](dProgram.Version, 200)
+					machine := cek.NewMachine[syn.DeBruijn](
+						dProgram.Version,
+						200,
+					)
 
 					result, err := machine.Run(dProgram.Term)
 					if err != nil {


### PR DESCRIPTION
- Fix bounds checking in constructor data builtin
- Remove unused return values from encoder methods
- Remove unused parameter from pretty printing
- Simplify type inference in encoding calls

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened numeric bounds in data and decoding and simplified encoding/pretty-print APIs after Plutus versioning. This improves safety and makes the API clearer.

- **Bug Fixes**
  - Validate constructor tags by bit length and uint overflow to prevent invalid tags.
  - Decoder ensureBits now guards against bits overflow and reports NotEnoughBits explicitly.

- **Refactors**
  - Removed unused return values from encoder bits/nextWord.
  - Dropped the unused isTopLevel parameter from pretty printing.
  - Simplified Encode and Pretty calls by removing unnecessary type parameters; updated tests and CLI accordingly.

<sup>Written for commit 7bf413e8b034c8e79da6b50f03b6230bf6d5ae92. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

