### PR TITLE
build(make): list all targets in .PHONY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BINARIES=$(shell cd $(ROOT_DIR)/cmd && ls -1 | grep -v ^common)
 # Common flags for fuzz tests
 FUZZ_FLAGS ?= -run=^$ -fuzztime=10s
 
-.PHONY: mod-tidy test test-match bench fuzz format clean download-plutus-tests
+.PHONY: mod-tidy test test-match test-cover bench bench-baseline bench-compare fuzz format golines clean download-plutus-tests
 
 mod-tidy:
 	# Needed to fetch new dependencies and add them to go.mod


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Listed all Makefile targets in .PHONY to prevent file-target collisions and ensure commands always run as expected. Adds test-cover, bench-baseline, bench-compare, and golines to the .PHONY list.

<sup>Written for commit 2e6c4d91c75f8d3b713f7a9818882f22c3e430e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new build system targets for test coverage analysis, performance benchmarking (baseline and comparison modes), and code formatting utilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->