### PR TITLE
fix: string for named debruijn digit for index

### DIFF
--- a/syn/binder.go
+++ b/syn/binder.go
@@ -129,7 +129,7 @@ func (n NamedDeBruijn) TextName() string {
 }
 
 func (n NamedDeBruijn) String() string {
-	return fmt.Sprintf("NamedDeBruijn: %s %v", n.Text, n.Index)
+	return fmt.Sprintf("NamedDeBruijn: %s %d", n.Text, n.Index)
 }
 
 func (n NamedDeBruijn) LookupIndex() int {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed NamedDeBruijn.String() to format the index with %d instead of %v so it always renders as a decimal integer. This makes logs and output consistent and easier to read.

<sup>Written for commit f76bd90daeb7c66ac62fcf96fcf3011ab811cf09. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor formatting adjustment to internal debugging output.

---

**Note:** This release contains no user-facing changes or new features. The modification is limited to internal code formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->