### PR TITLE
fix: reduce encoder heap allocations

### DIFF
--- a/data/encode.go
+++ b/data/encode.go
@@ -27,8 +27,8 @@ func Encode(pd PlutusData) ([]byte, error) {
 
 // cborMarshal acts like cbor.Marshal but allows us to set our own encoder options
 func cborMarshal(data any) ([]byte, error) {
-	buf := bytes.NewBuffer(nil)
-	enc := encMode.NewEncoder(buf)
+	var buf bytes.Buffer
+	enc := encMode.NewEncoder(&buf)
 	err := enc.Encode(data)
 	return buf.Bytes(), err
 }

--- a/syn/lex/lexer.go
+++ b/syn/lex/lexer.go
@@ -229,7 +229,7 @@ func (l *Lexer) readString() (string, error) {
 			if unicode.IsLetter(l.ch) {
 				// Read consecutive letters to form the full name (e.g., DEL)
 				name := string(l.ch)
-				var nameSb232 strings.Builder
+				var nameSb strings.Builder
 				for {
 					l.readChar()
 					if !unicode.IsLetter(l.ch) {
@@ -237,9 +237,9 @@ func (l *Lexer) readString() (string, error) {
 						leftoverChar = true
 						break
 					}
-					nameSb232.WriteString(string(l.ch))
+					nameSb.WriteRune(l.ch)
 				}
-				name += nameSb232.String()
+				name += nameSb.String()
 
 				key := `\` + name
 				if val, ok := escapeMap[key]; ok {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce heap allocations in CBOR encoding by using a stack-allocated bytes.Buffer in cborMarshal to improve Encode performance. Minor lexer cleanup: renamed the temporary strings.Builder variable for clarity; behavior unchanged.

<sup>Written for commit 125faab9958fed0b75287806bf216c35ac0c9f48. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Internal refactors: simplified buffer initialization and streamlined internal string/escape handling.  
  * Minor renames and write-method adjustments for internal builders.  
  * No changes to public APIs or visible behavior; user-facing functionality remains unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->