### PR TITLE
test(benchmark): hoist slice allocations in bls pairing

### DIFF
--- a/tests/crypto_bench_test.go
+++ b/tests/crypto_bench_test.go
@@ -108,9 +108,11 @@ func BenchmarkDirectCrypto(b *testing.B) {
 	b.Run("BLS_Pairing", func(b *testing.B) {
 		g1, _ := bls.HashToG1(message, dst)
 		g2, _ := bls.HashToG2([]byte("another message"), dst)
+		g1s := []bls.G1Affine{g1}
+		g2s := []bls.G2Affine{g2}
 		b.ResetTimer()
 		for b.Loop() {
-			bls.Pair([]bls.G1Affine{g1}, []bls.G2Affine{g2})
+			bls.Pair(g1s, g2s)
 		}
 	})
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pre-allocates G1/G2 slices for bls.Pair in the BLS_Pairing benchmark and reuses them inside the loop. This removes per-iteration allocations so timing reflects the pairing operation, not slice creation.

<sup>Written for commit 9bd5eab74c6068b86e99c234bef679f7315ba1e7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Optimized benchmark performance by reducing memory allocations in cryptographic pairing tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->