### PR TITLE
test: cek crypto and syn pretty print tests

### DIFF
--- a/syn/builder_test.go
+++ b/syn/builder_test.go
@@ -406,7 +406,7 @@ func TestNameToDeBruijnComplex(t *testing.T) {
 }
 
 func TestNameToDeBruijnWithConstants(t *testing.T) {
-	// Create a program with constants and builtins: (lam x (addInteger x 1))
+	// Create a program with constants and builtins: (lam x ((addInteger 1) x))
 	addInt := NewBuiltin(builtin.AddInteger)
 	one := NewSimpleInteger(1)
 	apply := NewApply(addInt, one)

--- a/syn/parser_extended_test.go
+++ b/syn/parser_extended_test.go
@@ -1,0 +1,214 @@
+package syn
+
+import (
+	"testing"
+)
+
+func TestParseDelay(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			name:    "simple delay with constant",
+			input:   "(delay (con integer 42))",
+			wantErr: false,
+		},
+		{
+			name:    "delay with nested force",
+			input:   "(delay (force (delay (con integer 1))))",
+			wantErr: false,
+		},
+		{
+			name:    "delay with variable",
+			input:   "(delay x)",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewParser(tt.input)
+			_, err := p.ParseTerm()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseTerm() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseForce(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			name:    "simple force with delay",
+			input:   "(force (delay (con integer 42)))",
+			wantErr: false,
+		},
+		{
+			name:    "force with nested delay",
+			input:   "(force (delay (force (delay (con integer 1)))))",
+			wantErr: false,
+		},
+		{
+			name:    "force with variable",
+			input:   "(force x)",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewParser(tt.input)
+			_, err := p.ParseTerm()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseTerm() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseConstr(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			name:    "constr with no fields",
+			input:   "(program 1.1.0 (constr 0))",
+			wantErr: false,
+		},
+		{
+			name:    "constr with one field",
+			input:   "(program 1.1.0 (constr 0 (con integer 42)))",
+			wantErr: false,
+		},
+		{
+			name:    "constr with multiple fields",
+			input:   "(program 1.1.0 (constr 1 (con integer 1) (con integer 2) (con integer 3)))",
+			wantErr: false,
+		},
+		{
+			name:    "constr with nested terms",
+			input:   "(program 1.1.0 (constr 0 (delay (con integer 1)) (force x)))",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewParser(tt.input)
+			_, err := p.ParseProgram()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseProgram() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseCase(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			name:    "case with one branch",
+			input:   "(program 1.1.0 (case (constr 0) (con integer 1)))",
+			wantErr: false,
+		},
+		{
+			name:    "case with multiple branches",
+			input:   "(program 1.1.0 (case (constr 0) (con integer 1) (con integer 2) (con integer 3)))",
+			wantErr: false,
+		},
+		{
+			name:    "case with variable constr",
+			input:   "(program 1.1.0 (case x (con integer 1) (con integer 2)))",
+			wantErr: false,
+		},
+		{
+			name:    "case with nested terms",
+			input:   "(program 1.1.0 (case (constr 0) (delay (con integer 1)) (force x)))",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewParser(tt.input)
+			_, err := p.ParseProgram()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseProgram() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseError(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			name:    "simple error",
+			input:   "(error)",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewParser(tt.input)
+			term, err := p.ParseTerm()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseTerm() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err == nil {
+				if _, ok := term.(*Error); !ok {
+					t.Errorf("Expected *Error, got %T", term)
+				}
+			}
+		})
+	}
+}
+
+func TestParseComplexTerms(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			name:    "complex nested term",
+			input:   "(program 1.1.0 (lam x (force (delay (case (constr 0 x) (con integer 1) (con integer 2))))))",
+			wantErr: false,
+		},
+		{
+			name:    "apply with delay and force",
+			input:   "(program 1.0.0 [(force (delay (con integer 42))) (con integer 1)])",
+			wantErr: false,
+		},
+		{
+			name:    "case with constr in branches",
+			input:   "(program 1.1.0 (case x (constr 0) (constr 1 (con integer 1))))",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewParser(tt.input)
+			_, err := p.ParseProgram()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseProgram() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/syn/pretty_test.go
+++ b/syn/pretty_test.go
@@ -1,0 +1,41 @@
+package syn
+
+import (
+	"math/big"
+	"strings"
+	"testing"
+)
+
+func TestPrettyTerm(t *testing.T) {
+	// Test with a simple integer constant
+	term := &Constant{Con: &Integer{Inner: big.NewInt(42)}}
+
+	result := PrettyTerm[DeBruijn](term)
+
+	if result == "" {
+		t.Errorf("PrettyTerm returned empty string")
+	}
+
+	// Should contain "42"
+	if !strings.Contains(result, "42") {
+		t.Errorf("PrettyTerm output does not contain '42': %s", result)
+	}
+}
+
+func TestPrettyTermComplex(t *testing.T) {
+	// Test with a lambda
+	term := &Lambda[DeBruijn]{
+		Body: &Constant{Con: &Integer{Inner: big.NewInt(1)}},
+	}
+
+	result := PrettyTerm[DeBruijn](term)
+
+	if result == "" {
+		t.Errorf("PrettyTerm returned empty string")
+	}
+
+	// Should contain lambda syntax
+	if !strings.Contains(result, "lam") {
+		t.Errorf("PrettyTerm output does not contain 'lam': %s", result)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add comprehensive tests for CEK crypto and byte-string builtins, plus new parser and pretty printer tests in syn. This improves coverage and validates edge cases across signature verification, hashing, comparisons, UTF-8, and parsing.

- **New Features**
  - Ed25519 signature verification tests (valid/invalid signatures and keys).
  - Hashing tests for Blake2b-224 and RIPEMD-160 (length checks).
  - ByteString ops: cons, slice, index, and lt/lte comparisons; integer lt/lte.
  - UTF-8 encode/decode, including invalid input error handling.
  - Trace and ChooseList behavior.
  - Parser coverage for delay, force, constr, case, error, and complex programs.
  - PrettyTerm smoke tests for constants and lambdas.

<sup>Written for commit 8576ca05088fcb3251064090cff8baf01dc3bb04. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded comprehensive test coverage for cryptographic operations, builtin functions, and data type handling.
  * Added extensive test suite for parser functionality including delay, force, construction, and case expression handling.
  * Enhanced validation tests for pretty-printing and term formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->