### PR TITLE
fix: return correct type for bls12-381 g2

### DIFF
--- a/syn/constant.go
+++ b/syn/constant.go
@@ -117,7 +117,7 @@ type Bls12_381G2Element struct {
 func (Bls12_381G2Element) isConstant() {}
 
 func (Bls12_381G2Element) Typ() Typ {
-	return &TBls12_381G1Element{}
+	return &TBls12_381G2Element{}
 }
 
 type Bls12_381MlResult struct {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Corrected Typ() for Bls12_381G2Element to return TBls12_381G2Element instead of TBls12_381G1Element. Prevents type mismatches when using BLS12-381 G2 constants.

<sup>Written for commit 0fad7d2bccfee3b397eea26146cde1af5dc8f6be. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected type resolution for BLS 12-381 G2 element operations to ensure proper cryptographic type handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->