### PR TITLE
fix(cek): nil panic when traversing cost models

### DIFF
--- a/cek/cost_model.go
+++ b/cek/cost_model.go
@@ -212,6 +212,8 @@ func dataExMem(x data.PlutusData) func() ExMem {
 				acc += bigIntExMem(dat.Inner)()
 			case *data.ByteString:
 				acc += byteArrayExMem(dat.Inner)()
+			case nil:
+				// Skip nil values that may be in nested data structures
 			default:
 				panic("Unreachable")
 			}
@@ -262,6 +264,8 @@ func equalsDataExMem(
 				xAcc += bigIntExMem(dat.Inner)()
 			case *data.ByteString:
 				xAcc += byteArrayExMem(dat.Inner)()
+			case nil:
+				// Skip nil values that may be in nested data structures
 			default:
 				panic("Unreachable")
 			}
@@ -285,6 +289,8 @@ func equalsDataExMem(
 				yAcc += bigIntExMem(dat.Inner)()
 			case *data.ByteString:
 				yAcc += byteArrayExMem(dat.Inner)()
+			case nil:
+				// Skip nil values that may be in nested data structures
 			default:
 				panic("Unreachable")
 			}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a runtime panic in the CEK cost model by safely skipping nil values in nested PlutusData structures. Adds tests to prevent regressions.

- **Bug Fixes**
  - dataExMem and equalsDataExMem now ignore nil entries in Constr.Fields, List.Items, and Map.Pairs.
  - Added unit tests covering Constr/List/Map and mixed comparisons to ensure no panics.

<sup>Written for commit 501bbb7c5ad2b2aeb4d4030c3f7a5731a36ca01a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved crashes when encountering nil values in nested data structures during cost calculations.

* **Tests**
  * Added test coverage for nil value handling in nested data structure operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->