### PR TITLE
test: bidirectonal maps, binder, builder, constant

### DIFF
--- a/syn/bimap_test.go
+++ b/syn/bimap_test.go
@@ -1,0 +1,96 @@
+package syn
+
+import (
+	"testing"
+)
+
+func TestBiMap(t *testing.T) {
+	bm := &biMap{
+		left:  make(map[Unique]uint),
+		right: make(map[uint]Unique),
+	}
+
+	// Test insert and getByUnique
+	unique1 := Unique(42)
+	level1 := uint(10)
+	bm.insert(unique1, level1)
+
+	if level, ok := bm.getByUnique(unique1); !ok || level != level1 {
+		t.Errorf("Expected to find level %d for unique %d, got %d, ok=%v", level1, unique1, level, ok)
+	}
+
+	// Test getByLevel
+	if unique, ok := bm.getByLevel(level1); !ok || unique != unique1 {
+		t.Errorf("Expected to find unique %d for level %d, got %d, ok=%v", unique1, level1, unique, ok)
+	}
+
+	// Test non-existent unique
+	if _, ok := bm.getByUnique(Unique(999)); ok {
+		t.Error("Expected not to find non-existent unique")
+	}
+
+	// Test non-existent level
+	if _, ok := bm.getByLevel(999); ok {
+		t.Error("Expected not to find non-existent level")
+	}
+
+	// Test insert another pair
+	unique2 := Unique(100)
+	level2 := uint(20)
+	bm.insert(unique2, level2)
+
+	if level, ok := bm.getByUnique(unique2); !ok || level != level2 {
+		t.Errorf("Expected to find level %d for unique %d, got %d, ok=%v", level2, unique2, level, ok)
+	}
+
+	if unique, ok := bm.getByLevel(level2); !ok || unique != unique2 {
+		t.Errorf("Expected to find unique %d for level %d, got %d, ok=%v", unique2, level2, unique, ok)
+	}
+
+	// Test remove
+	bm.remove(unique1, level1)
+
+	if _, ok := bm.getByUnique(unique1); ok {
+		t.Error("Expected unique1 to be removed")
+	}
+
+	if _, ok := bm.getByLevel(level1); ok {
+		t.Error("Expected level1 to be removed")
+	}
+
+	// Test that unique2 is still there
+	if level, ok := bm.getByUnique(unique2); !ok || level != level2 {
+		t.Errorf("Expected unique2 to still exist with level %d, got %d, ok=%v", level2, level, ok)
+	}
+}
+
+func TestBiMapOverwrite(t *testing.T) {
+	bm := &biMap{
+		left:  make(map[Unique]uint),
+		right: make(map[uint]Unique),
+	}
+
+	// Insert initial pair
+	unique := Unique(1)
+	level1 := uint(10)
+	bm.insert(unique, level1)
+
+	// Insert same unique with different level (should overwrite)
+	level2 := uint(20)
+	bm.insert(unique, level2)
+
+	// Should find new level
+	if level, ok := bm.getByUnique(unique); !ok || level != level2 {
+		t.Errorf("Expected level %d after overwrite, got %d, ok=%v", level2, level, ok)
+	}
+
+	// Old level should not exist
+	if _, ok := bm.getByLevel(level1); ok {
+		t.Error("Expected old level to be removed after overwrite")
+	}
+
+	// New level should point to unique
+	if foundUnique, ok := bm.getByLevel(level2); !ok || foundUnique != unique {
+		t.Errorf("Expected level %d to point to unique %d, got %d, ok=%v", level2, unique, foundUnique, ok)
+	}
+}

--- a/syn/binder_test.go
+++ b/syn/binder_test.go
@@ -1,0 +1,114 @@
+package syn
+
+import (
+	"testing"
+)
+
+func TestNameBinder(t *testing.T) {
+	name := Name{
+		Text:   "testVar",
+		Unique: Unique(42),
+	}
+
+	// Test TextName
+	if name.TextName() != "testVar" {
+		t.Errorf("Expected TextName 'testVar', got %q", name.TextName())
+	}
+
+	// Test String
+	expectedString := "Name: testVar 42"
+	if name.String() != expectedString {
+		t.Errorf("Expected String %q, got %q", expectedString, name.String())
+	}
+}
+
+func TestNamedDeBruijnBinder(t *testing.T) {
+	nd := NamedDeBruijn{
+		Text:  "param",
+		Index: DeBruijn(5),
+	}
+
+	// Test TextName
+	expectedTextName := "param_5"
+	if nd.TextName() != expectedTextName {
+		t.Errorf("Expected TextName %q, got %q", expectedTextName, nd.TextName())
+	}
+
+	// Test String
+	expectedString := "NamedDeBruijn: param 5"
+	if nd.String() != expectedString {
+		t.Errorf("Expected String %q, got %q", expectedString, nd.String())
+	}
+
+	// Test LookupIndex
+	if nd.LookupIndex() != 5 {
+		t.Errorf("Expected LookupIndex 5, got %d", nd.LookupIndex())
+	}
+}
+
+func TestDeBruijnBinder(t *testing.T) {
+	db := DeBruijn(7)
+
+	// Test TextName
+	expectedTextName := "i_7"
+	if db.TextName() != expectedTextName {
+		t.Errorf("Expected TextName %q, got %q", expectedTextName, db.TextName())
+	}
+
+	// Test String
+	expectedString := "DeBruijn: 7"
+	if db.String() != expectedString {
+		t.Errorf("Expected String %q, got %q", expectedString, db.String())
+	}
+
+	// Test LookupIndex
+	if db.LookupIndex() != 7 {
+		t.Errorf("Expected LookupIndex 7, got %d", db.LookupIndex())
+	}
+}
+
+// TestBinderInterfaceCompliance tests that all binder types implement the Binder interface
+func TestBinderInterfaceCompliance(t *testing.T) {
+	var _ Binder = Name{}
+	var _ Binder = NamedDeBruijn{}
+	var _ Binder = DeBruijn(0)
+
+	var _ Eval = NamedDeBruijn{}
+	var _ Eval = DeBruijn(0)
+}
+
+// TestUniqueType tests the Unique type
+func TestUniqueType(t *testing.T) {
+	u1 := Unique(42)
+	u2 := Unique(42)
+	u3 := Unique(43)
+
+	if u1 != u2 {
+		t.Error("Expected equal Unique values to be equal")
+	}
+
+	if u1 == u3 {
+		t.Error("Expected different Unique values to not be equal")
+	}
+}
+
+// TestDeBruijnType tests the DeBruijn type
+func TestDeBruijnType(t *testing.T) {
+	db1 := DeBruijn(5)
+	db2 := DeBruijn(5)
+	db3 := DeBruijn(6)
+
+	if db1 != db2 {
+		t.Error("Expected equal DeBruijn values to be equal")
+	}
+
+	if db1 == db3 {
+		t.Error("Expected different DeBruijn values to not be equal")
+	}
+
+	// Test negative values are allowed (they represent invalid states)
+	dbNeg := DeBruijn(-1)
+	if dbNeg.LookupIndex() != -1 {
+		t.Errorf("Expected LookupIndex -1, got %d", dbNeg.LookupIndex())
+	}
+}

--- a/syn/builder_test.go
+++ b/syn/builder_test.go
@@ -1,0 +1,291 @@
+package syn
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/blinklabs-io/plutigo/builtin"
+)
+
+func TestIntern(t *testing.T) {
+	// Create a simple term
+	term := NewVar("x", Unique(0))
+
+	// Intern the term
+	interned := Intern(term)
+
+	// Check that the same term is returned
+	if interned != term {
+		t.Error("Intern should return the same term object")
+	}
+
+	// Check that it's still a Var
+	if _, ok := interned.(*Var[Name]); !ok {
+		t.Error("Intern should preserve term type")
+	}
+}
+
+func TestNewProgram(t *testing.T) {
+	version := [3]uint32{1, 0, 0}
+	term := &Var[Name]{Name: NewRawName("test")}
+
+	program := NewProgram(version, term)
+
+	if program.Version != version {
+		t.Errorf("Expected version %v, got %v", version, program.Version)
+	}
+
+	if program.Term != term {
+		t.Error("Term not set correctly")
+	}
+}
+
+func TestNewName(t *testing.T) {
+	name := NewName("testVar", Unique(42))
+
+	if name.Text != "testVar" {
+		t.Errorf("Expected text 'testVar', got %q", name.Text)
+	}
+
+	if name.Unique != 42 {
+		t.Errorf("Expected unique 42, got %d", name.Unique)
+	}
+}
+
+func TestNewRawName(t *testing.T) {
+	name := NewRawName("testVar")
+
+	if name.Text != "testVar" {
+		t.Errorf("Expected text 'testVar', got %q", name.Text)
+	}
+
+	if name.Unique != 0 {
+		t.Errorf("Expected unique 0, got %d", name.Unique)
+	}
+}
+
+func TestNewVar(t *testing.T) {
+	term := NewVar("testVar", Unique(42))
+
+	varTerm, ok := term.(*Var[Name])
+	if !ok {
+		t.Fatal("Expected Var term")
+	}
+
+	if varTerm.Name.Text != "testVar" {
+		t.Errorf("Expected name 'testVar', got %q", varTerm.Name.Text)
+	}
+
+	if varTerm.Name.Unique != 42 {
+		t.Errorf("Expected unique 42, got %d", varTerm.Name.Unique)
+	}
+}
+
+func TestNewRawVar(t *testing.T) {
+	term := NewRawVar("testVar")
+
+	varTerm, ok := term.(*Var[Name])
+	if !ok {
+		t.Fatal("Expected Var term")
+	}
+
+	if varTerm.Name.Text != "testVar" {
+		t.Errorf("Expected name 'testVar', got %q", varTerm.Name.Text)
+	}
+
+	if varTerm.Name.Unique != 0 {
+		t.Errorf("Expected unique 0, got %d", varTerm.Name.Unique)
+	}
+}
+
+func TestNewApply(t *testing.T) {
+	function := NewRawVar("f")
+	argument := NewRawVar("x")
+
+	apply := NewApply(function, argument)
+
+	applyTerm, ok := apply.(*Apply[Name])
+	if !ok {
+		t.Fatal("Expected Apply term")
+	}
+
+	if applyTerm.Function != function {
+		t.Error("Function not set correctly")
+	}
+
+	if applyTerm.Argument != argument {
+		t.Error("Argument not set correctly")
+	}
+}
+
+func TestNewLambda(t *testing.T) {
+	paramName := NewRawName("x")
+	body := NewRawVar("x")
+
+	lambda := NewLambda(paramName, body)
+
+	lambdaTerm, ok := lambda.(*Lambda[Name])
+	if !ok {
+		t.Fatal("Expected Lambda term")
+	}
+
+	if lambdaTerm.ParameterName != paramName {
+		t.Error("ParameterName not set correctly")
+	}
+
+	if lambdaTerm.Body != body {
+		t.Error("Body not set correctly")
+	}
+}
+
+func TestNewDelay(t *testing.T) {
+	innerTerm := NewRawVar("x")
+
+	delay := NewDelay(innerTerm)
+
+	delayTerm, ok := delay.(*Delay[Name])
+	if !ok {
+		t.Fatal("Expected Delay term")
+	}
+
+	if delayTerm.Term != innerTerm {
+		t.Error("Term not set correctly")
+	}
+}
+
+func TestNewForce(t *testing.T) {
+	innerTerm := NewRawVar("x")
+
+	force := NewForce(innerTerm)
+
+	forceTerm, ok := force.(*Force[Name])
+	if !ok {
+		t.Fatal("Expected Force term")
+	}
+
+	if forceTerm.Term != innerTerm {
+		t.Error("Term not set correctly")
+	}
+}
+
+func TestNewConstant(t *testing.T) {
+	integerConst := &Integer{Inner: big.NewInt(42)}
+
+	constant := NewConstant(integerConst)
+
+	constantTerm, ok := constant.(*Constant)
+	if !ok {
+		t.Fatal("Expected Constant term")
+	}
+
+	if constantTerm.Con != integerConst {
+		t.Error("Constant not set correctly")
+	}
+}
+
+func TestNewSimpleInteger(t *testing.T) {
+	term := NewSimpleInteger(42)
+
+	constantTerm, ok := term.(*Constant)
+	if !ok {
+		t.Fatal("Expected Constant term")
+	}
+
+	integerConst, ok := constantTerm.Con.(*Integer)
+	if !ok {
+		t.Fatal("Expected Integer constant")
+	}
+
+	if integerConst.Inner.Cmp(big.NewInt(42)) != 0 {
+		t.Errorf("Expected value 42, got %s", integerConst.Inner.String())
+	}
+}
+
+func TestNewInteger(t *testing.T) {
+	value := big.NewInt(123456789)
+	term := NewInteger(value)
+
+	constantTerm, ok := term.(*Constant)
+	if !ok {
+		t.Fatal("Expected Constant term")
+	}
+
+	integerConst, ok := constantTerm.Con.(*Integer)
+	if !ok {
+		t.Fatal("Expected Integer constant")
+	}
+
+	if integerConst.Inner.Cmp(value) != 0 {
+		t.Errorf("Expected value %s, got %s", value.String(), integerConst.Inner.String())
+	}
+}
+
+func TestNewBool(t *testing.T) {
+	term := NewBool(true)
+
+	constantTerm, ok := term.(*Constant)
+	if !ok {
+		t.Fatal("Expected Constant term")
+	}
+
+	boolConst, ok := constantTerm.Con.(*Bool)
+	if !ok {
+		t.Fatal("Expected Bool constant")
+	}
+
+	if boolConst.Inner != true {
+		t.Error("Expected true, got false")
+	}
+}
+
+func TestNewBuiltin(t *testing.T) {
+	term := NewBuiltin(builtin.AddInteger)
+
+	builtinTerm, ok := term.(*Builtin)
+	if !ok {
+		t.Fatal("Expected Builtin term")
+	}
+
+	if builtinTerm.DefaultFunction != builtin.AddInteger {
+		t.Error("Builtin function not set correctly")
+	}
+}
+
+func TestAddInteger(t *testing.T) {
+	term := AddInteger()
+
+	builtinTerm, ok := term.(*Builtin)
+	if !ok {
+		t.Fatal("Expected Builtin term")
+	}
+
+	if builtinTerm.DefaultFunction != builtin.AddInteger {
+		t.Error("Expected AddInteger builtin")
+	}
+}
+
+func TestSubtractInteger(t *testing.T) {
+	term := SubtractInteger()
+
+	builtinTerm, ok := term.(*Builtin)
+	if !ok {
+		t.Fatal("Expected Builtin term")
+	}
+
+	if builtinTerm.DefaultFunction != builtin.SubtractInteger {
+		t.Error("Expected SubtractInteger builtin")
+	}
+}
+
+func TestIfThenElse(t *testing.T) {
+	term := IfThenElse()
+
+	builtinTerm, ok := term.(*Builtin)
+	if !ok {
+		t.Fatal("Expected Builtin term")
+	}
+
+	if builtinTerm.DefaultFunction != builtin.IfThenElse {
+		t.Error("Expected IfThenElse builtin")
+	}
+}

--- a/syn/constant_test.go
+++ b/syn/constant_test.go
@@ -1,0 +1,164 @@
+package syn
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/blinklabs-io/plutigo/data"
+	bls "github.com/consensys/gnark-crypto/ecc/bls12-381"
+)
+
+func TestIntegerTyp(t *testing.T) {
+	integer := Integer{Inner: big.NewInt(42)}
+
+	typ := integer.Typ()
+
+	if _, ok := typ.(*TInteger); !ok {
+		t.Errorf("Expected TInteger, got %T", typ)
+	}
+}
+
+func TestByteStringTyp(t *testing.T) {
+	bs := ByteString{Inner: []byte{1, 2, 3}}
+
+	typ := bs.Typ()
+
+	if _, ok := typ.(*TByteString); !ok {
+		t.Errorf("Expected TByteString, got %T", typ)
+	}
+}
+
+func TestStringTyp(t *testing.T) {
+	str := String{Inner: "hello"}
+
+	typ := str.Typ()
+
+	if _, ok := typ.(*TString); !ok {
+		t.Errorf("Expected TString, got %T", typ)
+	}
+}
+
+func TestUnitTyp(t *testing.T) {
+	unit := Unit{}
+
+	typ := unit.Typ()
+
+	if _, ok := typ.(*TUnit); !ok {
+		t.Errorf("Expected TUnit, got %T", typ)
+	}
+}
+
+func TestBoolTyp(t *testing.T) {
+	boolConst := Bool{Inner: true}
+
+	typ := boolConst.Typ()
+
+	if _, ok := typ.(*TBool); !ok {
+		t.Errorf("Expected TBool, got %T", typ)
+	}
+}
+
+func TestProtoListTyp(t *testing.T) {
+	elementType := &TInteger{}
+	protoList := ProtoList{
+		LTyp: elementType,
+		List: []IConstant{
+			&Integer{Inner: big.NewInt(1)},
+			&Integer{Inner: big.NewInt(2)},
+		},
+	}
+
+	typ := protoList.Typ()
+
+	listTyp, ok := typ.(*TList)
+	if !ok {
+		t.Errorf("Expected TList, got %T", typ)
+		return
+	}
+
+	if listTyp.Typ != elementType {
+		t.Errorf("Expected element type %T, got %T", elementType, listTyp.Typ)
+	}
+}
+
+func TestProtoPairTyp(t *testing.T) {
+	fstType := &TInteger{}
+	sndType := &TBool{}
+	protoPair := ProtoPair{
+		FstType: fstType,
+		SndType: sndType,
+		First:   &Integer{Inner: big.NewInt(42)},
+		Second:  &Bool{Inner: true},
+	}
+
+	typ := protoPair.Typ()
+
+	pairTyp, ok := typ.(*TPair)
+	if !ok {
+		t.Errorf("Expected TPair, got %T", typ)
+		return
+	}
+
+	if pairTyp.First != fstType {
+		t.Errorf("Expected first type %T, got %T", fstType, pairTyp.First)
+	}
+
+	if pairTyp.Second != sndType {
+		t.Errorf("Expected second type %T, got %T", sndType, pairTyp.Second)
+	}
+}
+
+func TestDataTyp(t *testing.T) {
+	dataConst := Data{Inner: data.NewInteger(big.NewInt(42))} // Simple integer data for testing
+
+	typ := dataConst.Typ()
+
+	if _, ok := typ.(*TData); !ok {
+		t.Errorf("Expected TData, got %T", typ)
+	}
+}
+
+func TestBls12_381G1ElementTyp(t *testing.T) {
+	g1 := Bls12_381G1Element{Inner: &bls.G1Jac{}} // Empty G1 element for testing
+
+	typ := g1.Typ()
+
+	if _, ok := typ.(*TBls12_381G1Element); !ok {
+		t.Errorf("Expected TBls12_381G1Element, got %T", typ)
+	}
+}
+
+func TestBls12_381G2ElementTyp(t *testing.T) {
+	g2 := Bls12_381G2Element{Inner: &bls.G2Jac{}} // Empty G2 element for testing
+
+	typ := g2.Typ()
+
+	if _, ok := typ.(*TBls12_381G2Element); !ok {
+		t.Errorf("Expected TBls12_381G2Element, got %T", typ)
+	}
+}
+
+func TestBls12_381MlResultTyp(t *testing.T) {
+	ml := Bls12_381MlResult{Inner: &bls.GT{}} // Empty GT element for testing
+
+	typ := ml.Typ()
+
+	if _, ok := typ.(*TBls12_381MlResult); !ok {
+		t.Errorf("Expected TBls12_381MlResult, got %T", typ)
+	}
+}
+
+// Test that all constant types implement IConstant interface
+func TestIConstantInterfaceCompliance(t *testing.T) {
+	var _ IConstant = Integer{}
+	var _ IConstant = ByteString{}
+	var _ IConstant = String{}
+	var _ IConstant = Unit{}
+	var _ IConstant = Bool{}
+	var _ IConstant = ProtoList{}
+	var _ IConstant = ProtoPair{}
+	var _ IConstant = Data{}
+	var _ IConstant = Bls12_381G1Element{}
+	var _ IConstant = Bls12_381G2Element{}
+	var _ IConstant = Bls12_381MlResult{}
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add unit tests for biMap, binder types, builder constructors, and constant type inference in the syn package. Improves coverage and verifies insert/get/remove behavior, interface compliance, formatting, builtin wiring, and Typ() outputs.

- Covers biMap insert/get/remove and overwrite cases
- Tests Name, NamedDeBruijn, DeBruijn (TextName, String, LookupIndex, interface compliance)
- Validates builder constructors: Program, Var/Apply/Lambda/Delay/Force, Constant, Integer/Bool, Builtin (AddInteger, SubtractInteger, IfThenElse)
- Checks Typ() for Integer, ByteString, String, Unit, Bool, ProtoList, ProtoPair, Data, and BLS12-381 G1/G2/GT constants

<sup>Written for commit a74f2ff6e151e0e3a3e4a4a609ca2b1b20d30182. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test coverage for core data structures, term construction, and type validation utilities to enhance code reliability and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->