### PR TITLE
fix: decode map with duplicate keys

### DIFF
--- a/data/data_test.go
+++ b/data/data_test.go
@@ -224,6 +224,31 @@ var testDefs = []struct {
 		// {_ h'01': 1, h'02': 2}
 		CborHex: "bf410101410202ff",
 	},
+	// Map with duplicate keys
+	{
+		Data: NewMapDefIndef(
+			false,
+			[][2]PlutusData{
+				{
+					NewByteString([]byte("6Key")),
+					NewByteString([]byte("1")),
+				},
+				{
+					NewByteString([]byte("5Key")),
+					NewByteString([]byte("7")),
+				},
+				{
+					NewByteString([]byte("6Key")),
+					NewByteString(nil),
+				},
+				{
+					NewByteString([]byte("5Key")),
+					NewByteString(nil),
+				},
+			},
+		),
+		CborHex: "a444364b6579413144354b6579413744364b65794044354b657940",
+	},
 }
 
 func TestPlutusDataEncode(t *testing.T) {

--- a/data/decode.go
+++ b/data/decode.go
@@ -105,9 +105,10 @@ func decodeCborRawMap(data []byte) (any, error) {
 	// The below is a hack to work around our CBOR library not supporting preserving key
 	// order when decoding a map. We decode our map to determine its length, create a dummy
 	// list the same length as our map to determine the header size, and then decode each
-	// key/value pair individually
+	// key/value pair individually. We use a pointer for the key to keep duplicates to get
+	// an accurate count for decoding
 	useIndef := (data[0] & CborIndefFlag) == CborIndefFlag
-	var tmpData map[RawMessageStr]RawMessageStr
+	var tmpData map[*RawMessageStr]RawMessageStr
 	if err := cborUnmarshal(data, &tmpData); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CBOR map decoding when maps contain duplicate keys. We now count entries correctly and decode each key/value pair reliably.

- **Bug Fixes**
  - Use map[*RawMessageStr]RawMessageStr for the temporary decode to preserve duplicate keys and get an accurate entry count.
  - Add a test case with duplicate byte string keys to prevent regressions.

<sup>Written for commit 2aff4cb22a97ea9ca416735eb5f106d9cb26387f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decoding to correctly preserve and count duplicate keys in CBOR maps, yielding more accurate decode results.

* **Tests**
  * Added tests covering maps with duplicate keys to verify correct round-trip encoding/decoding behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->