### PR TITLE
test: property-based and fuzz tests

### DIFF
--- a/builtin/default_function_test.go
+++ b/builtin/default_function_test.go
@@ -1,0 +1,119 @@
+package builtin
+
+import (
+	"testing"
+)
+
+func TestFromByte(t *testing.T) {
+	tests := []struct {
+		input    byte
+		expected DefaultFunction
+		hasError bool
+	}{
+		{0, AddInteger, false},
+		{1, SubtractInteger, false},
+		{MaxDefaultFunction, IndexArray, false},
+		{MaxDefaultFunction + 1, 0, true},
+		{255, 0, true},
+	}
+
+	for _, test := range tests {
+		result, err := FromByte(test.input)
+		if test.hasError {
+			if err == nil {
+				t.Errorf(
+					"Expected error for input %d, but got none",
+					test.input,
+				)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("Unexpected error for input %d: %v", test.input, err)
+			}
+			if result != test.expected {
+				t.Errorf("For input %d, expected %v, got %v", test.input, test.expected, result)
+			}
+		}
+	}
+}
+
+func TestDefaultFunctionString(t *testing.T) {
+	tests := []struct {
+		df       DefaultFunction
+		expected string
+	}{
+		{AddInteger, "addInteger"},
+		{SubtractInteger, "subtractInteger"},
+		{Sha2_256, "sha2_256"},
+		{IfThenElse, "ifThenElse"},
+		{IndexArray, "indexArray"},
+	}
+
+	for _, test := range tests {
+		result := test.df.String()
+		if result != test.expected {
+			t.Errorf(
+				"For %v, expected %s, got %s",
+				test.df,
+				test.expected,
+				result,
+			)
+		}
+	}
+}
+
+func TestBuiltinsMap(t *testing.T) {
+	// Test a few key mappings
+	expectedMappings := map[string]DefaultFunction{
+		"addInteger":      AddInteger,
+		"subtractInteger": SubtractInteger,
+		"sha2_256":        Sha2_256,
+		"ifThenElse":      IfThenElse,
+		"indexArray":      IndexArray,
+	}
+
+	for name, expected := range expectedMappings {
+		actual, exists := Builtins[name]
+		if !exists {
+			t.Errorf("Builtin %s not found in map", name)
+		} else if actual != expected {
+			t.Errorf("For %s, expected %v, got %v", name, expected, actual)
+		}
+	}
+}
+
+func TestConstants(t *testing.T) {
+	if MinDefaultFunction != 0 {
+		t.Errorf("MinDefaultFunction should be 0, got %d", MinDefaultFunction)
+	}
+	expectedTotal := int(MaxDefaultFunction) - int(MinDefaultFunction) + 1
+	if int(TotalBuiltinCount) != expectedTotal {
+		t.Errorf("TotalBuiltinCount should be %d (MaxDefaultFunction - MinDefaultFunction + 1), got %d", expectedTotal, TotalBuiltinCount)
+	}
+}
+
+func FuzzFromByte(f *testing.F) {
+	validBytes := []byte{0, 1, 10, 20, 50, 90}
+	invalidBytes := []byte{94, 255}
+	for _, b := range validBytes {
+		f.Add(b)
+	}
+	for _, b := range invalidBytes {
+		f.Add(b)
+	}
+	f.Fuzz(func(t *testing.T, b byte) {
+		df, err := FromByte(b)
+		if b <= MaxDefaultFunction {
+			if err != nil {
+				t.Errorf("FromByte(%d) should not error for valid byte, got %v", b, err)
+			}
+			if df != DefaultFunction(b) {
+				t.Errorf("FromByte(%d) should return DefaultFunction(%d), got %v", b, b, df)
+			}
+		} else {
+			if err == nil {
+				t.Errorf("FromByte(%d) should error for invalid byte > MaxDefaultFunction (%d)", b, MaxDefaultFunction)
+			}
+		}
+	})
+}

--- a/cek/machine_test.go
+++ b/cek/machine_test.go
@@ -1,0 +1,192 @@
+package cek
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/plutigo/syn"
+)
+
+func TestNewMachine(t *testing.T) {
+	version := [3]uint32{1, 2, 0}
+	slippage := uint32(100)
+
+	machine := NewMachine[syn.DeBruijn](version, slippage)
+
+	if machine.slippage != slippage {
+		t.Errorf("Expected slippage %d, got %d", slippage, machine.slippage)
+	}
+	if machine.version != version {
+		t.Errorf("Expected version %v, got %v", version, machine.version)
+	}
+	if len(machine.Logs) != 0 {
+		t.Errorf("Expected empty logs, got %v", machine.Logs)
+	}
+}
+
+func TestNewMachineWithVersionCosts(t *testing.T) {
+	version := [3]uint32{1, 2, 0}
+	slippage := uint32(100)
+
+	machine := NewMachineWithVersionCosts[syn.DeBruijn](version, slippage)
+
+	expectedCostModel := GetCostModel(version)
+	if machine.costs != expectedCostModel {
+		t.Errorf(
+			"Expected cost model %v, got %v",
+			expectedCostModel,
+			machine.costs,
+		)
+	}
+}
+
+func TestMachineRunSimple(t *testing.T) {
+	// Simple program: (con integer 42)
+	input := `(program 1.2.0 (con integer 42))`
+
+	pprogram, err := syn.Parse(input)
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+
+	program, err := syn.NameToDeBruijn(pprogram)
+	if err != nil {
+		t.Fatalf("NameToDeBruijn error: %v", err)
+	}
+
+	machine := NewMachineWithVersionCosts[syn.DeBruijn](program.Version, 200)
+
+	result, err := machine.Run(program.Term)
+	if err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+
+	pretty := syn.PrettyTerm[syn.DeBruijn](result)
+	expected := "(con integer 42)"
+	if pretty != expected {
+		t.Errorf("Expected %q, got %q", expected, pretty)
+	}
+}
+
+func TestMachineRunWithBuiltin(t *testing.T) {
+	// Program: (program 1.2.0 [(builtin addInteger) (con integer 1) (con integer 2)])
+	input := `(program 1.2.0 [(builtin addInteger) (con integer 1) (con integer 2)])`
+
+	pprogram, err := syn.Parse(input)
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+
+	program, err := syn.NameToDeBruijn(pprogram)
+	if err != nil {
+		t.Fatalf("NameToDeBruijn error: %v", err)
+	}
+
+	machine := NewMachineWithVersionCosts[syn.DeBruijn](program.Version, 200)
+
+	result, err := machine.Run(program.Term)
+	if err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+
+	pretty := syn.PrettyTerm[syn.DeBruijn](result)
+	expected := "(con integer 3)"
+	if pretty != expected {
+		t.Errorf("Expected %q, got %q", expected, pretty)
+	}
+}
+
+func TestMachineExBudget(t *testing.T) {
+	version := [3]uint32{1, 2, 0}
+	machine := NewMachine[syn.DeBruijn](version, 100)
+
+	initialBudget := machine.ExBudget
+
+	// Run a simple program
+	input := `(program 1.2.0 (con integer 42))`
+
+	pprogram, err := syn.Parse(input)
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+
+	program, err := syn.NameToDeBruijn(pprogram)
+	if err != nil {
+		t.Fatalf("NameToDeBruijn error: %v", err)
+	}
+
+	_, err = machine.Run(program.Term)
+	if err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+
+	// Budget should have decreased
+	if machine.ExBudget.Cpu >= initialBudget.Cpu {
+		t.Error("CPU budget should have decreased")
+	}
+	if machine.ExBudget.Mem >= initialBudget.Mem {
+		t.Error("Mem budget should have decreased")
+	}
+}
+
+func TestMachineDeterministic(t *testing.T) {
+	// Property: running the same program multiple times gives same result
+	input := `(program 1.2.0 [(builtin addInteger) (con integer 1) (con integer 2)])`
+
+	pprogram, err := syn.Parse(input)
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+
+	program, err := syn.NameToDeBruijn(pprogram)
+	if err != nil {
+		t.Fatalf("NameToDeBruijn error: %v", err)
+	}
+
+	version := program.Version
+
+	results := make([]string, 5)
+	for i := 0; i < 5; i++ {
+		machine := NewMachineWithVersionCosts[syn.DeBruijn](version, 200)
+		result, err := machine.Run(program.Term)
+		if err != nil {
+			t.Fatalf("Run error on attempt %d: %v", i, err)
+		}
+		results[i] = syn.PrettyTerm[syn.DeBruijn](result)
+	}
+
+	for i := 1; i < len(results); i++ {
+		if results[i] != results[0] {
+			t.Errorf(
+				"Non-deterministic result: attempt 0: %s, attempt %d: %s",
+				results[0],
+				i,
+				results[i],
+			)
+		}
+	}
+}
+
+func FuzzMachineRun(f *testing.F) {
+	testPrograms := []string{
+		`(program 1.2.0 (con integer 42))`,
+		`(program 1.2.0 [(builtin addInteger) (con integer 1) (con integer 2)])`,
+	}
+	for _, prog := range testPrograms {
+		f.Add(prog)
+	}
+	f.Fuzz(func(t *testing.T, input string) {
+		pprogram, err := syn.Parse(input)
+		if err != nil {
+			return // Skip invalid
+		}
+		program, err := syn.NameToDeBruijn(pprogram)
+		if err != nil {
+			return
+		}
+		machine := NewMachineWithVersionCosts[syn.DeBruijn](
+			program.Version,
+			1000,
+		)
+		_, _ = machine.Run(program.Term) // Ignore errors, check no panic
+	})
+}

--- a/syn/lex/lexer_test.go
+++ b/syn/lex/lexer_test.go
@@ -1,0 +1,207 @@
+package lex
+
+import (
+	"math/big"
+	"reflect"
+	"testing"
+)
+
+func TestLexerNextToken(t *testing.T) {
+	input := `(program 1.0.0 (con integer 42))`
+
+	expectedTokens := []Token{
+		{Type: TokenLParen, Literal: "(", Position: 0},
+		{Type: TokenProgram, Literal: "program", Position: 1},
+		{Type: TokenNumber, Literal: "1", Position: 9, Value: big.NewInt(1)},
+		{Type: TokenDot, Literal: ".", Position: 10},
+		{Type: TokenNumber, Literal: "0", Position: 11, Value: big.NewInt(0)},
+		{Type: TokenDot, Literal: ".", Position: 12},
+		{Type: TokenNumber, Literal: "0", Position: 13, Value: big.NewInt(0)},
+		{Type: TokenLParen, Literal: "(", Position: 15},
+		{Type: TokenCon, Literal: "con", Position: 16},
+		{Type: TokenIdentifier, Literal: "integer", Position: 20},
+		{Type: TokenNumber, Literal: "42", Position: 28, Value: big.NewInt(42)},
+		{Type: TokenRParen, Literal: ")", Position: 30},
+		{Type: TokenRParen, Literal: ")", Position: 31},
+		{Type: TokenEOF, Literal: "", Position: 32},
+	}
+
+	lexer := NewLexer(input)
+
+	for i, expected := range expectedTokens {
+		token := lexer.NextToken()
+		if token.Type != expected.Type {
+			t.Errorf(
+				"Token %d: expected type %v, got %v",
+				i,
+				expected.Type,
+				token.Type,
+			)
+		}
+		if token.Literal != expected.Literal {
+			t.Errorf(
+				"Token %d: expected literal %q, got %q",
+				i,
+				expected.Literal,
+				token.Literal,
+			)
+		}
+		if token.Position != expected.Position {
+			t.Errorf(
+				"Token %d: expected position %d, got %d",
+				i,
+				expected.Position,
+				token.Position,
+			)
+		}
+		if expected.Value != nil {
+			if !reflect.DeepEqual(token.Value, expected.Value) {
+				t.Errorf(
+					"Token %d: expected value %v, got %v",
+					i,
+					expected.Value,
+					token.Value,
+				)
+			}
+		}
+	}
+}
+
+func TestLexerStrings(t *testing.T) {
+	input := `"hello world" "with \"quotes\""`
+
+	expectedTokens := []Token{
+		{
+			Type:     TokenString,
+			Literal:  "hello world",
+			Position: 0,
+			Value:    "hello world",
+		},
+		{
+			Type:     TokenString,
+			Literal:  `with "quotes"`,
+			Position: 14,
+			Value:    `with "quotes"`,
+		},
+		{Type: TokenEOF, Literal: "", Position: 31},
+	}
+
+	lexer := NewLexer(input)
+
+	for i, expected := range expectedTokens {
+		token := lexer.NextToken()
+		if token.Type != expected.Type {
+			t.Errorf(
+				"Token %d: expected type %v, got %v",
+				i,
+				expected.Type,
+				token.Type,
+			)
+		}
+		if token.Literal != expected.Literal {
+			t.Errorf(
+				"Token %d: expected literal %q, got %q",
+				i,
+				expected.Literal,
+				token.Literal,
+			)
+		}
+		if token.Position != expected.Position {
+			t.Errorf(
+				"Token %d: expected position %d, got %d",
+				i,
+				expected.Position,
+				token.Position,
+			)
+		}
+		if expected.Value != nil {
+			if token.Value != expected.Value {
+				t.Errorf(
+					"Token %d: expected value %v, got %v",
+					i,
+					expected.Value,
+					token.Value,
+				)
+			}
+		}
+	}
+}
+
+func TestLexerByteString(t *testing.T) {
+	input := `#aaBBcc`
+
+	expected := Token{
+		Type:     TokenByteString,
+		Literal:  "aaBBcc",
+		Position: 0,
+		Value:    []byte{0xaa, 0xBB, 0xcc},
+	}
+
+	lexer := NewLexer(input)
+	token := lexer.NextToken()
+
+	if token.Type != expected.Type {
+		t.Errorf("Expected type %v, got %v", expected.Type, token.Type)
+	}
+	if token.Literal != expected.Literal {
+		t.Errorf("Expected literal %q, got %q", expected.Literal, token.Literal)
+	}
+	if token.Position != expected.Position {
+		t.Errorf(
+			"Expected position %d, got %d",
+			expected.Position,
+			token.Position,
+		)
+	}
+	if !reflect.DeepEqual(token.Value, expected.Value) {
+		t.Errorf("Expected value %v, got %v", expected.Value, token.Value)
+	}
+}
+
+func TestLexerKeywords(t *testing.T) {
+	input := `lam delay force builtin constr case con error program list pair I B List Map Constr True False ()`
+
+	keywords := []TokenType{
+		TokenLam, TokenDelay, TokenForce, TokenBuiltin, TokenConstr, TokenCase, TokenCon, TokenErrorTerm,
+		TokenProgram, TokenList, TokenPair, TokenI, TokenB, TokenPlutusList, TokenMap, TokenPlutusConstr,
+		TokenTrue, TokenFalse, TokenUnit,
+	}
+
+	lexer := NewLexer(input)
+	position := 0
+
+	for _, expectedType := range keywords {
+		token := lexer.NextToken()
+		if token.Type != expectedType {
+			t.Errorf(
+				"Expected type %v at position %d, got %v",
+				expectedType,
+				position,
+				token.Type,
+			)
+		}
+		position = token.Position + len(token.Literal)
+	}
+}
+
+func FuzzLexerNextToken(f *testing.F) {
+	testInputs := []string{
+		`(program 1.2.0 (con integer 42))`,
+		`"hello"`,
+		`#aaBBcc`,
+		`lam delay force`,
+	}
+	for _, input := range testInputs {
+		f.Add(input)
+	}
+	f.Fuzz(func(t *testing.T, input string) {
+		lexer := NewLexer(input)
+		for {
+			token := lexer.NextToken()
+			if token.Type == TokenEOF {
+				break
+			}
+			// Just ensure no panic
+		}
+	})
+}

--- a/syn/parser_test.go
+++ b/syn/parser_test.go
@@ -1,0 +1,69 @@
+package syn
+
+import (
+	"testing"
+)
+
+func TestParsePrettyRoundTrip(t *testing.T) {
+	// Test that parsing a pretty-printed program gives the same AST
+	programs := []string{
+		`(program 1.2.0 (con integer 42))`,
+		`(program 1.2.0 [(builtin addInteger) (con integer 1) (con integer 2)])`,
+		`(program 1.2.0 (lam x x))`,
+	}
+
+	for _, input := range programs {
+		parsed, err := Parse(input)
+		if err != nil {
+			t.Fatalf("Failed to parse input %q: %v", input, err)
+		}
+
+		pretty := Pretty(parsed)
+
+		parsedAgain, err := Parse(pretty)
+		if err != nil {
+			t.Errorf("Failed to parse pretty output %q: %v", pretty, err)
+			continue
+		}
+
+		// Check that pretty printing again gives the same result
+		prettyAgain := Pretty(parsedAgain)
+		if pretty != prettyAgain {
+			t.Errorf(
+				"Round-trip failed for input %q: first pretty %q, second %q",
+				input,
+				pretty,
+				prettyAgain,
+			)
+		}
+	}
+}
+
+func FuzzParse(f *testing.F) {
+	f.Add("(program 1.2.0 (con integer 42))")
+	f.Add(
+		"(program 1.2.0 [(builtin addInteger) (con integer 1) (con integer 2)])",
+	)
+	f.Fuzz(func(t *testing.T, input string) {
+		// Just try to parse, don't care about result
+		Parse(input)
+	})
+}
+
+func FuzzPretty(f *testing.F) {
+	testPrograms := []string{
+		"(program 1.2.0 (con integer 42))",
+		"(program 1.2.0 [(builtin addInteger) (con integer 1) (con integer 2)])",
+	}
+	for _, prog := range testPrograms {
+		parsed, err := Parse(prog)
+		if err != nil {
+			f.Fatal("Failed to parse canonical program:", err)
+		}
+		f.Add(Pretty(parsed))
+	}
+	f.Fuzz(func(t *testing.T, pretty string) {
+		// Try to parse the pretty output
+		Parse(pretty)
+	})
+}

--- a/tests/crypto_bench_test.go
+++ b/tests/crypto_bench_test.go
@@ -84,7 +84,9 @@ func BenchmarkDirectCrypto(b *testing.B) {
 		p, _ := bls.HashToG1(message, dst)
 		var jac bls.G1Jac
 		jac.FromAffine(&p)
-		scalar := new(big.Int).SetBytes([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+		scalar := new(
+			big.Int,
+		).SetBytes([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
 		b.ResetTimer()
 		for b.Loop() {
 			var result bls.G1Jac


### PR DESCRIPTION








<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds property-based and fuzz tests across builtins, CEK machine, parser, lexer, and CBOR data to harden against edge cases. Adds a Makefile fuzz target to run all fuzzers.

- **New Features**
  - Fuzzers: FromByte (builtin), DecodeCBOR (data), Parse and Pretty (syn), Lexer.NextToken (syn/lex), Machine.Run (cek).
  - Property tests: Parse↔Pretty round-trip, CBOR encode/decode round-trip, CEK determinism and budget checks.
  - Makefile: new fuzz target to run all fuzz suites with go test -fuzz.

<sup>Written for commit 20559c7c6d08c9b0cb09024f5f176cc3e555cd11. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive unit and fuzz tests across parsing, lexing, execution/machine, data handling, and builtin components — covering round‑trip, encode/decode, determinism, budgeting, mapping correctness, and resilience.
* **Chores**
  * Added a public build target to run fuzz suites across multiple packages and a default fuzz flags variable.
* **Style**
  * Minor formatting tweak in a benchmark (no behavioral change).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->