### PR TITLE
test: builtins for data manipulation

### DIFF
--- a/cek/builtins.go
+++ b/cek/builtins.go
@@ -3383,7 +3383,7 @@ func findFirstSetBit[T syn.Eval](
 			continue
 		}
 
-		for pos := 0; pos < 8; pos++ {
+		for pos := range 8 {
 			if value&(1<<pos) != 0 {
 				bitIndex = pos + (len(bytes)-byteIndex-1)*8
 
@@ -3391,7 +3391,7 @@ func findFirstSetBit[T syn.Eval](
 			}
 		}
 
-		if byteIndex != -1 {
+		if bitIndex != -1 {
 			break
 		}
 	}

--- a/cek/machine.go
+++ b/cek/machine.go
@@ -19,17 +19,17 @@ const debug = false
 // is minimal compared to the evaluation performance benefits.
 var (
 	computePool = sync.Pool{
-		New: func() interface{} {
+		New: func() any {
 			return &Compute[syn.DeBruijn]{}
 		},
 	}
 	returnPool = sync.Pool{
-		New: func() interface{} {
+		New: func() any {
 			return &Return[syn.DeBruijn]{}
 		},
 	}
 	donePool = sync.Pool{
-		New: func() interface{} {
+		New: func() any {
 			return &Done[syn.DeBruijn]{}
 		},
 	}
@@ -688,7 +688,7 @@ func (m *Machine[T]) stepAndMaybeSpend(step StepKind) error {
 }
 
 func (m *Machine[T]) spendUnbudgetedSteps() error {
-	for i := uint8(0); i < uint8(len(m.unbudgetedSteps)-1); i++ {
+	for i := range uint8(len(m.unbudgetedSteps) - 1) {
 		unspent_step_budget := m.costs.machineCosts.get(StepKind(i))
 
 		unspent_step_budget.occurrences(m.unbudgetedSteps[i])

--- a/syn/builder_test.go
+++ b/syn/builder_test.go
@@ -334,10 +334,16 @@ func TestNameToNamedDeBruijn(t *testing.T) {
 	// Check that the lambda parameter has index 0
 	lambda := converted.Term.(*Lambda[NamedDeBruijn])
 	if lambda.ParameterName.Index != 0 {
-		t.Errorf("Expected parameter index 0, got %d", lambda.ParameterName.Index)
+		t.Errorf(
+			"Expected parameter index 0, got %d",
+			lambda.ParameterName.Index,
+		)
 	}
 	if lambda.ParameterName.Text != "x" {
-		t.Errorf("Expected parameter text 'x', got %s", lambda.ParameterName.Text)
+		t.Errorf(
+			"Expected parameter text 'x', got %s",
+			lambda.ParameterName.Text,
+		)
 	}
 
 	// Check that the body variable has index 1
@@ -393,7 +399,10 @@ func TestNameToDeBruijnComplex(t *testing.T) {
 	// Check the structure
 	lambda := converted.Term.(*Lambda[DeBruijn])
 	if lambda.ParameterName != 0 {
-		t.Errorf("Expected lambda parameter index 0, got %d", lambda.ParameterName)
+		t.Errorf(
+			"Expected lambda parameter index 0, got %d",
+			lambda.ParameterName,
+		)
 	}
 
 	delayTerm := lambda.Body.(*Delay[DeBruijn])

--- a/syn/conversions.go
+++ b/syn/conversions.go
@@ -214,8 +214,6 @@ func (c *converter) getIndex(name *Name) (DeBruijn, error) {
 }
 
 // getUnique finds the Unique identifier for a given DeBruijn index
-//
-//nolint:unused
 func (c *converter) getUnique(index DeBruijn) (Unique, error) {
 	if index < 0 {
 		return 0, errors.New("negative DeBruijn index")

--- a/syn/parser_extended_test.go
+++ b/syn/parser_extended_test.go
@@ -105,7 +105,11 @@ func TestParseConstr(t *testing.T) {
 			p := NewParser(tt.input)
 			_, err := p.ParseProgram()
 			if (err != nil) != tt.wantErr {
-				t.Errorf("ParseProgram() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf(
+					"ParseProgram() error = %v, wantErr %v",
+					err,
+					tt.wantErr,
+				)
 			}
 		})
 	}
@@ -144,7 +148,11 @@ func TestParseCase(t *testing.T) {
 			p := NewParser(tt.input)
 			_, err := p.ParseProgram()
 			if (err != nil) != tt.wantErr {
-				t.Errorf("ParseProgram() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf(
+					"ParseProgram() error = %v, wantErr %v",
+					err,
+					tt.wantErr,
+				)
 			}
 		})
 	}
@@ -207,7 +215,11 @@ func TestParseComplexTerms(t *testing.T) {
 			p := NewParser(tt.input)
 			_, err := p.ParseProgram()
 			if (err != nil) != tt.wantErr {
-				t.Errorf("ParseProgram() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf(
+					"ParseProgram() error = %v, wantErr %v",
+					err,
+					tt.wantErr,
+				)
 			}
 		})
 	}


### PR DESCRIPTION








<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for data manipulation builtins and byte-string bit operations, including data serialisation and integer-to/from-byte-string conversions. Fixes findFirstSetBit to use little-endian indexing and corrects the break condition.

- **Bug Fixes**
  - Updated findFirstSetBit to iterate bytes in little-endian order and stop on first match.

- **Refactors**
  - Added evalBuiltinWithError to assert error-returning builtins.
  - Removed unused BLS helper expectations from this test file.

<sup>Written for commit 9c70a9f354ab3df2cfbc9b798b7449e2f81ad6c1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed bit-scanning behavior so first-set-bit detection stops at the correct position.

* **Tests**
  * Greatly expanded and reworked test coverage for many builtin behaviors, data shapes, encodings and error cases.
  * Added a helper to surface evaluation errors and removed several legacy test utilities.
  * Improved test readability with multi-line formatting and clearer error messages.

* **Refactor / Chores**
  * Minor internal refactors and formatting cleanups across code and tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->