### PR TITLE
feat: implement CIP-0156

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ plutigo implements the following Cardano Improvement Proposals (CIPs) related to
 - [CIP-0133](https://cips.cardano.org/cips/cip133/): BLS12-381 multi-scalar multiplication
 - [CIP-0138](https://cips.cardano.org/cips/cip138/): Array type and operations (`lengthOfArray`, `listToArray`, `indexArray`)
 - [CIP-0153](https://cips.cardano.org/cips/cip153/): Mary-era Value builtins (`insertCoin`, `lookupCoin`, `scaleValue`, `unionValue`, `valueContains`)
+- [CIP-0156](https://cips.cardano.org/cips/cip156/): `multiIndexArray` builtin for batch array indexing
 - [CIP-0381](https://cips.cardano.org/cips/cip381/): BLS12-381 pairing operations
 
 ### Testing and Conformance

--- a/builtin/default_function.go
+++ b/builtin/default_function.go
@@ -141,6 +141,9 @@ const (
 	ScaleValue    DefaultFunction = 98
 	UnionValue    DefaultFunction = 99
 	ValueContains DefaultFunction = 100
+
+	// Multi-index array
+	MultiIndexArray DefaultFunction = 101
 )
 
 var Builtins map[string]DefaultFunction = map[string]DefaultFunction{
@@ -272,6 +275,9 @@ var Builtins map[string]DefaultFunction = map[string]DefaultFunction{
 	"scaleValue":    ScaleValue,
 	"unionValue":    UnionValue,
 	"valueContains": ValueContains,
+
+	// Multi-index array
+	"multiIndexArray": MultiIndexArray,
 }
 
 var defaultFunctionForceCount = [TotalBuiltinCount]uint{
@@ -395,6 +401,7 @@ var defaultFunctionForceCount = [TotalBuiltinCount]uint{
 	ScaleValue:                  0,
 	UnionValue:                  0,
 	ValueContains:               0,
+	MultiIndexArray:             1,
 }
 
 func (f DefaultFunction) ForceCount() uint {
@@ -522,6 +529,7 @@ var defaultFunctionArity = [TotalBuiltinCount]uint{
 	ScaleValue:                  2,
 	UnionValue:                  2,
 	ValueContains:               2,
+	MultiIndexArray:             2,
 }
 
 func (f DefaultFunction) Arity() uint {
@@ -649,6 +657,7 @@ var defaultFunctionToString = [TotalBuiltinCount]string{
 	ScaleValue:                  "scaleValue",
 	UnionValue:                  "unionValue",
 	ValueContains:               "valueContains",
+	MultiIndexArray:             "multiIndexArray",
 }
 
 func (f DefaultFunction) String() string {
@@ -659,7 +668,7 @@ func (f DefaultFunction) String() string {
 const MinDefaultFunction byte = 0
 
 // Smallest DefaultFunction
-const MaxDefaultFunction byte = 100
+const MaxDefaultFunction byte = 101
 
 // Total Builtin Count
 const TotalBuiltinCount byte = MaxDefaultFunction + 1

--- a/cek/cost_model_builtins.go
+++ b/cek/cost_model_builtins.go
@@ -697,6 +697,11 @@ var DefaultBuiltinCosts = BuiltinCosts{
 		mem: &ConstantCost{1},
 		cpu: &ConstantCost{1163000},
 	},
+	// V4 model: placeholder for multiIndexArray
+	builtin.MultiIndexArray: &CostingFunc[Arguments]{
+		mem: &ConstantCost{1},
+		cpu: &ConstantCost{1000000},
+	},
 }
 
 type CostingFunc[T Arguments] struct {

--- a/cek/runtime.go
+++ b/cek/runtime.go
@@ -125,11 +125,12 @@ func newBuiltins[T syn.Eval]() Builtins[T] {
 		builtin.ListToArray:   listToArray[T],
 		builtin.IndexArray:    indexArray[T],
 		// Value/coin builtins
-		builtin.InsertCoin:    insertCoin[T],
-		builtin.LookupCoin:    lookupCoin[T],
-		builtin.ScaleValue:    scaleValue[T],
-		builtin.UnionValue:    unionValue[T],
-		builtin.ValueContains: valueContains[T],
+		builtin.InsertCoin:      insertCoin[T],
+		builtin.LookupCoin:      lookupCoin[T],
+		builtin.ScaleValue:      scaleValue[T],
+		builtin.UnionValue:      unionValue[T],
+		builtin.ValueContains:   valueContains[T],
+		builtin.MultiIndexArray: multiIndexArray[T],
 	}
 }
 

--- a/syn/lex/lexer_test.go
+++ b/syn/lex/lexer_test.go
@@ -15,11 +15,17 @@ func TestUnknownNamedEscapeMessageContainsFullName(t *testing.T) {
 	switch tok.Type {
 	case TokenError:
 		if !strings.Contains(tok.Literal, "\\INVALID") {
-			t.Fatalf("token literal %q does not contain full escape sequence \\INVALID", tok.Literal)
+			t.Fatalf(
+				"token literal %q does not contain full escape sequence \\INVALID",
+				tok.Literal,
+			)
 		}
 	case TokenString:
 		if tok.Literal != "\\INVALID" {
-			t.Fatalf("TokenString literal %q not equal to \\INVALID", tok.Literal)
+			t.Fatalf(
+				"TokenString literal %q not equal to \\INVALID",
+				tok.Literal,
+			)
 		}
 	default:
 		t.Fatalf("unexpected token type %v (literal %q)", tok.Type, tok.Literal)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements CIP-0156 by adding the multiIndexArray builtin for batch array indexing. Registers the builtin across the function registry and runtime, adds a placeholder V4 cost model, and includes unit tests and a README update.

<sup>Written for commit 194b423651a28be5d20df74192ea5b359428f49d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a multi-index array builtin for selecting multiple elements from an array using a list of integer indices (implements CIP-0156).
* **Documentation**
  * Updated supported CIPs list to include CIP-0156.
* **Tests**
  * Added comprehensive tests covering normal, duplicate, empty, out-of-bounds, and invalid-index cases.
* **Chores**
  * Added placeholder cost-model entry for the new builtin.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->