### PR TITLE
fix: insert unique overwrite

### DIFF
--- a/syn/bimap.go
+++ b/syn/bimap.go
@@ -6,6 +6,10 @@ type biMap struct {
 }
 
 func (b *biMap) insert(unique Unique, level uint) {
+	// If unique already exists, remove the old level mapping
+	if oldLevel, exists := b.left[unique]; exists {
+		delete(b.right, oldLevel)
+	}
 	b.left[unique] = level
 	b.right[level] = unique
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix biMap insert to correctly overwrite an existing Unique. When re-inserting the same Unique, remove its old level from the right map to keep mappings in sync and prevent stale reverse lookups.

<sup>Written for commit 22bb77b107c39875fd8522d0179436687c0bf82c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed data consistency issue when re-inserting existing entries into bidirectional maps by properly cleaning up previous mappings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->