### PR TITLE
ci(benchmark): switch to manual runs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,12 +1,7 @@
 name: benchmark
 
 on:
-  push:
-    tags:
-      - v*
-    branches:
-      - main
-  pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched the benchmark GitHub Actions workflow to manual runs. It no longer triggers on main, tags, or pull requests and now runs only via workflow_dispatch.

<sup>Written for commit c6410a7ef5ba48f46e8a2a64058b3d230bfbb102. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated benchmark workflow to require manual triggering instead of automatically running on code pushes and pull requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->