### PR TITLE
fix(cek): correct bit 7 checking in findFirstSetBit

### DIFF
--- a/cek/builtins.go
+++ b/cek/builtins.go
@@ -3376,14 +3376,14 @@ func findFirstSetBit[T syn.Eval](
 
 	bitIndex := -1
 
-	// Find first set bit - iterate bytes in reverse order (like Rust .rev())
+	// Find first set bit - iterate bytes in reverse order (little-endian)
 	for byteIndex := len(bytes) - 1; byteIndex >= 0; byteIndex-- {
 		value := bytes[byteIndex]
 		if value == 0 {
 			continue
 		}
 
-		for pos := range 7 {
+		for pos := 0; pos < 8; pos++ {
 			if value&(1<<pos) != 0 {
 				bitIndex = pos + (len(bytes)-byteIndex-1)*8
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix findFirstSetBit to check all 8 bits per byte (little-endian) by iterating positions 0-7. Previously bit 7 could be skipped, causing an incorrect bitIndex when only the highest bit was set.

<sup>Written for commit c5a8213ea5a2bae443c8fcf0e9de80cbb5268629. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal bit-search logic to improve efficiency in bitfield operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->