### PR TITLE
perf: prealloc slices, cache CBOR encmode, use buffers

### DIFF
--- a/data/encode.go
+++ b/data/encode.go
@@ -6,6 +6,20 @@ import (
 	"github.com/fxamacker/cbor/v2"
 )
 
+// encMode is cached at package level to avoid recreation on every encode call
+var encMode cbor.EncMode
+
+func init() {
+	opts := cbor.EncOptions{
+		// NOTE: set any additional encoder options here
+	}
+	var err error
+	encMode, err = opts.EncMode()
+	if err != nil {
+		panic("failed to initialize CBOR encoder: " + err.Error())
+	}
+}
+
 // Encode encodes a PlutusData value into CBOR bytes.
 func Encode(pd PlutusData) ([]byte, error) {
 	return cborMarshal(pd)
@@ -14,14 +28,7 @@ func Encode(pd PlutusData) ([]byte, error) {
 // cborMarshal acts like cbor.Marshal but allows us to set our own encoder options
 func cborMarshal(data any) ([]byte, error) {
 	buf := bytes.NewBuffer(nil)
-	opts := cbor.EncOptions{
-		// NOTE: set any additional encoder options here
-	}
-	em, err := opts.EncMode()
-	if err != nil {
-		return nil, err
-	}
-	enc := em.NewEncoder(buf)
-	err = enc.Encode(data)
+	enc := encMode.NewEncoder(buf)
+	err := enc.Encode(data)
 	return buf.Bytes(), err
 }

--- a/syn/lex/lexer.go
+++ b/syn/lex/lexer.go
@@ -108,7 +108,7 @@ func (l *Lexer) readNumber() (string, error) {
 }
 
 func (l *Lexer) readString() (string, error) {
-	var tmpString string
+	var sb strings.Builder
 	leftoverChar := false
 	for {
 		if !leftoverChar {
@@ -126,7 +126,7 @@ func (l *Lexer) readString() (string, error) {
 			// Check for simple one-char escapes (like \" and \\\)
 			tmpEscape := `\` + string(l.ch)
 			if val, ok := escapeMap[tmpEscape]; ok {
-				tmpString += val
+				sb.WriteString(val)
 				continue
 			}
 			// Unicode escape
@@ -161,7 +161,7 @@ func (l *Lexer) readString() (string, error) {
 						unicodeHex,
 					)
 				}
-				tmpString += string(r)
+				sb.Write(r)
 				continue
 			}
 			// Hex escape
@@ -198,7 +198,7 @@ func (l *Lexer) readString() (string, error) {
 						hexStr,
 					)
 				}
-				tmpString += string(r)
+				sb.Write(r)
 				continue
 			}
 			// Octal escape
@@ -222,7 +222,7 @@ func (l *Lexer) readString() (string, error) {
 						octalStr,
 					)
 				}
-				tmpString += string(rune(tmpOctal))
+				sb.WriteRune(rune(tmpOctal))
 				continue
 			}
 			// Handle named escapes (e.g., \DEL) after specific sequences
@@ -243,7 +243,7 @@ func (l *Lexer) readString() (string, error) {
 
 				key := `\` + name
 				if val, ok := escapeMap[key]; ok {
-					tmpString += val
+					sb.WriteString(val)
 					continue
 				}
 
@@ -275,17 +275,17 @@ func (l *Lexer) readString() (string, error) {
 					decStr,
 				)
 			}
-			tmpString += string(rune(tmpDec))
+			sb.WriteRune(rune(tmpDec))
 			continue
 		}
 
 		if l.ch == '"' {
 			l.readChar() // Consume closing quote
 
-			return tmpString, nil
+			return sb.String(), nil
 		}
 
-		tmpString += string(l.ch)
+		sb.WriteRune(l.ch)
 	}
 }
 

--- a/syn/parser.go
+++ b/syn/parser.go
@@ -319,7 +319,7 @@ func (p *Parser) parseConstr() (Term[Name], error) {
 
 	p.nextToken()
 
-	var fields []Term[Name]
+	fields := make([]Term[Name], 0, 8)
 
 	for p.curToken.Type != lex.TokenRParen {
 		term, err := p.ParseTerm()
@@ -351,7 +351,7 @@ func (p *Parser) parseCase() (Term[Name], error) {
 		return nil, err
 	}
 
-	var branches []Term[Name]
+	branches := make([]Term[Name], 0, 4)
 
 	for p.curToken.Type != lex.TokenRParen {
 		branch, err := p.ParseTerm()
@@ -617,7 +617,7 @@ func (p *Parser) parseConstant() (Term[Name], error) {
 			return nil, err
 		}
 
-		var items []IConstant
+		items := make([]IConstant, 0, 8)
 
 		for p.curToken.Type != lex.TokenRBracket {
 			if err := p.expect(lex.TokenLParen); err != nil {
@@ -650,7 +650,7 @@ func (p *Parser) parseConstant() (Term[Name], error) {
 				return nil, err
 			}
 
-			var innerItems []IConstant
+			innerItems := make([]IConstant, 0, 8)
 
 			for p.curToken.Type != lex.TokenRBracket {
 				if err := p.expect(lex.TokenLParen); err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve runtime performance by reducing allocations across CBOR encode/decode, lexer/parser, and CEK evaluation. We cache CBOR modes, preallocate slices, and use buffers/builders to cut CPU and memory use.

- **Performance**
  - Cache cbor.EncMode/DecMode at package init and reuse for all Encode/Decode.
  - Replace slices.Concat and string concatenation with bytes.Buffer and strings.Builder in data marshaling and lexer.
  - Preallocate slices; use indexed writes in CEK (fields, branches, discharge/withEnv); preallocate in parser (fields, branches, constants).
  - Allocate constructor/case args only when needed; use nil slices instead of empty allocations.
  - Remove unnecessary copies when building CBOR indefinite-length arrays and map pairs.

<sup>Written for commit 85b9585a6f03b9f1656070fda1287b874539cf6b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced memory allocations and improved performance across parsing, runtime frames, and return paths via pre-sized slice allocation and allocation avoidance.
  * Streamlined CBOR serialization using buffered writes to eliminate intermediate allocations.
  * Cached encoder/decoder configuration to avoid repeated initialization overhead.
  * Improved string handling during lexical parsing for more efficient accumulation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->