### PR TITLE
refactor: update cost models

### DIFF
--- a/cek/cost_model_builtins.go
+++ b/cek/cost_model_builtins.go
@@ -1392,10 +1392,8 @@ func (ExpMod) HasConstants() []bool {
 	return []bool{false, false, false}
 }
 
-var V1BuiltinCosts = func() BuiltinCosts {
-	var costs BuiltinCosts
-	// Initialize with V1 cost models
-	costs[builtin.AddInteger] = &CostingFunc[Arguments]{
+var V1BuiltinCosts = BuiltinCosts{
+	builtin.AddInteger: &CostingFunc[Arguments]{
 		mem: &MaxSizeModel{MaxSize{
 			intercept: 1,
 			slope:     1,
@@ -1404,126 +1402,19 @@ var V1BuiltinCosts = func() BuiltinCosts {
 			intercept: 205665,
 			slope:     812,
 		}},
-	}
-	costs[builtin.SubtractInteger] = &CostingFunc[Arguments]{
-		mem: &MaxSizeModel{MaxSize{
-			intercept: 1,
-			slope:     1,
-		}},
-		cpu: &MaxSizeModel{MaxSize{
-			intercept: 205665,
-			slope:     812,
-		}},
-	}
-	costs[builtin.MultiplyInteger] = &CostingFunc[Arguments]{
-		mem: &AddedSizesModel{AddedSizes{
+	},
+	builtin.AndByteString: &CostingFunc[Arguments]{
+		mem: &ThreeLinearInMaxYZ{LinearCost{
 			intercept: 0,
 			slope:     1,
 		}},
-		cpu: &MultipliedSizesModel{MultipliedSizes{
-			intercept: 69522,
-			slope:     11687,
+		cpu: &ThreeLinearInYandZ{TwoVariableLinearSize{
+			intercept: 100181,
+			slope1:    726,
+			slope2:    719,
 		}},
-	}
-	costs[builtin.DivideInteger] = &CostingFunc[Arguments]{
-		mem: &SubtractedSizesModel{SubtractedSizes{
-			intercept: 0,
-			slope:     1,
-			minimum:   1,
-		}},
-		cpu: &ConstAboveDiagonalModel{
-			ConstantOrTwoArguments{
-				constant: 196500,
-				model: &MultipliedSizesModel{MultipliedSizes{
-					intercept: 453240,
-					slope:     220,
-				}},
-			},
-		},
-	}
-	costs[builtin.QuotientInteger] = &CostingFunc[Arguments]{
-		mem: &SubtractedSizesModel{SubtractedSizes{
-			intercept: 0,
-			slope:     1,
-			minimum:   1,
-		}},
-		cpu: &ConstAboveDiagonalModel{
-			ConstantOrTwoArguments{
-				constant: 196500,
-				model: &MultipliedSizesModel{MultipliedSizes{
-					intercept: 453240,
-					slope:     220,
-				}},
-			},
-		},
-	}
-	costs[builtin.RemainderInteger] = &CostingFunc[Arguments]{
-		mem: &LinearInY{LinearCost{
-			intercept: 0,
-			slope:     1,
-		}},
-		cpu: &ConstAboveDiagonalModel{
-			ConstantOrTwoArguments{
-				constant: 196500,
-				model: &MultipliedSizesModel{MultipliedSizes{
-					intercept: 453240,
-					slope:     220,
-				}},
-			},
-		},
-	}
-	costs[builtin.ModInteger] = &CostingFunc[Arguments]{
-		mem: &LinearInY{LinearCost{
-			intercept: 0,
-			slope:     1,
-		}},
-		cpu: &ConstAboveDiagonalModel{
-			ConstantOrTwoArguments{
-				constant: 196500,
-				model: &MultipliedSizesModel{MultipliedSizes{
-					intercept: 453240,
-					slope:     220,
-				}},
-			},
-		},
-	}
-	costs[builtin.EqualsInteger] = &CostingFunc[Arguments]{
-		mem: &LinearOnDiagonalModel{
-			ConstantOrLinear{
-				constant:  1,
-				intercept: 0,
-				slope:     1,
-			},
-		},
-		cpu: &LinearOnDiagonalModel{
-			ConstantOrLinear{
-				constant:  1000,
-				intercept: 1000,
-				slope:     1,
-			},
-		},
-	}
-	costs[builtin.LessThanInteger] = &CostingFunc[Arguments]{
-		mem: &MaxSizeModel{MaxSize{
-			intercept: 1,
-			slope:     1,
-		}},
-		cpu: &MaxSizeModel{MaxSize{
-			intercept: 1000,
-			slope:     1,
-		}},
-	}
-	costs[builtin.LessThanEqualsInteger] = &CostingFunc[Arguments]{
-		mem: &MaxSizeModel{MaxSize{
-			intercept: 1,
-			slope:     1,
-		}},
-		cpu: &MaxSizeModel{MaxSize{
-			intercept: 1000,
-			slope:     1,
-		}},
-	}
-	costs[builtin.AppendByteString] = &CostingFunc[Arguments]{
+	},
+	builtin.AppendByteString: &CostingFunc[Arguments]{
 		mem: &AddedSizesModel{AddedSizes{
 			intercept: 0,
 			slope:     1,
@@ -1532,335 +1423,1365 @@ var V1BuiltinCosts = func() BuiltinCosts {
 			intercept: 1000,
 			slope:     571,
 		}},
-	}
-	costs[builtin.ConsByteString] = &CostingFunc[Arguments]{
+	},
+	builtin.AppendString: &CostingFunc[Arguments]{
+		mem: &AddedSizesModel{AddedSizes{
+			intercept: 4,
+			slope:     1,
+		}},
+		cpu: &AddedSizesModel{AddedSizes{
+			intercept: 1000,
+			slope:     24177,
+		}},
+	},
+	builtin.BData: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{1000},
+	},
+	builtin.Blake2b_224: &CostingFunc[Arguments]{
+		mem: &ConstantCost{4},
+		cpu: &LinearInX{LinearCost{
+			intercept: 207616,
+			slope:     8310,
+		}},
+	},
+	builtin.Blake2b_256: &CostingFunc[Arguments]{
+		mem: &ConstantCost{4},
+		cpu: &LinearInX{LinearCost{
+			intercept: 117366,
+			slope:     10475,
+		}},
+	},
+	builtin.Bls12_381_G1_Add: &CostingFunc[Arguments]{
+		mem: &ConstantCost{18},
+		cpu: &ConstantCost{962335},
+	},
+	builtin.Bls12_381_G1_Compress: &CostingFunc[Arguments]{
+		mem: &ConstantCost{6},
+		cpu: &ConstantCost{2780678},
+	},
+	builtin.Bls12_381_G1_Equal: &CostingFunc[Arguments]{
+		mem: &ConstantCost{1},
+		cpu: &ConstantCost{442008},
+	},
+	builtin.Bls12_381_G1_HashToGroup: &CostingFunc[Arguments]{
+		mem: &ConstantCost{18},
+		cpu: &LinearInX{LinearCost{
+			intercept: 52538055,
+			slope:     3756,
+		}},
+	},
+	builtin.Bls12_381_G1_MultiScalarMul: &CostingFunc[Arguments]{
+		mem: &ConstantCost{18},
+		cpu: &LinearInX{LinearCost{
+			intercept: 321837444,
+			slope:     25087669,
+		}},
+	},
+	builtin.Bls12_381_G1_Neg: &CostingFunc[Arguments]{
+		mem: &ConstantCost{18},
+		cpu: &ConstantCost{267929},
+	},
+	builtin.Bls12_381_G1_ScalarMul: &CostingFunc[Arguments]{
+		mem: &ConstantCost{18},
+		cpu: &LinearInX{LinearCost{
+			intercept: 76433006,
+			slope:     8868,
+		}},
+	},
+	builtin.Bls12_381_G1_Uncompress: &CostingFunc[Arguments]{
+		mem: &ConstantCost{18},
+		cpu: &ConstantCost{52948122},
+	},
+	builtin.Bls12_381_G2_Add: &CostingFunc[Arguments]{
+		mem: &ConstantCost{36},
+		cpu: &ConstantCost{1995836},
+	},
+	builtin.Bls12_381_G2_Compress: &CostingFunc[Arguments]{
+		mem: &ConstantCost{12},
+		cpu: &ConstantCost{3227919},
+	},
+	builtin.Bls12_381_G2_Equal: &CostingFunc[Arguments]{
+		mem: &ConstantCost{1},
+		cpu: &ConstantCost{901022},
+	},
+	builtin.Bls12_381_G2_HashToGroup: &CostingFunc[Arguments]{
+		mem: &ConstantCost{36},
+		cpu: &LinearInX{LinearCost{
+			intercept: 166917843,
+			slope:     4307,
+		}},
+	},
+	builtin.Bls12_381_G2_MultiScalarMul: &CostingFunc[Arguments]{
+		mem: &ConstantCost{36},
+		cpu: &LinearInX{LinearCost{
+			intercept: 617887431,
+			slope:     67302824,
+		}},
+	},
+	builtin.Bls12_381_G2_Neg: &CostingFunc[Arguments]{
+		mem: &ConstantCost{36},
+		cpu: &ConstantCost{284546},
+	},
+	builtin.Bls12_381_G2_ScalarMul: &CostingFunc[Arguments]{
+		mem: &ConstantCost{36},
+		cpu: &LinearInX{LinearCost{
+			intercept: 158221314,
+			slope:     26549,
+		}},
+	},
+	builtin.Bls12_381_G2_Uncompress: &CostingFunc[Arguments]{
+		mem: &ConstantCost{36},
+		cpu: &ConstantCost{74698472},
+	},
+	builtin.Bls12_381_FinalVerify: &CostingFunc[Arguments]{
+		mem: &ConstantCost{1},
+		cpu: &ConstantCost{333849714},
+	},
+	builtin.Bls12_381_MillerLoop: &CostingFunc[Arguments]{
+		mem: &ConstantCost{72},
+		cpu: &ConstantCost{254006273},
+	},
+	builtin.Bls12_381_MulMlResult: &CostingFunc[Arguments]{
+		mem: &ConstantCost{72},
+		cpu: &ConstantCost{2174038},
+	},
+	builtin.ByteStringToInteger: &CostingFunc[Arguments]{
+		mem: &LinearInY{LinearCost{
+			intercept: 0,
+			slope:     1,
+		}},
+		cpu: &QuadraticInYModel{QuadraticFunction{
+			coeff0: 1006041,
+			coeff1: 43623,
+			coeff2: 251,
+		}},
+	},
+	builtin.ChooseData: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{19537},
+	},
+	builtin.ChooseList: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{175354},
+	},
+	builtin.ChooseUnit: &CostingFunc[Arguments]{
+		mem: &ConstantCost{4},
+		cpu: &ConstantCost{46417},
+	},
+	builtin.ComplementByteString: &CostingFunc[Arguments]{
+		mem: &LinearCost{
+			intercept: 0,
+			slope:     1,
+		},
+		cpu: &LinearInX{LinearCost{
+			intercept: 107878,
+			slope:     680,
+		}},
+	},
+	builtin.ConsByteString: &CostingFunc[Arguments]{
 		mem: &AddedSizesModel{AddedSizes{
 			intercept: 0,
 			slope:     1,
 		}},
-		cpu: &AddedSizesModel{AddedSizes{
-			intercept: 1000,
-			slope:     221,
+		cpu: &LinearInY{LinearCost{
+			intercept: 221973,
+			slope:     511,
 		}},
-	}
-	costs[builtin.SliceByteString] = &CostingFunc[Arguments]{
-		mem: &ConstantCost{4},
-		cpu: &ConstantCost{1000},
-	}
-	costs[builtin.LengthOfByteString] = &CostingFunc[Arguments]{
-		mem: &ConstantCost{10},
-		cpu: &ConstantCost{1000},
-	}
-	costs[builtin.IndexByteString] = &CostingFunc[Arguments]{
-		mem: &ConstantCost{4},
-		cpu: &ConstantCost{1000},
-	}
-	costs[builtin.EqualsByteString] = &CostingFunc[Arguments]{
-		mem: &LinearOnDiagonalModel{
-			ConstantOrLinear{
-				constant:  1,
-				intercept: 0,
-				slope:     1,
-			},
-		},
-		cpu: &LinearOnDiagonalModel{
-			ConstantOrLinear{
-				constant:  1000,
-				intercept: 1000,
-				slope:     1,
-			},
-		},
-	}
-	costs[builtin.LessThanByteString] = &CostingFunc[Arguments]{
-		mem: &LinearOnDiagonalModel{
-			ConstantOrLinear{
-				constant:  1,
-				intercept: 0,
-				slope:     1,
-			},
-		},
-		cpu: &LinearOnDiagonalModel{
-			ConstantOrLinear{
-				constant:  1000,
-				intercept: 1000,
-				slope:     1,
-			},
-		},
-	}
-	costs[builtin.LessThanEqualsByteString] = &CostingFunc[Arguments]{
-		mem: &LinearOnDiagonalModel{
-			ConstantOrLinear{
-				constant:  1,
-				intercept: 0,
-				slope:     1,
-			},
-		},
-		cpu: &LinearOnDiagonalModel{
-			ConstantOrLinear{
-				constant:  1000,
-				intercept: 1000,
-				slope:     1,
-			},
-		},
-	}
-	costs[builtin.Sha2_256] = &CostingFunc[Arguments]{
-		mem: &ConstantCost{4},
-		cpu: &ConstantCost{1000},
-	}
-	costs[builtin.Sha3_256] = &CostingFunc[Arguments]{
-		mem: &ConstantCost{4},
-		cpu: &ConstantCost{1000},
-	}
-	costs[builtin.Blake2b_256] = &CostingFunc[Arguments]{
-		mem: &ConstantCost{4},
-		cpu: &ConstantCost{1000},
-	}
-	costs[builtin.VerifyEd25519Signature] = &CostingFunc[Arguments]{
-		mem: &ConstantCost{10},
-		cpu: &ConstantCost{1000},
-	}
-	costs[builtin.AppendString] = &CostingFunc[Arguments]{
-		mem: &AddedSizesModel{AddedSizes{
-			intercept: 4,
-			slope:     1,
+	},
+	builtin.ConstrData: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{89141},
+	},
+	builtin.CountSetBits: &CostingFunc[Arguments]{
+		mem: &ConstantCost{1},
+		cpu: &LinearInX{LinearCost{
+			intercept: 107490,
+			slope:     3298,
 		}},
-		cpu: &AddedSizesModel{AddedSizes{
-			intercept: 1000,
-			slope:     59957,
-		}},
-	}
-	costs[builtin.EqualsString] = &CostingFunc[Arguments]{
-		mem: &LinearOnDiagonalModel{
-			ConstantOrLinear{
-				constant:  1,
-				intercept: 0,
-				slope:     1,
-			},
-		},
-		cpu: &LinearOnDiagonalModel{
-			ConstantOrLinear{
-				constant:  1000,
-				intercept: 1000,
-				slope:     1,
-			},
-		},
-	}
-	costs[builtin.EncodeUtf8] = &CostingFunc[Arguments]{
-		mem: &LinearInY{LinearCost{
+	},
+	builtin.DecodeUtf8: &CostingFunc[Arguments]{
+		mem: &LinearCost{
 			intercept: 4,
 			slope:     2,
+		},
+		cpu: &LinearInX{LinearCost{
+			intercept: 497525,
+			slope:     14068,
 		}},
-		cpu: &LinearInY{LinearCost{
+	},
+	builtin.DivideInteger: &CostingFunc[Arguments]{
+		mem: &SubtractedSizesModel{SubtractedSizes{
+			intercept: 0,
+			slope:     1,
+			minimum:   1,
+		}},
+		cpu: &ConstAboveDiagonalModel{
+			ConstantOrTwoArguments{
+				constant: 196500,
+				model: &MultipliedSizesModel{MultipliedSizes{
+					intercept: 453240,
+					slope:     220,
+				}},
+			},
+		},
+	},
+	builtin.DropList: &CostingFunc[Arguments]{
+		mem: &ConstantCost{4},
+		cpu: &LinearInX{LinearCost{
+			intercept: 116711,
+			slope:     1957,
+		}},
+	},
+	builtin.EncodeUtf8: &CostingFunc[Arguments]{
+		mem: &LinearCost{
+			intercept: 4,
+			slope:     2,
+		},
+		cpu: &LinearInX{LinearCost{
 			intercept: 1000,
 			slope:     28662,
 		}},
-	}
-	costs[builtin.DecodeUtf8] = &CostingFunc[Arguments]{
+	},
+	builtin.EqualsByteString: &CostingFunc[Arguments]{
+		mem: &ConstantCost{1},
+		cpu: &LinearOnDiagonalModel{
+			ConstantOrLinear{
+				constant:  245000,
+				intercept: 216773,
+				slope:     62,
+			},
+		},
+	},
+	builtin.EqualsData: &CostingFunc[Arguments]{
+		mem: &ConstantCost{1},
+		cpu: &MinSizeModel{MinSize{
+			intercept: 1060367,
+			slope:     12586,
+		}},
+	},
+	builtin.EqualsInteger: &CostingFunc[Arguments]{
+		mem: &ConstantCost{1},
+		cpu: &MinSizeModel{MinSize{
+			intercept: 208512,
+			slope:     421,
+		}},
+	},
+	builtin.EqualsString: &CostingFunc[Arguments]{
+		mem: &ConstantCost{1},
+		cpu: &LinearOnDiagonalModel{
+			ConstantOrLinear{
+				constant:  187000,
+				intercept: 1000,
+				slope:     52998,
+			},
+		},
+	},
+	builtin.ExpModInteger: &CostingFunc[Arguments]{
+		mem: &ThreeLinearInZ{LinearCost{
+			intercept: 0,
+			slope:     1,
+		}},
+		cpu: &ExpMod{
+			coeff00: 607153,
+			coeff11: 231697,
+			coeff12: 53144,
+		},
+	},
+	builtin.FindFirstSetBit: &CostingFunc[Arguments]{
+		mem: &ConstantCost{1},
+		cpu: &LinearInX{LinearCost{
+			intercept: 106057,
+			slope:     655,
+		}},
+	},
+	builtin.FstPair: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{80436},
+	},
+	builtin.HeadList: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{43249},
+	},
+	builtin.IData: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{1000},
+	},
+	builtin.IfThenElse: &CostingFunc[Arguments]{
+		mem: &ConstantCost{1},
+		cpu: &ConstantCost{80556},
+	},
+	builtin.IndexArray: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{232010},
+	},
+	builtin.IndexByteString: &CostingFunc[Arguments]{
+		mem: &ConstantCost{4},
+		cpu: &ConstantCost{57667},
+	},
+	builtin.InsertCoin: &CostingFunc[Arguments]{
+		mem: &LinearInX{LinearCost{
+			intercept: 45,
+			slope:     21,
+		}},
+		cpu: &LinearInX{LinearCost{
+			intercept: 356924,
+			slope:     18413,
+		}},
+	},
+	builtin.IntegerToByteString: &CostingFunc[Arguments]{
+		mem: &ThreeLiteralInYorLinearInZ{LinearCost{
+			intercept: 0,
+			slope:     1,
+		}},
+		cpu: &ThreeQuadraticInZ{QuadraticFunction{
+			coeff0: 1293828,
+			coeff1: 28716,
+			coeff2: 63,
+		}},
+	},
+	builtin.Keccak_256: &CostingFunc[Arguments]{
+		mem: &ConstantCost{4},
+		cpu: &LinearInX{LinearCost{
+			intercept: 2261318,
+			slope:     64571,
+		}},
+	},
+	builtin.LengthOfArray: &CostingFunc[Arguments]{
+		mem: &ConstantCost{10},
+		cpu: &ConstantCost{231883},
+	},
+	builtin.LengthOfByteString: &CostingFunc[Arguments]{
+		mem: &ConstantCost{10},
+		cpu: &ConstantCost{1000},
+	},
+	builtin.LessThanByteString: &CostingFunc[Arguments]{
+		mem: &ConstantCost{1},
+		cpu: &MinSizeModel{MinSize{
+			intercept: 197145,
+			slope:     156,
+		}},
+	},
+	builtin.LessThanEqualsByteString: &CostingFunc[Arguments]{
+		mem: &ConstantCost{1},
+		cpu: &MinSizeModel{MinSize{
+			intercept: 197145,
+			slope:     156,
+		}},
+	},
+	builtin.LessThanEqualsInteger: &CostingFunc[Arguments]{
+		mem: &ConstantCost{1},
+		cpu: &MinSizeModel{MinSize{
+			intercept: 204924,
+			slope:     473,
+		}},
+	},
+	builtin.LessThanInteger: &CostingFunc[Arguments]{
+		mem: &ConstantCost{1},
+		cpu: &MinSizeModel{MinSize{
+			intercept: 208896,
+			slope:     511,
+		}},
+	},
+	builtin.ListData: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{52467},
+	},
+	builtin.ListToArray: &CostingFunc[Arguments]{
+		mem: &LinearCost{
+			intercept: 7,
+			slope:     1,
+		},
+		cpu: &LinearInX{LinearCost{
+			intercept: 1000,
+			slope:     24838,
+		}},
+	},
+	builtin.LookupCoin: &CostingFunc[Arguments]{
+		mem: &ConstantCost{1},
+		cpu: &ThreeLinearInZ{LinearCost{
+			intercept: 219951,
+			slope:     9444,
+		}},
+	},
+	builtin.MapData: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{64832},
+	},
+	builtin.MkCons: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{65493},
+	},
+	builtin.MkNilData: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{22558},
+	},
+	builtin.MkNilPairData: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{16563},
+	},
+	builtin.MkPairData: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{76511},
+	},
+	builtin.ModInteger: &CostingFunc[Arguments]{
+		mem: &SubtractedSizesModel{SubtractedSizes{
+			intercept: 0,
+			slope:     1,
+			minimum:   1,
+		}},
+		cpu: &ConstAboveDiagonalModel{
+			ConstantOrTwoArguments{
+				constant: 196500,
+				model: &MultipliedSizesModel{MultipliedSizes{
+					intercept: 453240,
+					slope:     220,
+				}},
+			},
+		},
+	},
+	builtin.MultiplyInteger: &CostingFunc[Arguments]{
+		mem: &AddedSizesModel{AddedSizes{
+			intercept: 0,
+			slope:     1,
+		}},
+		cpu: &AddedSizesModel{AddedSizes{
+			intercept: 69522,
+			slope:     11687,
+		}},
+	},
+	builtin.NullList: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{60091},
+	},
+	builtin.OrByteString: &CostingFunc[Arguments]{
+		mem: &ThreeLinearInMaxYZ{LinearCost{
+			intercept: 0,
+			slope:     1,
+		}},
+		cpu: &ThreeLinearInYandZ{TwoVariableLinearSize{
+			intercept: 100181,
+			slope1:    726,
+			slope2:    719,
+		}},
+	},
+	builtin.QuotientInteger: &CostingFunc[Arguments]{
+		mem: &SubtractedSizesModel{SubtractedSizes{
+			intercept: 0,
+			slope:     1,
+			minimum:   1,
+		}},
+		cpu: &ConstAboveDiagonalModel{
+			ConstantOrTwoArguments{
+				constant: 196500,
+				model: &MultipliedSizesModel{MultipliedSizes{
+					intercept: 453240,
+					slope:     220,
+				}},
+			},
+		},
+	},
+	builtin.ReadBit: &CostingFunc[Arguments]{
+		mem: &ConstantCost{1},
+		cpu: &ConstantCost{95336},
+	},
+	builtin.RemainderInteger: &CostingFunc[Arguments]{
+		mem: &SubtractedSizesModel{SubtractedSizes{
+			intercept: 0,
+			slope:     1,
+			minimum:   1,
+		}},
+		cpu: &ConstAboveDiagonalModel{
+			ConstantOrTwoArguments{
+				constant: 196500,
+				model: &MultipliedSizesModel{MultipliedSizes{
+					intercept: 453240,
+					slope:     220,
+				}},
+			},
+		},
+	},
+	builtin.ReplicateByte: &CostingFunc[Arguments]{
+		mem: &LinearInX{LinearCost{
+			intercept: 1,
+			slope:     1,
+		}},
+		cpu: &LinearInX{LinearCost{
+			intercept: 180194,
+			slope:     159,
+		}},
+	},
+	builtin.Ripemd_160: &CostingFunc[Arguments]{
+		mem: &ConstantCost{3},
+		cpu: &LinearInX{LinearCost{
+			intercept: 1964219,
+			slope:     24520,
+		}},
+	},
+	builtin.RotateByteString: &CostingFunc[Arguments]{
+		mem: &LinearInX{LinearCost{
+			intercept: 0,
+			slope:     1,
+		}},
+		cpu: &LinearInX{LinearCost{
+			intercept: 159378,
+			slope:     8813,
+		}},
+	},
+	builtin.ScaleValue: &CostingFunc[Arguments]{
 		mem: &LinearInY{LinearCost{
-			intercept: 4,
-			slope:     2,
+			intercept: 12,
+			slope:     21,
 		}},
 		cpu: &LinearInY{LinearCost{
 			intercept: 1000,
-			slope:     35892,
+			slope:     277577,
 		}},
-	}
-	costs[builtin.IfThenElse] = &CostingFunc[Arguments]{
-		mem: &ConstantCost{1},
-		cpu: &ConstantCost{1000},
-	}
-	costs[builtin.ChooseUnit] = &CostingFunc[Arguments]{
+	},
+	builtin.SerialiseData: &CostingFunc[Arguments]{
+		mem: &LinearCost{
+			intercept: 0,
+			slope:     2,
+		},
+		cpu: &LinearInX{LinearCost{
+			intercept: 1159724,
+			slope:     392670,
+		}},
+	},
+	builtin.Sha2_256: &CostingFunc[Arguments]{
 		mem: &ConstantCost{4},
-		cpu: &ConstantCost{1000},
-	}
-	costs[builtin.Trace] = &CostingFunc[Arguments]{
+		cpu: &LinearInX{LinearCost{
+			intercept: 806990,
+			slope:     30482,
+		}},
+	},
+	builtin.Sha3_256: &CostingFunc[Arguments]{
+		mem: &ConstantCost{4},
+		cpu: &LinearInX{LinearCost{
+			intercept: 1927926,
+			slope:     82523,
+		}},
+	},
+	builtin.ShiftByteString: &CostingFunc[Arguments]{
+		mem: &LinearInX{LinearCost{
+			intercept: 0,
+			slope:     1,
+		}},
+		cpu: &LinearInX{LinearCost{
+			intercept: 158519,
+			slope:     8942,
+		}},
+	},
+	builtin.SliceByteString: &CostingFunc[Arguments]{
+		mem: &ThreeLinearInZ{LinearCost{
+			intercept: 4,
+			slope:     0,
+		}},
+		cpu: &ThreeLinearInZ{LinearCost{
+			intercept: 265318,
+			slope:     0,
+		}},
+	},
+	builtin.SndPair: &CostingFunc[Arguments]{
 		mem: &ConstantCost{32},
-		cpu: &ConstantCost{1000},
-	}
-	costs[builtin.FstPair] = &CostingFunc[Arguments]{
+		cpu: &ConstantCost{85931},
+	},
+	builtin.SubtractInteger: &CostingFunc[Arguments]{
+		mem: &MaxSizeModel{MaxSize{
+			intercept: 1,
+			slope:     1,
+		}},
+		cpu: &MaxSizeModel{MaxSize{
+			intercept: 205665,
+			slope:     812,
+		}},
+	},
+	builtin.TailList: &CostingFunc[Arguments]{
 		mem: &ConstantCost{32},
-		cpu: &ConstantCost{1000},
-	}
-	costs[builtin.SndPair] = &CostingFunc[Arguments]{
+		cpu: &ConstantCost{41182},
+	},
+	builtin.Trace: &CostingFunc[Arguments]{
 		mem: &ConstantCost{32},
-		cpu: &ConstantCost{1000},
-	}
-	costs[builtin.ChooseList] = &CostingFunc[Arguments]{
+		cpu: &ConstantCost{212342},
+	},
+	builtin.UnBData: &CostingFunc[Arguments]{
 		mem: &ConstantCost{32},
-		cpu: &ConstantCost{1000},
-	}
-	costs[builtin.MkCons] = &CostingFunc[Arguments]{
+		cpu: &ConstantCost{31220},
+	},
+	builtin.UnConstrData: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{32696},
+	},
+	builtin.UnIData: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{43357},
+	},
+	builtin.UnListData: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{32247},
+	},
+	builtin.UnMapData: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{38314},
+	},
+	builtin.UnionValue: &CostingFunc[Arguments]{
 		mem: &AddedSizesModel{AddedSizes{
-			intercept: 32,
-			slope:     32,
+			intercept: 24,
+			slope:     21,
+		}},
+		cpu: &LinearInXAndY{TwoVariableLinearSize{
+			intercept: 1000,
+			slope1:    172116,
+			slope2:    183150,
+		}},
+	},
+	builtin.ValueContains: &CostingFunc[Arguments]{
+		mem: &ConstantCost{1},
+		cpu: &ConstAboveDiagonalModel{
+			ConstantOrTwoArguments{
+				constant: 318444,
+				model: &LinearInXAndY{TwoVariableLinearSize{
+					intercept: 619335,
+					slope1:    1997,
+					slope2:    28258,
+				}},
+			},
+		},
+	},
+	builtin.VerifyEcdsaSecp256k1Signature: &CostingFunc[Arguments]{
+		mem: &ConstantCost{10},
+		cpu: &ConstantCost{35190005},
+	},
+	builtin.VerifyEd25519Signature: &CostingFunc[Arguments]{
+		mem: &ConstantCost{10},
+		cpu: &ThreeLinearInZ{LinearCost{
+			intercept: 57996947,
+			slope:     18975,
+		}},
+	},
+	builtin.VerifySchnorrSecp256k1Signature: &CostingFunc[Arguments]{
+		mem: &ConstantCost{10},
+		cpu: &ThreeLinearInY{LinearCost{
+			intercept: 39121781,
+			slope:     32260,
+		}},
+	},
+	builtin.WriteBits: &CostingFunc[Arguments]{
+		mem: &ThreeLinearInX{LinearCost{
+			intercept: 0,
+			slope:     1,
+		}},
+		cpu: &ThreeLinearInY{LinearCost{
+			intercept: 281145,
+			slope:     18848,
+		}},
+	},
+	builtin.XorByteString: &CostingFunc[Arguments]{
+		mem: &ThreeLinearInMaxYZ{LinearCost{
+			intercept: 0,
+			slope:     1,
+		}},
+		cpu: &ThreeLinearInYandZ{TwoVariableLinearSize{
+			intercept: 100181,
+			slope1:    726,
+			slope2:    719,
+		}},
+	},
+}
+
+var V2BuiltinCosts = BuiltinCosts{
+	builtin.AddInteger: &CostingFunc[Arguments]{
+		mem: &MaxSizeModel{MaxSize{
+			intercept: 1,
+			slope:     1,
+		}},
+		cpu: &MaxSizeModel{MaxSize{
+			intercept: 100788,
+			slope:     420,
+		}},
+	},
+	builtin.AndByteString: &CostingFunc[Arguments]{
+		mem: &ThreeLinearInMaxYZ{LinearCost{
+			intercept: 0,
+			slope:     1,
+		}},
+		cpu: &ThreeLinearInYandZ{TwoVariableLinearSize{
+			intercept: 100181,
+			slope1:    726,
+			slope2:    719,
+		}},
+	},
+	builtin.AppendByteString: &CostingFunc[Arguments]{
+		mem: &AddedSizesModel{AddedSizes{
+			intercept: 0,
+			slope:     1,
+		}},
+		cpu: &AddedSizesModel{AddedSizes{
+			intercept: 1000,
+			slope:     173,
+		}},
+	},
+	builtin.AppendString: &CostingFunc[Arguments]{
+		mem: &AddedSizesModel{AddedSizes{
+			intercept: 4,
+			slope:     1,
 		}},
 		cpu: &AddedSizesModel{AddedSizes{
 			intercept: 1000,
 			slope:     59957,
 		}},
-	}
-	costs[builtin.HeadList] = &CostingFunc[Arguments]{
+	},
+	builtin.BData: &CostingFunc[Arguments]{
 		mem: &ConstantCost{32},
-		cpu: &ConstantCost{1000},
-	}
-	costs[builtin.TailList] = &CostingFunc[Arguments]{
-		mem: &ConstantCost{32},
-		cpu: &ConstantCost{1000},
-	}
-	costs[builtin.NullList] = &CostingFunc[Arguments]{
-		mem: &ConstantCost{32},
-		cpu: &ConstantCost{1000},
-	}
-	costs[builtin.ChooseData] = &CostingFunc[Arguments]{
-		mem: &ConstantCost{32},
-		cpu: &ConstantCost{1000},
-	}
-	costs[builtin.ConstrData] = &CostingFunc[Arguments]{
+		cpu: &ConstantCost{11183},
+	},
+	builtin.Blake2b_224: &CostingFunc[Arguments]{
+		mem: &ConstantCost{4},
+		cpu: &LinearInX{LinearCost{
+			intercept: 207616,
+			slope:     8310,
+		}},
+	},
+	builtin.Blake2b_256: &CostingFunc[Arguments]{
+		mem: &ConstantCost{4},
+		cpu: &LinearInX{LinearCost{
+			intercept: 201305,
+			slope:     8356,
+		}},
+	},
+	builtin.Bls12_381_G1_Add: &CostingFunc[Arguments]{
+		mem: &ConstantCost{18},
+		cpu: &ConstantCost{962335},
+	},
+	builtin.Bls12_381_G1_Compress: &CostingFunc[Arguments]{
+		mem: &ConstantCost{6},
+		cpu: &ConstantCost{2780678},
+	},
+	builtin.Bls12_381_G1_Equal: &CostingFunc[Arguments]{
+		mem: &ConstantCost{1},
+		cpu: &ConstantCost{442008},
+	},
+	builtin.Bls12_381_G1_HashToGroup: &CostingFunc[Arguments]{
+		mem: &ConstantCost{18},
+		cpu: &LinearInX{LinearCost{
+			intercept: 52538055,
+			slope:     3756,
+		}},
+	},
+	builtin.Bls12_381_G1_MultiScalarMul: &CostingFunc[Arguments]{
+		mem: &ConstantCost{18},
+		cpu: &LinearInX{LinearCost{
+			intercept: 321837444,
+			slope:     25087669,
+		}},
+	},
+	builtin.Bls12_381_G1_Neg: &CostingFunc[Arguments]{
+		mem: &ConstantCost{18},
+		cpu: &ConstantCost{267929},
+	},
+	builtin.Bls12_381_G1_ScalarMul: &CostingFunc[Arguments]{
+		mem: &ConstantCost{18},
+		cpu: &LinearInX{LinearCost{
+			intercept: 76433006,
+			slope:     8868,
+		}},
+	},
+	builtin.Bls12_381_G1_Uncompress: &CostingFunc[Arguments]{
+		mem: &ConstantCost{18},
+		cpu: &ConstantCost{52948122},
+	},
+	builtin.Bls12_381_G2_Add: &CostingFunc[Arguments]{
+		mem: &ConstantCost{36},
+		cpu: &ConstantCost{1995836},
+	},
+	builtin.Bls12_381_G2_Compress: &CostingFunc[Arguments]{
+		mem: &ConstantCost{12},
+		cpu: &ConstantCost{3227919},
+	},
+	builtin.Bls12_381_G2_Equal: &CostingFunc[Arguments]{
+		mem: &ConstantCost{1},
+		cpu: &ConstantCost{901022},
+	},
+	builtin.Bls12_381_G2_HashToGroup: &CostingFunc[Arguments]{
+		mem: &ConstantCost{36},
+		cpu: &LinearInX{LinearCost{
+			intercept: 166917843,
+			slope:     4307,
+		}},
+	},
+	builtin.Bls12_381_G2_MultiScalarMul: &CostingFunc[Arguments]{
+		mem: &ConstantCost{36},
+		cpu: &LinearInX{LinearCost{
+			intercept: 617887431,
+			slope:     67302824,
+		}},
+	},
+	builtin.Bls12_381_G2_Neg: &CostingFunc[Arguments]{
+		mem: &ConstantCost{36},
+		cpu: &ConstantCost{284546},
+	},
+	builtin.Bls12_381_G2_ScalarMul: &CostingFunc[Arguments]{
+		mem: &ConstantCost{36},
+		cpu: &LinearInX{LinearCost{
+			intercept: 158221314,
+			slope:     26549,
+		}},
+	},
+	builtin.Bls12_381_G2_Uncompress: &CostingFunc[Arguments]{
+		mem: &ConstantCost{36},
+		cpu: &ConstantCost{74698472},
+	},
+	builtin.Bls12_381_FinalVerify: &CostingFunc[Arguments]{
+		mem: &ConstantCost{1},
+		cpu: &ConstantCost{333849714},
+	},
+	builtin.Bls12_381_MillerLoop: &CostingFunc[Arguments]{
+		mem: &ConstantCost{72},
+		cpu: &ConstantCost{254006273},
+	},
+	builtin.Bls12_381_MulMlResult: &CostingFunc[Arguments]{
+		mem: &ConstantCost{72},
+		cpu: &ConstantCost{2174038},
+	},
+	builtin.ByteStringToInteger: &CostingFunc[Arguments]{
 		mem: &LinearInY{LinearCost{
-			intercept: 32,
-			slope:     32,
+			intercept: 0,
+			slope:     1,
+		}},
+		cpu: &QuadraticInYModel{QuadraticFunction{
+			coeff0: 1006041,
+			coeff1: 43623,
+			coeff2: 251,
+		}},
+	},
+	builtin.ChooseData: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{94375},
+	},
+	builtin.ChooseList: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{132994},
+	},
+	builtin.ChooseUnit: &CostingFunc[Arguments]{
+		mem: &ConstantCost{4},
+		cpu: &ConstantCost{61462},
+	},
+	builtin.ComplementByteString: &CostingFunc[Arguments]{
+		mem: &LinearCost{
+			intercept: 0,
+			slope:     1,
+		},
+		cpu: &LinearInX{LinearCost{
+			intercept: 107878,
+			slope:     680,
+		}},
+	},
+	builtin.ConsByteString: &CostingFunc[Arguments]{
+		mem: &AddedSizesModel{AddedSizes{
+			intercept: 0,
+			slope:     1,
 		}},
 		cpu: &LinearInY{LinearCost{
-			intercept: 1000,
-			slope:     5431,
+			intercept: 72010,
+			slope:     178,
 		}},
-	}
-	costs[builtin.MapData] = &CostingFunc[Arguments]{
+	},
+	builtin.ConstrData: &CostingFunc[Arguments]{
 		mem: &ConstantCost{32},
-		cpu: &ConstantCost{1000},
-	}
-	costs[builtin.ListData] = &CostingFunc[Arguments]{
-		mem: &LinearInY{LinearCost{
-			intercept: 32,
-			slope:     32,
+		cpu: &ConstantCost{22151},
+	},
+	builtin.CountSetBits: &CostingFunc[Arguments]{
+		mem: &ConstantCost{1},
+		cpu: &LinearInX{LinearCost{
+			intercept: 107490,
+			slope:     3298,
 		}},
-		cpu: &LinearInY{LinearCost{
-			intercept: 1000,
-			slope:     5431,
+	},
+	builtin.DecodeUtf8: &CostingFunc[Arguments]{
+		mem: &LinearCost{
+			intercept: 4,
+			slope:     2,
+		},
+		cpu: &LinearInX{LinearCost{
+			intercept: 91189,
+			slope:     769,
 		}},
-	}
-	costs[builtin.IData] = &CostingFunc[Arguments]{
-		mem: &ConstantCost{32},
-		cpu: &ConstantCost{1000},
-	}
-	costs[builtin.BData] = &CostingFunc[Arguments]{
-		mem: &ConstantCost{32},
-		cpu: &ConstantCost{1000},
-	}
-	costs[builtin.UnConstrData] = &CostingFunc[Arguments]{
-		mem: &ConstantCost{32},
-		cpu: &ConstantCost{1000},
-	}
-	costs[builtin.UnMapData] = &CostingFunc[Arguments]{
-		mem: &ConstantCost{32},
-		cpu: &ConstantCost{1000},
-	}
-	costs[builtin.UnListData] = &CostingFunc[Arguments]{
-		mem: &ConstantCost{32},
-		cpu: &ConstantCost{1000},
-	}
-	costs[builtin.UnIData] = &CostingFunc[Arguments]{
-		mem: &ConstantCost{32},
-		cpu: &ConstantCost{1000},
-	}
-	costs[builtin.UnBData] = &CostingFunc[Arguments]{
-		mem: &ConstantCost{32},
-		cpu: &ConstantCost{1000},
-	}
-	costs[builtin.EqualsData] = &CostingFunc[Arguments]{
-		mem: &LinearOnDiagonalModel{
-			ConstantOrLinear{
-				constant:  32,
-				intercept: 32,
-				slope:     32,
+	},
+	builtin.DivideInteger: &CostingFunc[Arguments]{
+		mem: &SubtractedSizesModel{SubtractedSizes{
+			intercept: 0,
+			slope:     1,
+			minimum:   1,
+		}},
+		cpu: &ConstAboveDiagonalModel{
+			ConstantOrTwoArguments{
+				constant: 85848,
+				model: &MultipliedSizesModel{MultipliedSizes{
+					intercept: 228465,
+					slope:     122,
+				}},
 			},
 		},
+	},
+	builtin.DropList: &CostingFunc[Arguments]{
+		mem: &ConstantCost{4},
+		cpu: &LinearInX{LinearCost{
+			intercept: 116711,
+			slope:     1957,
+		}},
+	},
+	builtin.EncodeUtf8: &CostingFunc[Arguments]{
+		mem: &LinearCost{
+			intercept: 4,
+			slope:     2,
+		},
+		cpu: &LinearInX{LinearCost{
+			intercept: 1000,
+			slope:     42921,
+		}},
+	},
+	builtin.EqualsByteString: &CostingFunc[Arguments]{
+		mem: &ConstantCost{1},
 		cpu: &LinearOnDiagonalModel{
 			ConstantOrLinear{
-				constant:  1000,
-				intercept: 1000,
-				slope:     1,
+				constant:  24548,
+				intercept: 29498,
+				slope:     38,
 			},
 		},
-	}
-	costs[builtin.SerialiseData] = &CostingFunc[Arguments]{
-		mem: &LinearInY{LinearCost{
+	},
+	builtin.EqualsData: &CostingFunc[Arguments]{
+		mem: &ConstantCost{1},
+		cpu: &MinSizeModel{MinSize{
+			intercept: 898148,
+			slope:     27279,
+		}},
+	},
+	builtin.EqualsInteger: &CostingFunc[Arguments]{
+		mem: &ConstantCost{1},
+		cpu: &MinSizeModel{MinSize{
+			intercept: 51775,
+			slope:     558,
+		}},
+	},
+	builtin.EqualsString: &CostingFunc[Arguments]{
+		mem: &ConstantCost{1},
+		cpu: &LinearOnDiagonalModel{
+			ConstantOrLinear{
+				constant:  39184,
+				intercept: 1000,
+				slope:     60594,
+			},
+		},
+	},
+	builtin.ExpModInteger: &CostingFunc[Arguments]{
+		mem: &ThreeLinearInZ{LinearCost{
 			intercept: 0,
-			slope:     2,
+			slope:     1,
+		}},
+		cpu: &ExpMod{
+			coeff00: 607153,
+			coeff11: 231697,
+			coeff12: 53144,
+		},
+	},
+	builtin.FindFirstSetBit: &CostingFunc[Arguments]{
+		mem: &ConstantCost{1},
+		cpu: &LinearInX{LinearCost{
+			intercept: 106057,
+			slope:     655,
+		}},
+	},
+	builtin.FstPair: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{141895},
+	},
+	builtin.HeadList: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{83150},
+	},
+	builtin.IData: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{15299},
+	},
+	builtin.IfThenElse: &CostingFunc[Arguments]{
+		mem: &ConstantCost{1},
+		cpu: &ConstantCost{76049},
+	},
+	builtin.IndexArray: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{232010},
+	},
+	builtin.IndexByteString: &CostingFunc[Arguments]{
+		mem: &ConstantCost{4},
+		cpu: &ConstantCost{13169},
+	},
+	builtin.InsertCoin: &CostingFunc[Arguments]{
+		mem: &LinearInX{LinearCost{
+			intercept: 45,
+			slope:     21,
+		}},
+		cpu: &LinearInX{LinearCost{
+			intercept: 356924,
+			slope:     18413,
+		}},
+	},
+	builtin.IntegerToByteString: &CostingFunc[Arguments]{
+		mem: &ThreeLiteralInYorLinearInZ{LinearCost{
+			intercept: 0,
+			slope:     1,
+		}},
+		cpu: &ThreeQuadraticInZ{QuadraticFunction{
+			coeff0: 1293828,
+			coeff1: 28716,
+			coeff2: 63,
+		}},
+	},
+	builtin.Keccak_256: &CostingFunc[Arguments]{
+		mem: &ConstantCost{4},
+		cpu: &LinearInX{LinearCost{
+			intercept: 2261318,
+			slope:     64571,
+		}},
+	},
+	builtin.LengthOfArray: &CostingFunc[Arguments]{
+		mem: &ConstantCost{10},
+		cpu: &ConstantCost{231883},
+	},
+	builtin.LengthOfByteString: &CostingFunc[Arguments]{
+		mem: &ConstantCost{10},
+		cpu: &ConstantCost{22100},
+	},
+	builtin.LessThanByteString: &CostingFunc[Arguments]{
+		mem: &ConstantCost{1},
+		cpu: &MinSizeModel{MinSize{
+			intercept: 28999,
+			slope:     74,
+		}},
+	},
+	builtin.LessThanEqualsByteString: &CostingFunc[Arguments]{
+		mem: &ConstantCost{1},
+		cpu: &MinSizeModel{MinSize{
+			intercept: 28999,
+			slope:     74,
+		}},
+	},
+	builtin.LessThanEqualsInteger: &CostingFunc[Arguments]{
+		mem: &ConstantCost{1},
+		cpu: &MinSizeModel{MinSize{
+			intercept: 43285,
+			slope:     552,
+		}},
+	},
+	builtin.LessThanInteger: &CostingFunc[Arguments]{
+		mem: &ConstantCost{1},
+		cpu: &MinSizeModel{MinSize{
+			intercept: 44749,
+			slope:     541,
+		}},
+	},
+	builtin.ListData: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{33852},
+	},
+	builtin.ListToArray: &CostingFunc[Arguments]{
+		mem: &LinearCost{
+			intercept: 7,
+			slope:     1,
+		},
+		cpu: &LinearInX{LinearCost{
+			intercept: 1000,
+			slope:     24838,
+		}},
+	},
+	builtin.LookupCoin: &CostingFunc[Arguments]{
+		mem: &ConstantCost{1},
+		cpu: &ThreeLinearInZ{LinearCost{
+			intercept: 219951,
+			slope:     9444,
+		}},
+	},
+	builtin.MapData: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{68246},
+	},
+	builtin.MkCons: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{72362},
+	},
+	builtin.MkNilData: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{7243},
+	},
+	builtin.MkNilPairData: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{7391},
+	},
+	builtin.MkPairData: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{11546},
+	},
+	builtin.ModInteger: &CostingFunc[Arguments]{
+		mem: &SubtractedSizesModel{SubtractedSizes{
+			intercept: 0,
+			slope:     1,
+			minimum:   1,
+		}},
+		cpu: &ConstAboveDiagonalModel{
+			ConstantOrTwoArguments{
+				constant: 85848,
+				model: &MultipliedSizesModel{MultipliedSizes{
+					intercept: 228465,
+					slope:     122,
+				}},
+			},
+		},
+	},
+	builtin.MultiplyInteger: &CostingFunc[Arguments]{
+		mem: &AddedSizesModel{AddedSizes{
+			intercept: 0,
+			slope:     1,
+		}},
+		cpu: &MultipliedSizesModel{MultipliedSizes{
+			intercept: 90434,
+			slope:     519,
+		}},
+	},
+	builtin.NullList: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{74433},
+	},
+	builtin.OrByteString: &CostingFunc[Arguments]{
+		mem: &ThreeLinearInMaxYZ{LinearCost{
+			intercept: 0,
+			slope:     1,
+		}},
+		cpu: &ThreeLinearInYandZ{TwoVariableLinearSize{
+			intercept: 100181,
+			slope1:    726,
+			slope2:    719,
+		}},
+	},
+	builtin.QuotientInteger: &CostingFunc[Arguments]{
+		mem: &SubtractedSizesModel{SubtractedSizes{
+			intercept: 0,
+			slope:     1,
+			minimum:   1,
+		}},
+		cpu: &ConstAboveDiagonalModel{
+			ConstantOrTwoArguments{
+				constant: 85848,
+				model: &MultipliedSizesModel{MultipliedSizes{
+					intercept: 228465,
+					slope:     122,
+				}},
+			},
+		},
+	},
+	builtin.ReadBit: &CostingFunc[Arguments]{
+		mem: &ConstantCost{1},
+		cpu: &ConstantCost{95336},
+	},
+	builtin.RemainderInteger: &CostingFunc[Arguments]{
+		mem: &SubtractedSizesModel{SubtractedSizes{
+			intercept: 0,
+			slope:     1,
+			minimum:   1,
+		}},
+		cpu: &ConstAboveDiagonalModel{
+			ConstantOrTwoArguments{
+				constant: 85848,
+				model: &MultipliedSizesModel{MultipliedSizes{
+					intercept: 228465,
+					slope:     122,
+				}},
+			},
+		},
+	},
+	builtin.ReplicateByte: &CostingFunc[Arguments]{
+		mem: &LinearInX{LinearCost{
+			intercept: 1,
+			slope:     1,
+		}},
+		cpu: &LinearInX{LinearCost{
+			intercept: 180194,
+			slope:     159,
+		}},
+	},
+	builtin.Ripemd_160: &CostingFunc[Arguments]{
+		mem: &ConstantCost{3},
+		cpu: &LinearInX{LinearCost{
+			intercept: 1964219,
+			slope:     24520,
+		}},
+	},
+	builtin.RotateByteString: &CostingFunc[Arguments]{
+		mem: &LinearInX{LinearCost{
+			intercept: 0,
+			slope:     1,
+		}},
+		cpu: &LinearInX{LinearCost{
+			intercept: 159378,
+			slope:     8813,
+		}},
+	},
+	builtin.ScaleValue: &CostingFunc[Arguments]{
+		mem: &LinearInY{LinearCost{
+			intercept: 12,
+			slope:     21,
 		}},
 		cpu: &LinearInY{LinearCost{
 			intercept: 1000,
-			slope:     533,
+			slope:     277577,
 		}},
-	}
-	return costs
-}()
-
-var V2BuiltinCosts = func() BuiltinCosts {
-	costs := DefaultBuiltinCosts
-	// Modify V2 costs where they differ from V3
-	costs[builtin.DivideInteger] = &CostingFunc[Arguments]{
-		mem: &SubtractedSizesModel{SubtractedSizes{
+	},
+	builtin.SerialiseData: &CostingFunc[Arguments]{
+		mem: &LinearCost{
 			intercept: 0,
-			slope:     1,
-			minimum:   1,
-		}},
-		cpu: &ConstAboveDiagonalModel{
-			ConstantOrTwoArguments{
-				constant: 85848,
-				model: &MultipliedSizesModel{MultipliedSizes{
-					intercept: 228465,
-					slope:     122,
-				}},
-			},
+			slope:     2,
 		},
-	}
-	// Similarly for quotientInteger, remainderInteger, modInteger
-	costs[builtin.QuotientInteger] = &CostingFunc[Arguments]{
-		mem: &SubtractedSizesModel{SubtractedSizes{
-			intercept: 0,
-			slope:     1,
-			minimum:   1,
+		cpu: &LinearInX{LinearCost{
+			intercept: 955506,
+			slope:     213312,
 		}},
-		cpu: &ConstAboveDiagonalModel{
-			ConstantOrTwoArguments{
-				constant: 85848,
-				model: &MultipliedSizesModel{MultipliedSizes{
-					intercept: 228465,
-					slope:     122,
-				}},
-			},
-		},
-	}
-	costs[builtin.RemainderInteger] = &CostingFunc[Arguments]{
-		mem: &LinearInY{LinearCost{
+	},
+	builtin.Sha2_256: &CostingFunc[Arguments]{
+		mem: &ConstantCost{4},
+		cpu: &LinearInX{LinearCost{
+			intercept: 270652,
+			slope:     22588,
+		}},
+	},
+	builtin.Sha3_256: &CostingFunc[Arguments]{
+		mem: &ConstantCost{4},
+		cpu: &LinearInX{LinearCost{
+			intercept: 1457325,
+			slope:     64566,
+		}},
+	},
+	builtin.ShiftByteString: &CostingFunc[Arguments]{
+		mem: &LinearInX{LinearCost{
 			intercept: 0,
 			slope:     1,
 		}},
+		cpu: &LinearInX{LinearCost{
+			intercept: 158519,
+			slope:     8942,
+		}},
+	},
+	builtin.SliceByteString: &CostingFunc[Arguments]{
+		mem: &ThreeLinearInZ{LinearCost{
+			intercept: 4,
+			slope:     0,
+		}},
+		cpu: &ThreeLinearInZ{LinearCost{
+			intercept: 20467,
+			slope:     1,
+		}},
+	},
+	builtin.SndPair: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{141992},
+	},
+	builtin.SubtractInteger: &CostingFunc[Arguments]{
+		mem: &MaxSizeModel{MaxSize{
+			intercept: 1,
+			slope:     1,
+		}},
+		cpu: &MaxSizeModel{MaxSize{
+			intercept: 100788,
+			slope:     420,
+		}},
+	},
+	builtin.TailList: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{81663},
+	},
+	builtin.Trace: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{59498},
+	},
+	builtin.UnBData: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{20142},
+	},
+	builtin.UnConstrData: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{24588},
+	},
+	builtin.UnIData: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{20744},
+	},
+	builtin.UnListData: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{25933},
+	},
+	builtin.UnMapData: &CostingFunc[Arguments]{
+		mem: &ConstantCost{32},
+		cpu: &ConstantCost{24623},
+	},
+	builtin.UnionValue: &CostingFunc[Arguments]{
+		mem: &AddedSizesModel{AddedSizes{
+			intercept: 24,
+			slope:     21,
+		}},
+		cpu: &LinearInXAndY{TwoVariableLinearSize{
+			intercept: 1000,
+			slope1:    172116,
+			slope2:    183150,
+		}},
+	},
+	builtin.ValueContains: &CostingFunc[Arguments]{
+		mem: &ConstantCost{1},
 		cpu: &ConstAboveDiagonalModel{
 			ConstantOrTwoArguments{
-				constant: 85848,
-				model: &MultipliedSizesModel{MultipliedSizes{
-					intercept: 228465,
-					slope:     122,
+				constant: 318444,
+				model: &LinearInXAndY{TwoVariableLinearSize{
+					intercept: 619335,
+					slope1:    1997,
+					slope2:    28258,
 				}},
 			},
 		},
-	}
-	costs[builtin.ModInteger] = &CostingFunc[Arguments]{
-		mem: &LinearInY{LinearCost{
+	},
+	builtin.VerifyEcdsaSecp256k1Signature: &CostingFunc[Arguments]{
+		mem: &ConstantCost{10},
+		cpu: &ConstantCost{43053543},
+	},
+	builtin.VerifyEd25519Signature: &CostingFunc[Arguments]{
+		mem: &ConstantCost{10},
+		cpu: &ThreeLinearInY{LinearCost{
+			intercept: 53384111,
+			slope:     14333,
+		}},
+	},
+	builtin.VerifySchnorrSecp256k1Signature: &CostingFunc[Arguments]{
+		mem: &ConstantCost{10},
+		cpu: &ThreeLinearInY{LinearCost{
+			intercept: 43574283,
+			slope:     26308,
+		}},
+	},
+	builtin.WriteBits: &CostingFunc[Arguments]{
+		mem: &ThreeLinearInX{LinearCost{
 			intercept: 0,
 			slope:     1,
 		}},
-		cpu: &ConstAboveDiagonalModel{
-			ConstantOrTwoArguments{
-				constant: 85848,
-				model: &MultipliedSizesModel{MultipliedSizes{
-					intercept: 228465,
-					slope:     122,
-				}},
-			},
-		},
-	}
-	return costs
-}()
+		cpu: &ThreeLinearInY{LinearCost{
+			intercept: 281145,
+			slope:     18848,
+		}},
+	},
+	builtin.XorByteString: &CostingFunc[Arguments]{
+		mem: &ThreeLinearInMaxYZ{LinearCost{
+			intercept: 0,
+			slope:     1,
+		}},
+		cpu: &ThreeLinearInYandZ{TwoVariableLinearSize{
+			intercept: 100181,
+			slope1:    726,
+			slope2:    719,
+		}},
+	},
+}


### PR DESCRIPTION
This commit rebuilds the V1/V2 cost models based on the data from:

https://github.com/IntersectMBO/plutus/tree/aee28e0467be0561de5c2f097f639914d8d7a294/plutus-core/cost-model/data

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilt the V1 and V2 builtin cost models from the latest Plutus Core cost-model data to improve accuracy and consistency across all operations.

- **Refactors**
  - Replaced V1BuiltinCosts and V2BuiltinCosts with fully populated BuiltinCosts maps sourced from Plutus Core data.
  - Updated CPU/memory models for all builtins (integers, byte strings, data ops, hashing, signatures, BLS12-381, etc.), removing placeholder constants and using size-based models where appropriate.
  - Removed V2’s reliance on mutating DefaultBuiltinCosts; V2 is now defined as a standalone map.
  - Aligned model shapes (linear, quadratic, min/max size, exp-mod) to the upstream specifications for more precise cost evaluation.

<sup>Written for commit 6a40b72a2edf95357c37be31c9247b87a85f114c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Converted builtin cost configurations for V1 and V2 to static inline mappings, simplifying initialization and loading.
  * Expanded and recalibrated many cost models across both versions—notably cryptographic, data/string, and arithmetic operations—with adjusted memory and CPU parameters for more consistent cost estimation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->