### PR TITLE
perf: split wrapper arena sizes

### DIFF
--- a/cek/bench_test.go
+++ b/cek/bench_test.go
@@ -93,7 +93,11 @@ func BenchmarkDischarge(b *testing.B) {
 			b.ReportAllocs()
 
 			for b.Loop() {
-				benchmarkTermSink = dischargeValue[syn.DeBruijn](value)
+				discharged, err := dischargeValue[syn.DeBruijn](value)
+				if err != nil {
+					b.Fatalf("dischargeValue failed: %v", err)
+				}
+				benchmarkTermSink = discharged
 			}
 		})
 	}

--- a/cek/builtins.go
+++ b/cek/builtins.go
@@ -299,36 +299,62 @@ func (m *Machine[T]) evalUnaryBuiltinFast(
 ) (Value[T], bool, error) {
 	switch fn {
 	case builtin.FstPair:
-		fstPair, sndPair, err := unwrapPair[T](arg)
+		if err := m.CostOne(&fn, valueExMem[T](arg)); err != nil {
+			return nil, true, err
+		}
+		first, _, err := splitPairValue(m, arg)
 		if err != nil {
 			return nil, true, err
 		}
-		if err := m.CostOne(&fn, pairExMem(fstPair, sndPair)); err != nil {
-			return nil, true, err
-		}
-		if fstPair == nil {
+		if first == nil {
 			return nil, true, &InternalError{
 				Code:    ErrCodeInternalError,
 				Message: "fstPair returned nil constant",
 			}
 		}
-		return machineConstantValue(m, fstPair), true, nil
+		return first, true, nil
 	case builtin.SndPair:
-		fstPair, sndPair, err := unwrapPair[T](arg)
+		if err := m.CostOne(&fn, valueExMem[T](arg)); err != nil {
+			return nil, true, err
+		}
+		_, second, err := splitPairValue(m, arg)
 		if err != nil {
 			return nil, true, err
 		}
-		if err := m.CostOne(&fn, pairExMem(fstPair, sndPair)); err != nil {
-			return nil, true, err
-		}
-		if sndPair == nil {
+		if second == nil {
 			return nil, true, &InternalError{
 				Code:    ErrCodeInternalError,
 				Message: "sndPair returned nil constant",
 			}
 		}
-		return machineConstantValue(m, sndPair), true, nil
+		return second, true, nil
 	case builtin.HeadList:
+		if dataList, ok := arg.(*dataListValue[T]); ok {
+			if err := m.CostOne(&fn, valueExMem[T](arg)); err != nil {
+				return nil, true, err
+			}
+			if len(dataList.items) == 0 {
+				return nil, true, &BuiltinError{
+					Code:    ErrCodeOutOfBounds,
+					Builtin: "headList",
+					Message: "headList on an empty list",
+				}
+			}
+			return m.allocDataValue(dataList.items[0]), true, nil
+		}
+		if dataMap, ok := arg.(*dataMapValue[T]); ok {
+			if err := m.CostOne(&fn, valueExMem[T](arg)); err != nil {
+				return nil, true, err
+			}
+			if len(dataMap.items) == 0 {
+				return nil, true, &BuiltinError{
+					Code:    ErrCodeOutOfBounds,
+					Builtin: "headList",
+					Message: "headList on an empty list",
+				}
+			}
+			return m.allocDataPairValue(dataMap.items[0][0], dataMap.items[0][1]), true, nil
+		}
 		list, err := unwrapList[T](nil, arg)
 		if err != nil {
 			return nil, true, err
@@ -349,8 +375,34 @@ func (m *Machine[T]) evalUnaryBuiltinFast(
 				Message: "headList returned nil constant",
 			}
 		}
-		return machineConstantValue(m, list.List[0]), true, nil
+		return dataAwareConstantValue(m, list.List[0]), true, nil
 	case builtin.TailList:
+		if dataList, ok := arg.(*dataListValue[T]); ok {
+			if err := m.CostOne(&fn, valueExMem[T](arg)); err != nil {
+				return nil, true, err
+			}
+			if len(dataList.items) == 0 {
+				return nil, true, &BuiltinError{
+					Code:    ErrCodeOutOfBounds,
+					Builtin: "tailList",
+					Message: "tailList on an empty list",
+				}
+			}
+			return m.allocDataListValue(dataList.items[1:]), true, nil
+		}
+		if dataMap, ok := arg.(*dataMapValue[T]); ok {
+			if err := m.CostOne(&fn, valueExMem[T](arg)); err != nil {
+				return nil, true, err
+			}
+			if len(dataMap.items) == 0 {
+				return nil, true, &BuiltinError{
+					Code:    ErrCodeOutOfBounds,
+					Builtin: "tailList",
+					Message: "tailList on an empty list",
+				}
+			}
+			return m.allocDataMapValue(dataMap.items[1:]), true, nil
+		}
 		list, err := unwrapList[T](nil, arg)
 		if err != nil {
 			return nil, true, err
@@ -367,6 +419,18 @@ func (m *Machine[T]) evalUnaryBuiltinFast(
 		}
 		return m.allocConstant(m.allocProtoListConstant(list.LTyp, list.List[1:])), true, nil
 	case builtin.NullList:
+		if v, ok := arg.(*dataListValue[T]); ok {
+			if err := m.CostOne(&fn, valueExMem[T](v)); err != nil {
+				return nil, true, err
+			}
+			return boolConstant(len(v.items) == 0), true, nil
+		}
+		if w, ok := arg.(*dataMapValue[T]); ok {
+			if err := m.CostOne(&fn, valueExMem[T](w)); err != nil {
+				return nil, true, err
+			}
+			return boolConstant(len(w.items) == 0), true, nil
+		}
 		list, err := unwrapList[T](nil, arg)
 		if err != nil {
 			return nil, true, err
@@ -398,17 +462,10 @@ func (m *Machine[T]) evalUnaryBuiltinFast(
 				Message: "constructor tag too large for integer conversion",
 			}
 		}
-		fields := m.allocConstantElems(len(constr.Fields))
-		for i, field := range constr.Fields {
-			fields[i] = m.allocDataConstant(field)
-		}
-		pair := m.allocProtoPairConstant(
-			sharedIntegerType,
-			sharedListDataType,
-			m.int64Constant(int64(constr.Tag)).Constant,
-			m.allocProtoListConstant(sharedDataType, fields),
-		)
-		return m.allocConstant(pair), true, nil
+		return m.allocPairValue(
+			m.int64Constant(int64(constr.Tag)),
+			m.allocDataListValue(constr.Fields),
+		), true, nil
 	case builtin.UnMapData:
 		datum, err := unwrapData[T](arg)
 		if err != nil {
@@ -425,16 +482,7 @@ func (m *Machine[T]) evalUnaryBuiltinFast(
 				Message: "data is not a map",
 			}
 		}
-		items := m.allocConstantElems(len(dataMap.Pairs))
-		for i, item := range dataMap.Pairs {
-			items[i] = m.allocProtoPairConstant(
-				sharedDataType,
-				sharedDataType,
-				m.allocDataConstant(item[0]),
-				m.allocDataConstant(item[1]),
-			)
-		}
-		return m.allocConstant(m.allocProtoListConstant(sharedPairDataType, items)), true, nil
+		return m.allocDataMapValue(dataMap.Pairs), true, nil
 	case builtin.UnListData:
 		datum, err := unwrapData[T](arg)
 		if err != nil {
@@ -451,11 +499,7 @@ func (m *Machine[T]) evalUnaryBuiltinFast(
 				Message: "data is not a list",
 			}
 		}
-		items := m.allocConstantElems(len(dataList.Items))
-		for i, item := range dataList.Items {
-			items[i] = m.allocDataConstant(item)
-		}
-		return m.allocConstant(m.allocProtoListConstant(sharedDataType, items)), true, nil
+		return m.allocDataListValue(dataList.Items), true, nil
 	case builtin.UnIData:
 		datum, err := unwrapData[T](arg)
 		if err != nil {
@@ -567,6 +611,40 @@ func (m *Machine[T]) evalBinaryBuiltinFast(
 		m.Logs = append(m.Logs, msg)
 		return rightVal, true, nil
 	case builtin.MkCons:
+		if dataMap, ok := rightVal.(*dataMapValue[T]); ok {
+			if err := m.CostTwo(&fn, valueExMem[T](leftVal), valueExMem[T](rightVal)); err != nil {
+				return nil, true, err
+			}
+			first, second, err := splitPairValue(m, leftVal)
+			if err != nil {
+				return nil, true, err
+			}
+			dataFirst, err := unwrapData[T](first)
+			if err != nil {
+				return nil, true, err
+			}
+			dataSecond, err := unwrapData[T](second)
+			if err != nil {
+				return nil, true, err
+			}
+			consList := make([][2]data.PlutusData, len(dataMap.items)+1)
+			consList[0] = [2]data.PlutusData{dataFirst, dataSecond}
+			copy(consList[1:], dataMap.items)
+			return m.allocDataMapValue(consList), true, nil
+		}
+		if dataList, ok := rightVal.(*dataListValue[T]); ok {
+			if err := m.CostTwo(&fn, valueExMem[T](leftVal), valueExMem[T](rightVal)); err != nil {
+				return nil, true, err
+			}
+			dataHead, err := unwrapData[T](leftVal)
+			if err != nil {
+				return nil, true, err
+			}
+			consList := make([]data.PlutusData, len(dataList.items)+1)
+			consList[0] = dataHead
+			copy(consList[1:], dataList.items)
+			return m.allocDataListValue(consList), true, nil
+		}
 		head, err := unwrapConstant[T](leftVal)
 		if err != nil {
 			return nil, true, err
@@ -608,6 +686,24 @@ func (m *Machine[T]) evalTernaryBuiltinFast(
 		}
 		return thirdVal, true, nil
 	case builtin.ChooseList:
+		if dataList, ok := firstVal.(*dataListValue[T]); ok {
+			if err := m.CostThree(&fn, valueExMem[T](firstVal), valueExMem[T](secondVal), valueExMem[T](thirdVal)); err != nil {
+				return nil, true, err
+			}
+			if len(dataList.items) == 0 {
+				return secondVal, true, nil
+			}
+			return thirdVal, true, nil
+		}
+		if dataMap, ok := firstVal.(*dataMapValue[T]); ok {
+			if err := m.CostThree(&fn, valueExMem[T](firstVal), valueExMem[T](secondVal), valueExMem[T](thirdVal)); err != nil {
+				return nil, true, err
+			}
+			if len(dataMap.items) == 0 {
+				return secondVal, true, nil
+			}
+			return thirdVal, true, nil
+		}
 		list, err := unwrapList[T](nil, firstVal)
 		if err != nil {
 			return nil, true, err
@@ -1721,6 +1817,26 @@ func chooseData[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 	}
 }
 
+func validateConstrTag(arg *big.Int) (uint, error) {
+	// Keep constrData tags within the same range that unConstrData can decode
+	// back into an integer without overflow.
+	if arg.Sign() < 0 {
+		return 0, &BuiltinError{
+			Code:    ErrCodeInvalidArgument,
+			Builtin: "constrData",
+			Message: "constructor tag must be non-negative",
+		}
+	}
+	if !arg.IsInt64() || arg.BitLen() > bits.UintSize {
+		return 0, &BuiltinError{
+			Code:    ErrCodeOverflow,
+			Builtin: "constrData",
+			Message: "constructor tag too large for unConstrData",
+		}
+	}
+	return uint(arg.Uint64()), nil
+}
+
 func constrData[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 	b.Args.Extract(&m.argHolder, b.ArgCount)
 
@@ -1729,12 +1845,21 @@ func constrData[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 		return nil, err
 	}
 
-	if arg1.Sign() < 0 {
-		return nil, &BuiltinError{
-			Code:    ErrCodeInvalidArgument,
-			Builtin: "constrData",
-			Message: "constructor tag must be non-negative",
+	if arg2, ok := m.argHolder[1].(*dataListValue[T]); ok {
+		err = m.CostTwo(&b.Func, bigIntExMem(arg1), valueExMem[T](arg2))
+		if err != nil {
+			return nil, err
 		}
+
+		tag, tagErr := validateConstrTag(arg1)
+		if tagErr != nil {
+			return nil, tagErr
+		}
+
+		return m.allocDataValue(&data.Constr{
+			Tag:    tag,
+			Fields: arg2.items,
+		}), nil
 	}
 
 	arg2, err := unwrapList[T](&syn.TData{}, m.argHolder[1])
@@ -1753,31 +1878,29 @@ func constrData[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 		dataList[i] = itemData.Inner
 	}
 
-	if arg1.BitLen() > 64 {
-		return nil, &BuiltinError{
-			Code:    ErrCodeOverflow,
-			Builtin: "constrData",
-			Message: "constructor tag too large",
-		}
+	tag, tagErr := validateConstrTag(arg1)
+	if tagErr != nil {
+		return nil, tagErr
 	}
-	tag64 := arg1.Uint64()
-	if tag64 > uint64(math.MaxUint) {
-		return nil, &BuiltinError{
-			Code:    ErrCodeOverflow,
-			Builtin: "constrData",
-			Message: "constructor tag too large",
-		}
-	}
-	tag := uint(tag64)
 
-	return m.allocConstant(m.allocDataConstant(&data.Constr{
+	return m.allocDataValue(&data.Constr{
 		Tag:    tag,
 		Fields: dataList,
-	})), nil
+	}), nil
 }
 
 func mapData[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 	b.Args.Extract(&m.argHolder, b.ArgCount)
+
+	if arg1, ok := m.argHolder[0].(*dataMapValue[T]); ok {
+		err := m.CostOne(&b.Func, valueExMem[T](arg1))
+		if err != nil {
+			return nil, err
+		}
+		return m.allocDataValue(&data.Map{
+			Pairs: arg1.items,
+		}), nil
+	}
 
 	pairType := &syn.TPair{
 		First:  &syn.TData{},
@@ -1802,13 +1925,23 @@ func mapData[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 		dataList[i] = [2]data.PlutusData{fst.Inner, snd.Inner}
 	}
 
-	return m.allocConstant(m.allocDataConstant(&data.Map{
+	return m.allocDataValue(&data.Map{
 		Pairs: dataList,
-	})), nil
+	}), nil
 }
 
 func listData[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 	b.Args.Extract(&m.argHolder, b.ArgCount)
+
+	if arg1, ok := m.argHolder[0].(*dataListValue[T]); ok {
+		err := m.CostOne(&b.Func, valueExMem[T](arg1))
+		if err != nil {
+			return nil, err
+		}
+		return m.allocDataValue(&data.List{
+			Items: arg1.items,
+		}), nil
+	}
 
 	arg1, err := unwrapList[T](&syn.TData{}, m.argHolder[0])
 	if err != nil {
@@ -1826,9 +1959,9 @@ func listData[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 		dataList[i] = itemData.Inner
 	}
 
-	return m.allocConstant(m.allocDataConstant(&data.List{
+	return m.allocDataValue(&data.List{
 		Items: dataList,
-	})), nil
+	}), nil
 }
 
 func iData[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
@@ -1844,7 +1977,7 @@ func iData[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 		return nil, err
 	}
 
-	return m.allocConstant(m.allocDataConstant(&data.Integer{Inner: arg1})), nil
+	return m.allocDataValue(&data.Integer{Inner: arg1}), nil
 }
 
 func bData[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
@@ -1860,7 +1993,7 @@ func bData[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 		return nil, err
 	}
 
-	return m.allocConstant(m.allocDataConstant(&data.ByteString{Inner: arg1})), nil
+	return m.allocDataValue(&data.ByteString{Inner: arg1}), nil
 }
 
 func unConstrData[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
@@ -1966,20 +2099,10 @@ func mkPairData[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 		return nil, err
 	}
 
-	pair := syn.ProtoPair{
-		FstType: &syn.TData{},
-		SndType: &syn.TData{},
-		First: &syn.Data{
-			Inner: arg1,
-		},
-		Second: &syn.Data{
-			Inner: arg2,
-		},
-	}
-
-	value := &Constant{&pair}
-
-	return value, nil
+	return m.allocPairValue(
+		m.allocDataValue(arg1),
+		m.allocDataValue(arg2),
+	), nil
 }
 
 func mkNilData[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
@@ -1995,14 +2118,7 @@ func mkNilData[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 		return nil, err
 	}
 
-	l := syn.ProtoList{
-		LTyp: &syn.TData{},
-		List: []syn.IConstant{},
-	}
-
-	value := &Constant{&l}
-
-	return value, nil
+	return m.allocDataListValue(nil), nil
 }
 
 func mkNilPairData[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
@@ -2018,17 +2134,7 @@ func mkNilPairData[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 		return nil, err
 	}
 
-	l := syn.ProtoList{
-		LTyp: &syn.TPair{
-			First:  &syn.TData{},
-			Second: &syn.TData{},
-		},
-		List: []syn.IConstant{},
-	}
-
-	value := &Constant{&l}
-
-	return value, nil
+	return m.allocDataMapValue(nil), nil
 }
 
 // ============================================================================

--- a/cek/builtins_test.go
+++ b/cek/builtins_test.go
@@ -129,6 +129,57 @@ func expectProtoPair(t *testing.T, constVal *Constant) *syn.ProtoPair {
 	return pair
 }
 
+func expectMaterializedConstant(
+	t *testing.T,
+	val Value[syn.DeBruijn],
+) syn.IConstant {
+	t.Helper()
+	constVal, ok := materializeConstantValue[syn.DeBruijn](val)
+	if !ok {
+		t.Fatalf("expected materializable constant result, got %T", val)
+	}
+	return constVal
+}
+
+func expectMaterializedData(
+	t *testing.T,
+	val Value[syn.DeBruijn],
+) *syn.Data {
+	t.Helper()
+	constant := expectMaterializedConstant(t, val)
+	dataConst, ok := constant.(*syn.Data)
+	if !ok {
+		t.Fatalf("expected Data constant, got %T", constant)
+	}
+	return dataConst
+}
+
+func expectMaterializedProtoList(
+	t *testing.T,
+	val Value[syn.DeBruijn],
+) *syn.ProtoList {
+	t.Helper()
+	constant := expectMaterializedConstant(t, val)
+	list, ok := constant.(*syn.ProtoList)
+	if !ok {
+		t.Fatalf("expected ProtoList constant, got %T", constant)
+	}
+	return list
+}
+
+func expectMaterializedProtoPair(
+	t *testing.T,
+	val Value[syn.DeBruijn],
+) *syn.ProtoPair {
+	t.Helper()
+	constant := expectMaterializedConstant(t, val)
+	pair, ok := constant.(*syn.ProtoPair)
+	if !ok {
+		t.Fatalf("expected ProtoPair constant, got %T", constant)
+	}
+	return pair
+}
+
 func TestAddIntegerBuiltin(t *testing.T) {
 	m := newTestMachine()
 	b := newTestBuiltin(builtin.AddInteger)
@@ -698,19 +749,48 @@ func TestUnConstrDataBuiltin(t *testing.T) {
 		t.Fatalf("evalBuiltinApp returned error: %v", err)
 	}
 
-	// UnConstrData returns a ProtoPair constant
-	constVal, ok := val.(*Constant)
+	// UnConstrData may use a lazy runtime pair, but it must materialize to the
+	// same ProtoPair constant shape.
+	constVal, ok := materializeConstantValue[syn.DeBruijn](val)
 	if !ok {
-		t.Fatalf("expected Constant result, got %T", val)
+		t.Fatalf("expected pair-like constant result, got %T", val)
 	}
 
-	pair, ok := constVal.Constant.(*syn.ProtoPair)
+	pair, ok := constVal.(*syn.ProtoPair)
 	if !ok {
-		t.Fatalf("expected ProtoPair constant, got %T", constVal.Constant)
+		t.Fatalf("expected ProtoPair constant, got %T", constVal)
 	}
 
 	if pair.FstType == nil || pair.SndType == nil {
 		t.Fatal("expected non-nil types in pair")
+	}
+
+	tagConst, ok := pair.First.(*syn.Integer)
+	if !ok {
+		t.Fatalf("expected Integer tag, got %T", pair.First)
+	}
+	if tagConst.Inner.Cmp(big.NewInt(1)) != 0 {
+		t.Fatalf("expected constructor tag 1, got %v", tagConst.Inner)
+	}
+
+	fieldsConst, ok := pair.Second.(*syn.ProtoList)
+	if !ok {
+		t.Fatalf("expected ProtoList fields, got %T", pair.Second)
+	}
+	if len(fieldsConst.List) != 1 {
+		t.Fatalf("expected 1 field, got %d", len(fieldsConst.List))
+	}
+
+	fieldData, ok := fieldsConst.List[0].(*syn.Data)
+	if !ok {
+		t.Fatalf("expected Data field, got %T", fieldsConst.List[0])
+	}
+	fieldInt, ok := fieldData.Inner.(*data.Integer)
+	if !ok {
+		t.Fatalf("expected Integer field payload, got %T", fieldData.Inner)
+	}
+	if fieldInt.Inner.Cmp(big.NewInt(99)) != 0 {
+		t.Fatalf("expected field payload 99, got %v", fieldInt.Inner)
 	}
 }
 
@@ -921,6 +1001,31 @@ func TestHeadListBuiltin(t *testing.T) {
 
 	if intConst.Inner.Int64() != 1 {
 		t.Fatalf("expected 1, got %v", intConst.Inner)
+	}
+}
+
+func TestHeadListBuiltinOnConstantDataList(t *testing.T) {
+	m := newTestMachine()
+	b := newTestBuiltin(builtin.HeadList)
+
+	list := &syn.ProtoList{
+		LTyp: &syn.TData{},
+		List: []syn.IConstant{
+			&syn.Data{Inner: &data.Integer{Inner: big.NewInt(1)}},
+			&syn.Data{Inner: &data.Integer{Inner: big.NewInt(2)}},
+		},
+	}
+
+	b = b.ApplyArg(&Constant{list})
+
+	val := evalBuiltin(t, m, b)
+	dataConst := expectMaterializedData(t, val)
+	intData, ok := dataConst.Inner.(*data.Integer)
+	if !ok {
+		t.Fatalf("expected Integer data, got %T", dataConst.Inner)
+	}
+	if intData.Inner.Cmp(big.NewInt(1)) != 0 {
+		t.Fatalf("expected 1, got %v", intData.Inner)
 	}
 }
 
@@ -1237,6 +1342,30 @@ func TestFstPairBuiltin(t *testing.T) {
 	}
 }
 
+func TestFstPairBuiltinOnConstantDataPair(t *testing.T) {
+	m := newTestMachine()
+	b := newTestBuiltin(builtin.FstPair)
+
+	pair := &syn.ProtoPair{
+		FstType: &syn.TData{},
+		SndType: &syn.TData{},
+		First:   &syn.Data{Inner: &data.Integer{Inner: big.NewInt(1)}},
+		Second:  &syn.Data{Inner: &data.ByteString{Inner: []byte("two")}},
+	}
+
+	b = b.ApplyArg(&Constant{pair})
+
+	val := evalBuiltin(t, m, b)
+	dataConst := expectMaterializedData(t, val)
+	intData, ok := dataConst.Inner.(*data.Integer)
+	if !ok {
+		t.Fatalf("expected Integer data, got %T", dataConst.Inner)
+	}
+	if intData.Inner.Cmp(big.NewInt(1)) != 0 {
+		t.Fatalf("expected 1, got %v", intData.Inner)
+	}
+}
+
 func TestSndPairBuiltin(t *testing.T) {
 	m := NewMachine[syn.DeBruijn](lang.LanguageVersionV3, 0, nil)
 
@@ -1275,6 +1404,30 @@ func TestSndPairBuiltin(t *testing.T) {
 	}
 }
 
+func TestSndPairBuiltinOnConstantDataPair(t *testing.T) {
+	m := newTestMachine()
+	b := newTestBuiltin(builtin.SndPair)
+
+	pair := &syn.ProtoPair{
+		FstType: &syn.TData{},
+		SndType: &syn.TData{},
+		First:   &syn.Data{Inner: &data.Integer{Inner: big.NewInt(1)}},
+		Second:  &syn.Data{Inner: &data.ByteString{Inner: []byte("two")}},
+	}
+
+	b = b.ApplyArg(&Constant{pair})
+
+	val := evalBuiltin(t, m, b)
+	dataConst := expectMaterializedData(t, val)
+	bytesData, ok := dataConst.Inner.(*data.ByteString)
+	if !ok {
+		t.Fatalf("expected ByteString data, got %T", dataConst.Inner)
+	}
+	if string(bytesData.Inner) != "two" {
+		t.Fatalf("expected two, got %q", string(bytesData.Inner))
+	}
+}
+
 func TestConstrDataBuiltin(t *testing.T) {
 	m := NewMachine[syn.DeBruijn](lang.LanguageVersionV3, 0, nil)
 
@@ -1302,15 +1455,7 @@ func TestConstrDataBuiltin(t *testing.T) {
 		t.Fatalf("evalBuiltinApp returned error: %v", err)
 	}
 
-	constVal, ok := val.(*Constant)
-	if !ok {
-		t.Fatalf("expected Constant result, got %T", val)
-	}
-
-	dataConst, ok := constVal.Constant.(*syn.Data)
-	if !ok {
-		t.Fatalf("expected Data constant, got %T", constVal.Constant)
-	}
+	dataConst := expectMaterializedData(t, val)
 
 	// Should be a constructor data type
 	constrData, ok := dataConst.Inner.(*data.Constr)
@@ -1320,6 +1465,30 @@ func TestConstrDataBuiltin(t *testing.T) {
 
 	if constrData.Tag != 0 {
 		t.Fatalf("expected constructor 0, got %d", constrData.Tag)
+	}
+}
+
+func TestConstrDataBuiltinRejectsTagAboveMaxInt64(t *testing.T) {
+	m := newTestMachine()
+	b := newTestBuiltin(builtin.ConstrData)
+
+	tooLarge := new(big.Int).Add(big.NewInt(math.MaxInt64), big.NewInt(1))
+	list := &syn.ProtoList{LTyp: &syn.TData{}}
+
+	b = b.ApplyArg(&Constant{&syn.Integer{Inner: tooLarge}})
+	b = b.ApplyArg(&Constant{list})
+
+	_, err := evalBuiltinWithError(t, m, b)
+	if err == nil {
+		t.Fatal("expected overflow error for constructor tag above MaxInt64")
+	}
+
+	builtinErr, ok := err.(*BuiltinError)
+	if !ok {
+		t.Fatalf("expected BuiltinError, got %T", err)
+	}
+	if builtinErr.Code != ErrCodeOverflow {
+		t.Fatalf("expected overflow code, got %v", builtinErr.Code)
 	}
 }
 
@@ -1340,15 +1509,7 @@ func TestIDataBuiltin(t *testing.T) {
 		t.Fatalf("evalBuiltinApp returned error: %v", err)
 	}
 
-	constVal, ok := val.(*Constant)
-	if !ok {
-		t.Fatalf("expected Constant result, got %T", val)
-	}
-
-	dataConst, ok := constVal.Constant.(*syn.Data)
-	if !ok {
-		t.Fatalf("expected Data constant, got %T", constVal.Constant)
-	}
+	dataConst := expectMaterializedData(t, val)
 
 	// Should be an integer data type
 	intData, ok := dataConst.Inner.(*data.Integer)
@@ -1378,15 +1539,7 @@ func TestBDataBuiltin(t *testing.T) {
 		t.Fatalf("evalBuiltinApp returned error: %v", err)
 	}
 
-	constVal, ok := val.(*Constant)
-	if !ok {
-		t.Fatalf("expected Constant result, got %T", val)
-	}
-
-	dataConst, ok := constVal.Constant.(*syn.Data)
-	if !ok {
-		t.Fatalf("expected Data constant, got %T", constVal.Constant)
-	}
+	dataConst := expectMaterializedData(t, val)
 
 	// Should be a byte string data type
 	bsData, ok := dataConst.Inner.(*data.ByteString)
@@ -1425,15 +1578,7 @@ func TestListDataBuiltin(t *testing.T) {
 		t.Fatalf("evalBuiltinApp returned error: %v", err)
 	}
 
-	constVal, ok := val.(*Constant)
-	if !ok {
-		t.Fatalf("expected Constant result, got %T", val)
-	}
-
-	dataConst, ok := constVal.Constant.(*syn.Data)
-	if !ok {
-		t.Fatalf("expected Data constant, got %T", constVal.Constant)
-	}
+	dataConst := expectMaterializedData(t, val)
 
 	// Should be a list data type
 	listData, ok := dataConst.Inner.(*data.List)
@@ -2758,8 +2903,7 @@ func TestMkNilDataBuiltin(t *testing.T) {
 	b = b.ApplyArg(unit)
 
 	val := evalBuiltin(t, m, b)
-	constVal := expectConstant(t, val)
-	list := expectProtoList(t, constVal)
+	list := expectMaterializedProtoList(t, val)
 
 	if len(list.List) != 0 {
 		t.Errorf("expected empty list, got %d elements", len(list.List))
@@ -2780,8 +2924,7 @@ func TestMkNilPairDataBuiltin(t *testing.T) {
 	b = b.ApplyArg(unit)
 
 	val := evalBuiltin(t, m, b)
-	constVal := expectConstant(t, val)
-	list := expectProtoList(t, constVal)
+	list := expectMaterializedProtoList(t, val)
 
 	if len(list.List) != 0 {
 		t.Errorf("expected empty list, got %d elements", len(list.List))
@@ -2815,8 +2958,7 @@ func TestMkPairDataBuiltin(t *testing.T) {
 	b = b.ApplyArg(v2)
 
 	val := evalBuiltin(t, m, b)
-	constVal := expectConstant(t, val)
-	pair := expectProtoPair(t, constVal)
+	pair := expectMaterializedProtoPair(t, val)
 
 	// Check the values
 	fstData, ok := pair.First.(*syn.Data)
@@ -2945,8 +3087,14 @@ func TestUnListDataBuiltin(t *testing.T) {
 	b = b.ApplyArg(v1)
 
 	val := evalBuiltin(t, m, b)
-	constVal := expectConstant(t, val)
-	protoList := expectProtoList(t, constVal)
+	constVal, ok := materializeConstantValue[syn.DeBruijn](val)
+	if !ok {
+		t.Fatalf("expected list-like constant result, got %T", val)
+	}
+	protoList, ok := constVal.(*syn.ProtoList)
+	if !ok {
+		t.Fatalf("expected ProtoList constant, got %T", constVal)
+	}
 
 	if len(protoList.List) != 3 {
 		t.Errorf("expected list of length 3, got %d", len(protoList.List))
@@ -2990,8 +3138,14 @@ func TestUnMapDataBuiltin(t *testing.T) {
 	b = b.ApplyArg(v1)
 
 	val := evalBuiltin(t, m, b)
-	constVal := expectConstant(t, val)
-	protoList := expectProtoList(t, constVal)
+	constVal, ok := materializeConstantValue[syn.DeBruijn](val)
+	if !ok {
+		t.Fatalf("expected list-like constant result, got %T", val)
+	}
+	protoList, ok := constVal.(*syn.ProtoList)
+	if !ok {
+		t.Fatalf("expected ProtoList constant, got %T", constVal)
+	}
 
 	if len(protoList.List) != 2 {
 		t.Errorf("expected list of length 2, got %d", len(protoList.List))
@@ -3030,6 +3184,158 @@ func TestUnMapDataBuiltin(t *testing.T) {
 	}
 }
 
+func TestMkConsBuiltinOnDataListValue(t *testing.T) {
+	m := newTestMachine()
+	b := newTestBuiltin(builtin.MkCons)
+
+	head := m.allocDataValue(&data.Integer{Inner: big.NewInt(0)})
+	tail := m.allocDataListValue([]data.PlutusData{
+		&data.Integer{Inner: big.NewInt(1)},
+		&data.Integer{Inner: big.NewInt(2)},
+	})
+
+	b = b.ApplyArg(head)
+	b = b.ApplyArg(tail)
+
+	val := evalBuiltin(t, m, b)
+	protoList := expectMaterializedProtoList(t, val)
+	if len(protoList.List) != 3 {
+		t.Fatalf("expected list with 3 elements, got %d", len(protoList.List))
+	}
+	first, ok := protoList.List[0].(*syn.Data)
+	if !ok {
+		t.Fatalf("expected first element Data, got %T", protoList.List[0])
+	}
+	firstInt, ok := first.Inner.(*data.Integer)
+	if !ok {
+		t.Fatalf("expected first inner Integer, got %T", first.Inner)
+	}
+	if firstInt.Inner.Cmp(big.NewInt(0)) != 0 {
+		t.Fatalf("expected first value 0, got %v", firstInt.Inner)
+	}
+}
+
+func TestHeadListBuiltinOnDataMapValue(t *testing.T) {
+	m := newTestMachine()
+	b := newTestBuiltin(builtin.HeadList)
+
+	mapList := m.allocDataMapValue([][2]data.PlutusData{
+		{
+			&data.Integer{Inner: big.NewInt(1)},
+			&data.ByteString{Inner: []byte("one")},
+		},
+		{
+			&data.Integer{Inner: big.NewInt(2)},
+			&data.ByteString{Inner: []byte("two")},
+		},
+	})
+
+	b = b.ApplyArg(mapList)
+
+	val := evalBuiltin(t, m, b)
+	pair := expectMaterializedProtoPair(t, val)
+
+	keyData, ok := pair.First.(*syn.Data)
+	if !ok {
+		t.Fatalf("expected first to be Data, got %T", pair.First)
+	}
+	keyInt, ok := keyData.Inner.(*data.Integer)
+	if !ok {
+		t.Fatalf("expected key to be Integer, got %T", keyData.Inner)
+	}
+	if keyInt.Inner.Cmp(big.NewInt(1)) != 0 {
+		t.Fatalf("expected key 1, got %v", keyInt.Inner)
+	}
+
+	valData, ok := pair.Second.(*syn.Data)
+	if !ok {
+		t.Fatalf("expected second to be Data, got %T", pair.Second)
+	}
+	valBS, ok := valData.Inner.(*data.ByteString)
+	if !ok {
+		t.Fatalf("expected value to be ByteString, got %T", valData.Inner)
+	}
+	if string(valBS.Inner) != "one" {
+		t.Fatalf("expected value 'one', got %q", string(valBS.Inner))
+	}
+}
+
+func TestTailListBuiltinOnDataMapValue(t *testing.T) {
+	m := newTestMachine()
+	b := newTestBuiltin(builtin.TailList)
+
+	mapList := m.allocDataMapValue([][2]data.PlutusData{
+		{
+			&data.Integer{Inner: big.NewInt(1)},
+			&data.ByteString{Inner: []byte("one")},
+		},
+		{
+			&data.Integer{Inner: big.NewInt(2)},
+			&data.ByteString{Inner: []byte("two")},
+		},
+	})
+
+	b = b.ApplyArg(mapList)
+
+	val := evalBuiltin(t, m, b)
+	protoList := expectMaterializedProtoList(t, val)
+	if len(protoList.List) != 1 {
+		t.Fatalf("expected tail list of length 1, got %d", len(protoList.List))
+	}
+
+	pair, ok := protoList.List[0].(*syn.ProtoPair)
+	if !ok {
+		t.Fatalf("expected pair element, got %T", protoList.List[0])
+	}
+	keyData, ok := pair.First.(*syn.Data)
+	if !ok {
+		t.Fatalf("expected first to be Data, got %T", pair.First)
+	}
+	keyInt, ok := keyData.Inner.(*data.Integer)
+	if !ok {
+		t.Fatalf("expected key to be Integer, got %T", keyData.Inner)
+	}
+	if keyInt.Inner.Cmp(big.NewInt(2)) != 0 {
+		t.Fatalf("expected key 2, got %v", keyInt.Inner)
+	}
+}
+
+func TestMapDataBuiltinOnDataMapValue(t *testing.T) {
+	m := newTestMachine()
+	b := newTestBuiltin(builtin.MapData)
+
+	mapList := m.allocDataMapValue([][2]data.PlutusData{
+		{
+			&data.Integer{Inner: big.NewInt(1)},
+			&data.ByteString{Inner: []byte("one")},
+		},
+		{
+			&data.Integer{Inner: big.NewInt(2)},
+			&data.ByteString{Inner: []byte("two")},
+		},
+	})
+
+	b = b.ApplyArg(mapList)
+
+	val := evalBuiltin(t, m, b)
+	dataConst := expectMaterializedData(t, val)
+	dataMap, ok := dataConst.Inner.(*data.Map)
+	if !ok {
+		t.Fatalf("expected Data Map, got %T", dataConst.Inner)
+	}
+	if len(dataMap.Pairs) != 2 {
+		t.Fatalf("expected map with 2 pairs, got %d", len(dataMap.Pairs))
+	}
+
+	keyInt, ok := dataMap.Pairs[0][0].(*data.Integer)
+	if !ok {
+		t.Fatalf("expected first key Integer, got %T", dataMap.Pairs[0][0])
+	}
+	if keyInt.Inner.Cmp(big.NewInt(1)) != 0 {
+		t.Fatalf("expected first key 1, got %v", keyInt.Inner)
+	}
+}
+
 func TestMapDataBuiltin(t *testing.T) {
 	m := newTestMachine()
 	b := newTestBuiltin(builtin.MapData)
@@ -3061,8 +3367,7 @@ func TestMapDataBuiltin(t *testing.T) {
 	b = b.ApplyArg(v1)
 
 	val := evalBuiltin(t, m, b)
-	constVal := expectConstant(t, val)
-	resultData := expectData(t, constVal)
+	resultData := expectMaterializedData(t, val)
 	resultMap, ok := resultData.Inner.(*data.Map)
 	if !ok {
 		t.Fatalf("expected Map, got %T", resultData.Inner)

--- a/cek/machine.go
+++ b/cek/machine.go
@@ -105,6 +105,14 @@ type Machine[T syn.Eval] struct {
 	protoListChunkPos      int
 	protoPairChunks        [][]syn.ProtoPair
 	protoPairChunkPos      int
+	dataValueChunks        [][]dataValue[T]
+	dataValueChunkPos      int
+	dataListValueChunks    [][]dataListValue[T]
+	dataListValueChunkPos  int
+	dataMapValueChunks     [][]dataMapValue[T]
+	dataMapValueChunkPos   int
+	pairValueChunks        [][]pairValue[T]
+	pairValueChunkPos      int
 	constantElemChunks     [][]syn.IConstant
 	constantElemChunkPos   int
 	valueElemChunks        [][]Value[T]
@@ -121,9 +129,11 @@ type Machine[T syn.Eval] struct {
 }
 
 const (
-	envChunkSize          = 8192
+	envChunkSize          = 2048
 	envRetainChunkCap     = 8
-	valueChunkSize        = 4096
+	valueChunkSize        = 512
+	valueElemChunkSize    = 1024
+	valueRetainChunkCap   = 8
 	constantElemChunkSize = 4096
 	int64ConstantCacheCap = 4096
 )
@@ -345,6 +355,30 @@ func clearArenaChunks[S any](chunks [][]S, usedTotal int) {
 	}
 }
 
+func resetArenaChunks[S any](
+	chunks *[][]S,
+	pos *int,
+	retainCap int,
+) {
+	retainedUsed := *pos
+	if len(*chunks) > retainCap {
+		maxRetained := 0
+		for i := range retainCap {
+			maxRetained += len((*chunks)[i])
+		}
+		if retainedUsed > maxRetained {
+			retainedUsed = maxRetained
+		}
+	}
+	clearArenaChunks(*chunks, retainedUsed)
+	if len(*chunks) > retainCap {
+		retained := make([][]S, retainCap)
+		copy(retained, (*chunks)[:retainCap])
+		*chunks = retained
+	}
+	*pos = 0
+}
+
 func (m *Machine[T]) allocDelay(term *syn.Delay[T], env *Env[T]) *Delay[T] {
 	delay := allocArenaSlot(&m.delayChunks, &m.delayChunkPos)
 	delay.AST = term
@@ -411,6 +445,48 @@ func (m *Machine[T]) allocProtoPairConstant(
 	return pairConstant
 }
 
+func (m *Machine[T]) allocDataListValue(
+	items []data.PlutusData,
+) *dataListValue[T] {
+	listValue := allocArenaSlot(&m.dataListValueChunks, &m.dataListValueChunkPos)
+	listValue.items = items
+	return listValue
+}
+
+func (m *Machine[T]) allocDataValue(item data.PlutusData) *dataValue[T] {
+	dataVal := allocArenaSlot(&m.dataValueChunks, &m.dataValueChunkPos)
+	dataVal.item = item
+	return dataVal
+}
+
+func (m *Machine[T]) allocDataMapValue(
+	items [][2]data.PlutusData,
+) *dataMapValue[T] {
+	listValue := allocArenaSlot(&m.dataMapValueChunks, &m.dataMapValueChunkPos)
+	listValue.items = items
+	return listValue
+}
+
+func (m *Machine[T]) allocDataPairValue(
+	first data.PlutusData,
+	second data.PlutusData,
+) *pairValue[T] {
+	return m.allocPairValue(
+		m.allocDataValue(first),
+		m.allocDataValue(second),
+	)
+}
+
+func (m *Machine[T]) allocPairValue(
+	first Value[T],
+	second Value[T],
+) *pairValue[T] {
+	pair := allocArenaSlot(&m.pairValueChunks, &m.pairValueChunkPos)
+	pair.first = first
+	pair.second = second
+	return pair
+}
+
 func (m *Machine[T]) allocConstantElems(n int) []syn.IConstant {
 	return allocArenaSlice(
 		&m.constantElemChunks,
@@ -425,7 +501,7 @@ func (m *Machine[T]) allocValueElems(n int) []Value[T] {
 		&m.valueElemChunks,
 		&m.valueElemChunkPos,
 		n,
-		valueChunkSize,
+		valueElemChunkSize,
 	)
 }
 
@@ -533,7 +609,6 @@ func NewMachine[T syn.Eval](
 		freeFrameForce:         make([]*FrameForce[T], 0, 16),
 		freeFrameConstr:        make([]*FrameConstr[T], 0, 16),
 		freeFrameCases:         make([]*FrameCases[T], 0, 16),
-		dynamicIntConstants:    make(map[int64]*Constant, 512),
 		constrChunks:           make([][]Constr[T], 0, 8),
 		constrChunkPos:         0,
 		delayChunks:            make([][]Delay[T], 0, 8),
@@ -552,6 +627,14 @@ func NewMachine[T syn.Eval](
 		protoListChunkPos:      0,
 		protoPairChunks:        make([][]syn.ProtoPair, 0, 8),
 		protoPairChunkPos:      0,
+		dataValueChunks:        make([][]dataValue[T], 0, 8),
+		dataValueChunkPos:      0,
+		dataListValueChunks:    make([][]dataListValue[T], 0, 8),
+		dataListValueChunkPos:  0,
+		dataMapValueChunks:     make([][]dataMapValue[T], 0, 8),
+		dataMapValueChunkPos:   0,
+		pairValueChunks:        make([][]pairValue[T], 0, 8),
+		pairValueChunkPos:      0,
 		constantElemChunks:     make([][]syn.IConstant, 0, 8),
 		constantElemChunkPos:   0,
 		valueElemChunks:        make([][]Value[T], 0, 8),
@@ -617,32 +700,23 @@ func (m *Machine[T]) resetEnvArena() {
 }
 
 func (m *Machine[T]) resetValueArenas() {
-	clearArenaChunks(m.constrChunks, m.constrChunkPos)
-	m.constrChunkPos = 0
-	clearArenaChunks(m.delayChunks, m.delayChunkPos)
-	m.delayChunkPos = 0
-	clearArenaChunks(m.lambdaChunks, m.lambdaChunkPos)
-	m.lambdaChunkPos = 0
-	clearArenaChunks(m.constantChunks, m.constantChunkPos)
-	m.constantChunkPos = 0
-	clearArenaChunks(m.dataChunks, m.dataChunkPos)
-	m.dataChunkPos = 0
-	clearArenaChunks(m.integerChunks, m.integerChunkPos)
-	m.integerChunkPos = 0
-	clearArenaChunks(m.byteStringChunks, m.byteStringChunkPos)
-	m.byteStringChunkPos = 0
-	clearArenaChunks(m.protoListChunks, m.protoListChunkPos)
-	m.protoListChunkPos = 0
-	clearArenaChunks(m.protoPairChunks, m.protoPairChunkPos)
-	m.protoPairChunkPos = 0
-	clearArenaChunks(m.constantElemChunks, m.constantElemChunkPos)
-	m.constantElemChunkPos = 0
-	clearArenaChunks(m.valueElemChunks, m.valueElemChunkPos)
-	m.valueElemChunkPos = 0
-	clearArenaChunks(m.builtinChunks, m.builtinChunkPos)
-	m.builtinChunkPos = 0
-	clearArenaChunks(m.builtinArgChunks, m.builtinArgChunkPos)
-	m.builtinArgChunkPos = 0
+	resetArenaChunks(&m.constrChunks, &m.constrChunkPos, valueRetainChunkCap)
+	resetArenaChunks(&m.delayChunks, &m.delayChunkPos, valueRetainChunkCap)
+	resetArenaChunks(&m.lambdaChunks, &m.lambdaChunkPos, valueRetainChunkCap)
+	resetArenaChunks(&m.constantChunks, &m.constantChunkPos, valueRetainChunkCap)
+	resetArenaChunks(&m.dataChunks, &m.dataChunkPos, valueRetainChunkCap)
+	resetArenaChunks(&m.integerChunks, &m.integerChunkPos, valueRetainChunkCap)
+	resetArenaChunks(&m.byteStringChunks, &m.byteStringChunkPos, valueRetainChunkCap)
+	resetArenaChunks(&m.protoListChunks, &m.protoListChunkPos, valueRetainChunkCap)
+	resetArenaChunks(&m.protoPairChunks, &m.protoPairChunkPos, valueRetainChunkCap)
+	resetArenaChunks(&m.dataValueChunks, &m.dataValueChunkPos, valueRetainChunkCap)
+	resetArenaChunks(&m.dataListValueChunks, &m.dataListValueChunkPos, valueRetainChunkCap)
+	resetArenaChunks(&m.dataMapValueChunks, &m.dataMapValueChunkPos, valueRetainChunkCap)
+	resetArenaChunks(&m.pairValueChunks, &m.pairValueChunkPos, valueRetainChunkCap)
+	resetArenaChunks(&m.constantElemChunks, &m.constantElemChunkPos, valueRetainChunkCap)
+	resetArenaChunks(&m.valueElemChunks, &m.valueElemChunkPos, valueRetainChunkCap)
+	resetArenaChunks(&m.builtinChunks, &m.builtinChunkPos, valueRetainChunkCap)
+	resetArenaChunks(&m.builtinArgChunks, &m.builtinArgChunkPos, valueRetainChunkCap)
 }
 
 func (m *Machine[T]) finishReturn(ret *Return[T]) (syn.Term[T], error) {
@@ -657,7 +731,7 @@ func (m *Machine[T]) finishValue(value Value[T]) (syn.Term[T], error) {
 			return nil, err
 		}
 	}
-	return dischargeValue[T](value), nil
+	return dischargeValue[T](value)
 }
 
 // Run executes a Plutus term using the CEK (Control, Environment, Kontinuation) abstract machine.
@@ -1077,6 +1151,72 @@ func (m *Machine[T]) caseEvaluate(
 			return comp, nil
 		}
 		return nil, &ScriptError{Code: ErrCodeMissingCaseBranch, Message: "MissingCaseBranch"}
+	case *dataListValue[T]:
+		if len(v.items) == 0 {
+			if len(branches) != 2 && len(branches) != 1 {
+				return nil, &ScriptError{Code: ErrCodeInvalidBranchCount, Message: "InvalidCaseBranchCount"}
+			}
+			if !indexExists(branches, 1) {
+				return nil, &ScriptError{Code: ErrCodeMissingCaseBranch, Message: "MissingCaseBranch"}
+			}
+			comp := m.getCompute()
+			comp.Ctx = context
+			comp.Env = env
+			comp.Term = branches[1]
+			return comp, nil
+		}
+
+		if len(branches) < 1 || len(branches) > 2 {
+			return nil, &ScriptError{Code: ErrCodeInvalidBranchCount, Message: "InvalidCaseBranchCount"}
+		}
+
+		args := m.allocValueElems(2)
+		args[0] = m.allocDataValue(v.items[0])
+		args[1] = m.allocDataListValue(v.items[1:])
+		comp := m.getCompute()
+		comp.Ctx = m.transferArgStack(args, context)
+		comp.Env = env
+		comp.Term = branches[0]
+		return comp, nil
+	case *dataMapValue[T]:
+		if len(v.items) == 0 {
+			if len(branches) != 2 && len(branches) != 1 {
+				return nil, &ScriptError{Code: ErrCodeInvalidBranchCount, Message: "InvalidCaseBranchCount"}
+			}
+			if !indexExists(branches, 1) {
+				return nil, &ScriptError{Code: ErrCodeMissingCaseBranch, Message: "MissingCaseBranch"}
+			}
+			comp := m.getCompute()
+			comp.Ctx = context
+			comp.Env = env
+			comp.Term = branches[1]
+			return comp, nil
+		}
+
+		if len(branches) < 1 || len(branches) > 2 {
+			return nil, &ScriptError{Code: ErrCodeInvalidBranchCount, Message: "InvalidCaseBranchCount"}
+		}
+
+		args := m.allocValueElems(2)
+		args[0] = m.allocDataPairValue(v.items[0][0], v.items[0][1])
+		args[1] = m.allocDataMapValue(v.items[1:])
+		comp := m.getCompute()
+		comp.Ctx = m.transferArgStack(args, context)
+		comp.Env = env
+		comp.Term = branches[0]
+		return comp, nil
+	case *pairValue[T]:
+		if len(branches) != 1 {
+			return nil, &ScriptError{Code: ErrCodeInvalidBranchCount, Message: "InvalidCaseBranchCount"}
+		}
+		args := m.allocValueElems(2)
+		args[0] = v.first
+		args[1] = v.second
+		comp := m.getCompute()
+		comp.Ctx = m.transferArgStack(args, context)
+		comp.Env = env
+		comp.Term = branches[0]
+		return comp, nil
 	default:
 		return nil, &TypeError{Code: ErrCodeNonConstrScrutinized, Message: "NonConstrScrutinized"}
 	}
@@ -1355,12 +1495,25 @@ func (m *Machine[T]) transferArgStack(
 //
 // This function is crucial for producing the final result when evaluation
 // reaches the Done state, ensuring the output is a valid Plutus term.
-func dischargeValue[T syn.Eval](value Value[T]) syn.Term[T] {
-	var dischargedTerm syn.Term[T]
-
+func dischargeValue[T syn.Eval](value Value[T]) (syn.Term[T], error) {
 	switch v := value.(type) {
 	case *Constant:
-		dischargedTerm = constantTerm[T](v.Constant)
+		return constantTerm[T](v.Constant), nil
+	case *dataValue[T]:
+		return constantTerm[T](&syn.Data{Inner: v.item}), nil
+	case *dataListValue[T]:
+		return constantTerm[T](materializeDataListConstant(v.items)), nil
+	case *dataMapValue[T]:
+		return constantTerm[T](materializeDataMapConstant(v.items)), nil
+	case *pairValue[T]:
+		constant, ok := materializeConstantValue[T](v)
+		if !ok {
+			return nil, &InternalError{
+				Code:    ErrCodeInternalError,
+				Message: fmt.Sprintf("cannot discharge non-constant pair value: %T", v),
+			}
+		}
+		return constantTerm[T](constant), nil
 	case *Builtin[T]:
 		// Reconstruct the term that represents this builtin application
 		var forcedTerm syn.Term[T]
@@ -1378,41 +1531,61 @@ func dischargeValue[T syn.Eval](value Value[T]) syn.Term[T] {
 
 		// Add applications for each argument
 		for arg := range v.Args.Iter() {
+			discharged, err := dischargeValue[T](arg)
+			if err != nil {
+				return nil, err
+			}
 			forcedTerm = &syn.Apply[T]{
 				Function: forcedTerm,
-				Argument: dischargeValue[T](arg),
+				Argument: discharged,
 			}
 		}
 
-		dischargedTerm = forcedTerm
+		return forcedTerm, nil
 	case *Delay[T]:
 		// Discharge delayed computation with environment
-		dischargedTerm = &syn.Delay[T]{
-			Term: withEnv(0, v.Env, v.AST.Term),
+		body, err := withEnv(0, v.Env, v.AST.Term)
+		if err != nil {
+			return nil, err
 		}
+		return &syn.Delay[T]{Term: body}, nil
 
 	case *Lambda[T]:
 		// Discharge lambda with environment (lamCnt=1 to account for parameter)
-		dischargedTerm = &syn.Lambda[T]{
-			ParameterName: v.AST.ParameterName,
-			Body:          withEnv(1, v.Env, v.AST.Body),
+		body, err := withEnv(1, v.Env, v.AST.Body)
+		if err != nil {
+			return nil, err
 		}
+		return &syn.Lambda[T]{
+			ParameterName: v.AST.ParameterName,
+			Body:          body,
+		}, nil
 
 	case *Constr[T]:
 		// Recursively discharge all constructor fields
 		fields := make([]syn.Term[T], len(v.Fields))
 
 		for i, f := range v.Fields {
-			fields[i] = dischargeValue[T](f)
+			discharged, err := dischargeValue[T](f)
+			if err != nil {
+				return nil, err
+			}
+			fields[i] = discharged
 		}
 
-		dischargedTerm = &syn.Constr[T]{
+		return &syn.Constr[T]{
 			Tag:    v.Tag,
 			Fields: fields,
-		}
+		}, nil
 	}
 
-	return dischargedTerm
+	return nil, &InternalError{
+		Code: ErrCodeInternalError,
+		Message: fmt.Sprintf(
+			"unsupported value kind in dischargeValue: %T",
+			value,
+		),
+	}
 }
 
 // withEnv discharges a term while substituting values from an environment.
@@ -1430,81 +1603,102 @@ func withEnv[T syn.Eval](
 	lamCnt int,
 	env *Env[T],
 	term syn.Term[T],
-) syn.Term[T] {
-	var dischargedTerm syn.Term[T]
-
+) (syn.Term[T], error) {
 	switch t := term.(type) {
 	case *syn.Var[T]:
 		// Variable resolution with de Bruijn index adjustment
 		if lamCnt >= t.Name.LookupIndex() {
 			// Variable is bound by a lambda we haven't discharged yet
-			dischargedTerm = t
-		} else {
-			value, ok := lookupEnv(env, t.Name.LookupIndex()-lamCnt)
-			if ok {
-				// Variable found in environment, discharge its value
-				dischargedTerm = dischargeValue[T](value)
-			} else {
-				// Free variable (shouldn't happen in well-formed terms)
-				dischargedTerm = t
-			}
+			return t, nil
 		}
+		value, ok := lookupEnv(env, t.Name.LookupIndex()-lamCnt)
+		if ok {
+			// Variable found in environment, discharge its value
+			return dischargeValue[T](value)
+		}
+		// Free variable (shouldn't happen in well-formed terms)
+		return t, nil
 
 	case *syn.Lambda[T]:
 		// Lambda: increase lambda count for body processing
-		dischargedTerm = &syn.Lambda[T]{
-			ParameterName: t.ParameterName,
-			Body:          withEnv(lamCnt+1, env, t.Body),
+		body, err := withEnv(lamCnt+1, env, t.Body)
+		if err != nil {
+			return nil, err
 		}
+		return &syn.Lambda[T]{
+			ParameterName: t.ParameterName,
+			Body:          body,
+		}, nil
 
 	case *syn.Apply[T]:
 		// Application: process both function and argument
-		dischargedTerm = &syn.Apply[T]{
-			Function: withEnv(lamCnt, env, t.Function),
-			Argument: withEnv(lamCnt, env, t.Argument),
+		fn, err := withEnv(lamCnt, env, t.Function)
+		if err != nil {
+			return nil, err
 		}
+		arg, err := withEnv(lamCnt, env, t.Argument)
+		if err != nil {
+			return nil, err
+		}
+		return &syn.Apply[T]{
+			Function: fn,
+			Argument: arg,
+		}, nil
+
 	case *syn.Delay[T]:
 		// Delay: process delayed term
-		dischargedTerm = &syn.Delay[T]{
-			Term: withEnv(lamCnt, env, t.Term),
+		inner, err := withEnv(lamCnt, env, t.Term)
+		if err != nil {
+			return nil, err
 		}
+		return &syn.Delay[T]{Term: inner}, nil
 
 	case *syn.Force[T]:
 		// Force: process term to be forced
-		dischargedTerm = &syn.Force[T]{
-			Term: withEnv(lamCnt, env, t.Term),
+		inner, err := withEnv(lamCnt, env, t.Term)
+		if err != nil {
+			return nil, err
 		}
+		return &syn.Force[T]{Term: inner}, nil
 
 	case *syn.Constr[T]:
 		// Constructor: recursively process all fields
 		fields := make([]syn.Term[T], len(t.Fields))
-
 		for i, f := range t.Fields {
-			fields[i] = withEnv(lamCnt, env, f)
+			d, err := withEnv(lamCnt, env, f)
+			if err != nil {
+				return nil, err
+			}
+			fields[i] = d
 		}
-
-		dischargedTerm = &syn.Constr[T]{
+		return &syn.Constr[T]{
 			Tag:    t.Tag,
 			Fields: fields,
-		}
+		}, nil
+
 	case *syn.Case[T]:
 		// Case expression: process scrutinee and all branches
 		branches := make([]syn.Term[T], len(t.Branches))
-
 		for i, b := range t.Branches {
-			branches[i] = withEnv(lamCnt, env, b)
+			d, err := withEnv(lamCnt, env, b)
+			if err != nil {
+				return nil, err
+			}
+			branches[i] = d
 		}
-
-		dischargedTerm = &syn.Case[T]{
-			Constr:   withEnv(lamCnt, env, t.Constr),
+		constr, err := withEnv(lamCnt, env, t.Constr)
+		if err != nil {
+			return nil, err
+		}
+		return &syn.Case[T]{
+			Constr:   constr,
 			Branches: branches,
-		}
+		}, nil
+
 	default:
 		// Constants, builtins, errors: no environment processing needed
-		dischargedTerm = t
+		return t, nil
 	}
-
-	return dischargedTerm
 }
 
 func (m *Machine[T]) stepAndMaybeSpend(step StepKind) error {

--- a/cek/machine_test.go
+++ b/cek/machine_test.go
@@ -2,12 +2,21 @@ package cek
 
 import (
 	"math/big"
+	"strings"
 	"testing"
 	"unsafe"
 
 	"github.com/blinklabs-io/plutigo/lang"
 	"github.com/blinklabs-io/plutigo/syn"
 )
+
+type unsupportedDischargeValue struct{}
+
+func (unsupportedDischargeValue) String() string { return "unsupportedDischargeValue" }
+
+func (unsupportedDischargeValue) toExMem() ExMem { return 0 }
+
+func (unsupportedDischargeValue) isValue() {}
 
 func TestSmokeBuild(t *testing.T) {
 	// Ensure the package builds and a CEK machine can be allocated.
@@ -327,5 +336,18 @@ func TestRunResetsFrameStackAcrossInvocations(t *testing.T) {
 	}
 	if hidden[0].value != nil || hidden[0].env != nil || hidden[0].term != nil {
 		t.Fatalf("frameStack[0] retained stale data: %+v", hidden[0])
+	}
+}
+
+func TestDischargeValueUnsupportedValueReturnsInternalError(t *testing.T) {
+	_, err := dischargeValue[syn.DeBruijn](unsupportedDischargeValue{})
+	if err == nil {
+		t.Fatal("expected internal error for unsupported value kind")
+	}
+	if !IsInternalError(err) {
+		t.Fatalf("expected InternalError, got %T", err)
+	}
+	if !strings.Contains(err.Error(), "unsupportedDischargeValue") {
+		t.Fatalf("expected error to mention unsupported value type, got %q", err.Error())
 	}
 }

--- a/cek/runtime.go
+++ b/cek/runtime.go
@@ -572,33 +572,74 @@ func unwrapList[T syn.Eval](
 		default:
 			return nil, &TypeError{Code: ErrCodeTypeMismatch, Expected: "List", Got: fmt.Sprintf("%T", v.Constant), Message: "type mismatch"}
 		}
+	case *dataListValue[T]:
+		if typ != nil && !syn.EqualType(typ, sharedDataType) {
+			return nil, &TypeError{
+				Code:    ErrCodeTypeMismatch,
+				Message: fmt.Sprintf("Value not a List of type %T", typ),
+			}
+		}
+		i = materializeDataListConstant(v.items)
+	case *dataMapValue[T]:
+		if typ != nil && !syn.EqualType(typ, sharedPairDataType) {
+			return nil, &TypeError{
+				Code:    ErrCodeTypeMismatch,
+				Message: fmt.Sprintf("Value not a List of type %T", typ),
+			}
+		}
+		i = materializeDataMapConstant(v.items)
 	default:
-		return nil, &TypeError{Code: ErrCodeTypeMismatch, Expected: "Constant List", Got: fmt.Sprintf("%T", value), Message: "type mismatch"}
+		return nil, &TypeError{Code: ErrCodeTypeMismatch, Expected: "List", Got: fmt.Sprintf("%T", value), Message: "type mismatch"}
 	}
 
 	return i, nil
 }
 
-func unwrapPair[T syn.Eval](
+func splitPairValue[T syn.Eval](
+	m *Machine[T],
 	value Value[T],
-) (syn.IConstant, syn.IConstant, error) {
-	var i syn.IConstant
-	var j syn.IConstant
+) (Value[T], Value[T], error) {
+	var i Value[T]
+	var j Value[T]
 
 	switch v := value.(type) {
 	case *Constant:
 		switch c := v.Constant.(type) {
 		case *syn.ProtoPair:
-			i = c.First
-			j = c.Second
+			i = dataAwareConstantValue(m, c.First)
+			j = dataAwareConstantValue(m, c.Second)
 		default:
 			return nil, nil, &TypeError{Code: ErrCodeTypeMismatch, Expected: "Pair", Got: fmt.Sprintf("%T", v.Constant), Message: "type mismatch"}
 		}
+	case *pairValue[T]:
+		i = v.first
+		j = v.second
 	default:
-		return nil, nil, &TypeError{Code: ErrCodeTypeMismatch, Expected: "Constant Pair", Got: fmt.Sprintf("%T", value), Message: "type mismatch"}
+		return nil, nil, &TypeError{Code: ErrCodeTypeMismatch, Expected: "Pair", Got: fmt.Sprintf("%T", value), Message: "type mismatch"}
 	}
 
 	return i, j, nil
+}
+
+func dataAwareConstantValue[T syn.Eval](
+	m *Machine[T],
+	constant syn.IConstant,
+) Value[T] {
+	switch c := constant.(type) {
+	case *syn.Data:
+		return m.allocDataValue(c.Inner)
+	case *syn.ProtoPair:
+		first, ok := c.First.(*syn.Data)
+		if !ok {
+			break
+		}
+		second, ok := c.Second.(*syn.Data)
+		if !ok {
+			break
+		}
+		return m.allocDataPairValue(first.Inner, second.Inner)
+	}
+	return machineConstantValue(m, constant)
 }
 
 func unwrapData[T syn.Eval](value Value[T]) (data.PlutusData, error) {
@@ -612,8 +653,10 @@ func unwrapData[T syn.Eval](value Value[T]) (data.PlutusData, error) {
 		default:
 			return nil, &TypeError{Code: ErrCodeTypeMismatch, Expected: "Data", Got: fmt.Sprintf("%T", v.Constant), Message: "type mismatch"}
 		}
+	case *dataValue[T]:
+		i = v.item
 	default:
-		return nil, &TypeError{Code: ErrCodeTypeMismatch, Expected: "Constant Data", Got: fmt.Sprintf("%T", value), Message: "type mismatch"}
+		return nil, &TypeError{Code: ErrCodeTypeMismatch, Expected: "Data", Got: fmt.Sprintf("%T", value), Message: "type mismatch"}
 	}
 
 	return i, nil

--- a/cek/stack_machine.go
+++ b/cek/stack_machine.go
@@ -1035,6 +1035,60 @@ func (m *Machine[T]) caseEvaluateStack(
 
 		m.pushApplyFrames(args)
 		return branches[tag], env, nil, false, nil
+	case *dataListValue[T]:
+		if len(branches) < 1 || len(branches) > 2 {
+			return nil, nil, nil, false, &ScriptError{
+				Code:    ErrCodeInvalidBranchCount,
+				Message: "InvalidCaseBranchCount",
+			}
+		}
+		if len(v.items) == 0 {
+			if !indexExists(branches, 1) {
+				return nil, nil, nil, false, &ScriptError{
+					Code:    ErrCodeMissingCaseBranch,
+					Message: "MissingCaseBranch",
+				}
+			}
+			return branches[1], env, nil, false, nil
+		}
+		args := m.allocValueElems(2)
+		args[0] = m.allocDataValue(v.items[0])
+		args[1] = m.allocDataListValue(v.items[1:])
+		m.pushApplyFrames(args)
+		return branches[0], env, nil, false, nil
+	case *dataMapValue[T]:
+		if len(branches) < 1 || len(branches) > 2 {
+			return nil, nil, nil, false, &ScriptError{
+				Code:    ErrCodeInvalidBranchCount,
+				Message: "InvalidCaseBranchCount",
+			}
+		}
+		if len(v.items) == 0 {
+			if !indexExists(branches, 1) {
+				return nil, nil, nil, false, &ScriptError{
+					Code:    ErrCodeMissingCaseBranch,
+					Message: "MissingCaseBranch",
+				}
+			}
+			return branches[1], env, nil, false, nil
+		}
+		args := m.allocValueElems(2)
+		args[0] = m.allocDataPairValue(v.items[0][0], v.items[0][1])
+		args[1] = m.allocDataMapValue(v.items[1:])
+		m.pushApplyFrames(args)
+		return branches[0], env, nil, false, nil
+	case *pairValue[T]:
+		if len(branches) != 1 {
+			return nil, nil, nil, false, &ScriptError{
+				Code:    ErrCodeInvalidBranchCount,
+				Message: "InvalidCaseBranchCount",
+			}
+		}
+		args := m.allocValueElems(2)
+		args[0] = v.first
+		args[1] = v.second
+		m.pushApplyFrames(args)
+		return branches[0], env, nil, false, nil
 	default:
 		return nil, nil, nil, false, &TypeError{
 			Code:    ErrCodeNonConstrScrutinized,

--- a/cek/value.go
+++ b/cek/value.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"fmt"
 	"math/big"
+	"sync"
 
 	"github.com/blinklabs-io/plutigo/builtin"
+	"github.com/blinklabs-io/plutigo/data"
 	"github.com/blinklabs-io/plutigo/syn"
 )
 
@@ -35,6 +37,8 @@ var (
 		Constant: &syn.Unit{},
 	}
 	cachedIntConstants = buildCachedIntConstants()
+	sharedDynamicIntMu sync.RWMutex
+	sharedDynamicInts  = make(map[int64]*Constant, int64ConstantCacheCap)
 )
 
 func boolConstant(v bool) *Constant {
@@ -50,6 +54,10 @@ func int64Constant(v int64) *Constant {
 	if v >= cachedIntMin && v <= cachedIntMax {
 		return cachedIntConstants[v-cachedIntMin]
 	}
+	return newDynamicIntConstant(v)
+}
+
+func newDynamicIntConstant(v int64) *Constant {
 	integer := &syn.Integer{}
 	integer.SetInner(big.NewInt(v))
 	return &Constant{
@@ -57,18 +65,45 @@ func int64Constant(v int64) *Constant {
 	}
 }
 
+func loadSharedDynamicIntConstant(v int64) *Constant {
+	sharedDynamicIntMu.RLock()
+	cached := sharedDynamicInts[v]
+	sharedDynamicIntMu.RUnlock()
+	return cached
+}
+
+func storeSharedDynamicIntConstant(v int64, constant *Constant) *Constant {
+	sharedDynamicIntMu.Lock()
+	defer sharedDynamicIntMu.Unlock()
+	if cached := sharedDynamicInts[v]; cached != nil {
+		return cached
+	}
+	if len(sharedDynamicInts) >= int64ConstantCacheCap {
+		return nil
+	}
+	sharedDynamicInts[v] = constant
+	return constant
+}
+
 func (m *Machine[T]) int64Constant(v int64) *Constant {
 	if v >= cachedIntMin && v <= cachedIntMax {
 		return cachedIntConstants[v-cachedIntMin]
 	}
-	if cached := m.dynamicIntConstants[v]; cached != nil {
+	if cached := loadSharedDynamicIntConstant(v); cached != nil {
 		return cached
 	}
+	if m.dynamicIntConstants != nil {
+		if cached := m.dynamicIntConstants[v]; cached != nil {
+			return cached
+		}
+	}
 
-	integer := &syn.Integer{}
-	integer.SetInner(big.NewInt(v))
-	constant := &Constant{
-		Constant: integer,
+	constant := newDynamicIntConstant(v)
+	if shared := storeSharedDynamicIntConstant(v, constant); shared != nil {
+		return shared
+	}
+	if m.dynamicIntConstants == nil {
+		m.dynamicIntConstants = make(map[int64]*Constant, 64)
 	}
 	if len(m.dynamicIntConstants) < int64ConstantCacheCap {
 		m.dynamicIntConstants[v] = constant
@@ -76,7 +111,7 @@ func (m *Machine[T]) int64Constant(v int64) *Constant {
 	return constant
 }
 
-func machineConstantValue[T syn.Eval](m *Machine[T], constant syn.IConstant) *Constant {
+func machineConstantValue[T syn.Eval](m *Machine[T], constant syn.IConstant) Value[T] {
 	switch c := constant.(type) {
 	case *syn.Bool:
 		return boolConstant(c.Inner)
@@ -107,6 +142,71 @@ func (c Constant) toExMem() ExMem {
 	return iconstantExMem(c.Constant)()
 }
 
+type dataListValue[T syn.Eval] struct {
+	items []data.PlutusData
+}
+
+func (d dataListValue[T]) String() string {
+	return fmt.Sprintf("DataList[%d]", len(d.items))
+}
+
+func (dataListValue[T]) isValue() {}
+
+func (d dataListValue[T]) toExMem() ExMem {
+	acc := ExMem(NilCost)
+	for _, item := range d.items {
+		acc += dataExMem(item)() + ConsCost
+	}
+	return acc
+}
+
+type dataValue[T syn.Eval] struct {
+	item data.PlutusData
+}
+
+func (d dataValue[T]) String() string {
+	return fmt.Sprintf("%v", d.item)
+}
+
+func (dataValue[T]) isValue() {}
+
+func (d dataValue[T]) toExMem() ExMem {
+	return dataExMem(d.item)()
+}
+
+type dataMapValue[T syn.Eval] struct {
+	items [][2]data.PlutusData
+}
+
+func (d dataMapValue[T]) String() string {
+	return fmt.Sprintf("DataMapList[%d]", len(d.items))
+}
+
+func (dataMapValue[T]) isValue() {}
+
+func (d dataMapValue[T]) toExMem() ExMem {
+	acc := ExMem(NilCost)
+	for _, item := range d.items {
+		acc += ExMem(PairCost) + dataExMem(item[0])() + dataExMem(item[1])() + ConsCost
+	}
+	return acc
+}
+
+type pairValue[T syn.Eval] struct {
+	first  Value[T]
+	second Value[T]
+}
+
+func (p pairValue[T]) String() string {
+	return fmt.Sprintf("Pair[%T,%T]", p.first, p.second)
+}
+
+func (pairValue[T]) isValue() {}
+
+func (p pairValue[T]) toExMem() ExMem {
+	return ExMem(PairCost) + p.first.toExMem() + p.second.toExMem()
+}
+
 func buildCachedIntConstants() []*Constant {
 	ret := make([]*Constant, cachedIntMax-cachedIntMin+1)
 	for i := int64(cachedIntMin); i <= cachedIntMax; i++ {
@@ -117,6 +217,63 @@ func buildCachedIntConstants() []*Constant {
 		}
 	}
 	return ret
+}
+
+func materializeDataListConstant(items []data.PlutusData) *syn.ProtoList {
+	list := make([]syn.IConstant, len(items))
+	for i, item := range items {
+		list[i] = &syn.Data{Inner: item}
+	}
+	return &syn.ProtoList{
+		LTyp: sharedDataType,
+		List: list,
+	}
+}
+
+func materializeDataMapConstant(items [][2]data.PlutusData) *syn.ProtoList {
+	list := make([]syn.IConstant, len(items))
+	for i, item := range items {
+		list[i] = &syn.ProtoPair{
+			FstType: sharedDataType,
+			SndType: sharedDataType,
+			First:   &syn.Data{Inner: item[0]},
+			Second:  &syn.Data{Inner: item[1]},
+		}
+	}
+	return &syn.ProtoList{
+		LTyp: sharedPairDataType,
+		List: list,
+	}
+}
+
+func materializeConstantValue[T syn.Eval](value Value[T]) (syn.IConstant, bool) {
+	switch v := value.(type) {
+	case *Constant:
+		return v.Constant, true
+	case *dataValue[T]:
+		return &syn.Data{Inner: v.item}, true
+	case *dataListValue[T]:
+		return materializeDataListConstant(v.items), true
+	case *dataMapValue[T]:
+		return materializeDataMapConstant(v.items), true
+	case *pairValue[T]:
+		first, ok := materializeConstantValue[T](v.first)
+		if !ok {
+			return nil, false
+		}
+		second, ok := materializeConstantValue[T](v.second)
+		if !ok {
+			return nil, false
+		}
+		return &syn.ProtoPair{
+			FstType: first.Typ(),
+			SndType: second.Typ(),
+			First:   first,
+			Second:  second,
+		}, true
+	default:
+		return nil, false
+	}
 }
 
 func cloneConstant(constant syn.IConstant) syn.IConstant {

--- a/data/arena_decoder.go
+++ b/data/arena_decoder.go
@@ -1,0 +1,668 @@
+package data
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"math/big"
+)
+
+const (
+	dataDecodeChunkSize = 256
+	dataDecodeRetainCap = 2
+	dataSliceRetainCap  = 4
+)
+
+type arenaChunks[S any] struct {
+	chunks   [][]S
+	chunkIdx int
+	offset   int
+}
+
+func (a *arenaChunks[S]) used() int {
+	if len(a.chunks) == 0 {
+		return 0
+	}
+	return a.chunkIdx*dataDecodeChunkSize + a.offset
+}
+
+func (a *arenaChunks[S]) alloc() *S {
+	if a.chunkIdx < len(a.chunks) {
+		chunk := a.chunks[a.chunkIdx]
+		if chunk != nil && a.offset < len(chunk) {
+			slot := &chunk[a.offset]
+			a.offset++
+			return slot
+		}
+	}
+
+	if nextIdx := a.chunkIdx + 1; nextIdx < len(a.chunks) {
+		chunk := a.chunks[nextIdx]
+		if chunk == nil {
+			goto allocNewChunk
+		}
+		a.chunkIdx = nextIdx
+		a.offset = 1
+		return &chunk[0]
+	}
+
+allocNewChunk:
+	chunk := make([]S, dataDecodeChunkSize)
+	a.chunks = append(a.chunks, chunk)
+	a.chunkIdx = len(a.chunks) - 1
+	a.offset = 1
+	return &chunk[0]
+}
+
+func (a *arenaChunks[S]) reset(retainCap int) {
+	used := a.used()
+	retained := len(a.chunks)
+	if retained > retainCap {
+		retained = retainCap
+	}
+	if used > 0 && retained > 0 {
+		remaining := used
+		maxRetained := retained * dataDecodeChunkSize
+		if remaining > maxRetained {
+			remaining = maxRetained
+		}
+		for i := 0; i < retained && remaining > 0; i++ {
+			chunk := a.chunks[i]
+			if chunk == nil {
+				continue
+			}
+			clearCount := len(chunk)
+			if remaining < clearCount {
+				clearCount = remaining
+			}
+			clear(chunk[:clearCount])
+			remaining -= clearCount
+		}
+	}
+	if len(a.chunks) > retainCap {
+		for i := retainCap; i < len(a.chunks); i++ {
+			a.chunks[i] = nil
+		}
+		a.chunks = a.chunks[:retainCap]
+	}
+	a.chunkIdx = 0
+	a.offset = 0
+}
+
+type arenaSlices[S any] struct {
+	chunks [][]S
+	pos    int
+}
+
+func (a *arenaSlices[S]) alloc(n int) []S {
+	if n == 0 {
+		return nil
+	}
+
+	remaining := a.pos
+	for i := range a.chunks {
+		chunk := a.chunks[i]
+		if remaining < len(chunk) {
+			if remaining+n <= len(chunk) {
+				start := remaining
+				a.pos += n
+				return chunk[start : start+n]
+			}
+			a.pos += len(chunk) - remaining
+			remaining = 0
+			continue
+		}
+		remaining -= len(chunk)
+	}
+
+	size := dataDecodeChunkSize
+	if n > size {
+		size = n
+	}
+	chunk := make([]S, size)
+	a.chunks = append(a.chunks, chunk)
+	a.pos += n
+	return chunk[:n]
+}
+
+func (a *arenaSlices[S]) reset(retainCap int) {
+	retainedUsed := a.pos
+	if len(a.chunks) > retainCap {
+		maxRetained := 0
+		for i := range retainCap {
+			maxRetained += len(a.chunks[i])
+		}
+		if retainedUsed > maxRetained {
+			retainedUsed = maxRetained
+		}
+	}
+	remaining := retainedUsed
+	for i := range a.chunks {
+		if remaining <= 0 {
+			break
+		}
+		chunk := a.chunks[i]
+		if chunk == nil {
+			continue
+		}
+		clearCount := len(chunk)
+		if remaining < clearCount {
+			clearCount = remaining
+		}
+		clear(chunk[:clearCount])
+		remaining -= clearCount
+	}
+	if len(a.chunks) > retainCap {
+		for i := retainCap; i < len(a.chunks); i++ {
+			a.chunks[i] = nil
+		}
+		a.chunks = a.chunks[:retainCap]
+	}
+	a.pos = 0
+}
+
+// Decoder reuses arena-backed storage for decoded PlutusData values.
+// Returned values remain valid until the next Reset on the same decoder.
+type Decoder struct {
+	bigInts     arenaChunks[big.Int]
+	integers    arenaChunks[Integer]
+	byteStrings arenaChunks[ByteString]
+	constrs     arenaChunks[Constr]
+	lists       arenaChunks[List]
+	maps        arenaChunks[Map]
+	items       arenaSlices[PlutusData]
+	pairs       arenaSlices[[2]PlutusData]
+	bytes       arenaSlices[byte]
+}
+
+// NewDecoder returns a ready-to-use Decoder with empty internal pools.
+func NewDecoder() *Decoder {
+	return &Decoder{}
+}
+
+// Reset clears all internal arena pools so the Decoder can be reused; previously returned values become invalid.
+func (d *Decoder) Reset() {
+	d.bigInts.reset(dataDecodeRetainCap)
+	d.integers.reset(dataDecodeRetainCap)
+	d.byteStrings.reset(dataDecodeRetainCap)
+	d.constrs.reset(dataDecodeRetainCap)
+	d.lists.reset(dataDecodeRetainCap)
+	d.maps.reset(dataDecodeRetainCap)
+	d.items.reset(dataSliceRetainCap)
+	d.pairs.reset(dataSliceRetainCap)
+	d.bytes.reset(dataSliceRetainCap)
+}
+
+// Decode decodes CBOR bytes into PlutusData; the Decoder is not safe for concurrent use.
+func (d *Decoder) Decode(data []byte) (PlutusData, error) {
+	v, err := d.decode(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode CBOR: %w", err)
+	}
+	return v, nil
+}
+
+func (d *Decoder) decode(data []byte) (PlutusData, error) {
+	if len(data) == 0 {
+		return nil, errors.New("empty data")
+	}
+	cborType := data[0] & CborTypeMask
+	switch cborType {
+	case CborTypeUnsignedInt, CborTypeNegativeInt:
+		return d.decodeInteger(data)
+	case CborTypeByteString:
+		return d.decodeByteString(data)
+	case CborTypeArray:
+		tmpList, rest, err := d.decodeListNext(data)
+		if err != nil {
+			return nil, err
+		}
+		if len(rest) > 0 {
+			return nil, fmt.Errorf("unexpected %d trailing bytes", len(rest))
+		}
+		return tmpList, nil
+	case CborTypeMap:
+		tmpMap, rest, err := d.decodeMapNext(data)
+		if err != nil {
+			return nil, err
+		}
+		if len(rest) > 0 {
+			return nil, fmt.Errorf("unexpected %d trailing bytes", len(rest))
+		}
+		return tmpMap, nil
+	case CborTypeTag:
+		tagNumber, tagContent, err := decodeCBORTag(data)
+		if err != nil {
+			return nil, err
+		}
+		switch {
+		case tagNumber == 102 || (tagNumber >= 121 && tagNumber <= 127) || (tagNumber >= 1280 && tagNumber <= 1400):
+			tmpConstr, rest, err := d.decodeConstrNext(tagNumber, tagContent)
+			if err != nil {
+				return nil, err
+			}
+			if len(rest) > 0 {
+				return nil, fmt.Errorf("unexpected %d trailing bytes", len(rest))
+			}
+			return tmpConstr, nil
+		case tagNumber == 2 || tagNumber == 3:
+			return d.decodeInteger(data)
+		default:
+			return nil, fmt.Errorf("unknown CBOR tag for PlutusData: %d", tagNumber)
+		}
+	}
+	return nil, fmt.Errorf("unsupported CBOR major type 0x%02x for PlutusData", cborType)
+}
+
+func (d *Decoder) decodeNextPlutusData(data []byte) (PlutusData, []byte, error) {
+	if len(data) == 0 {
+		return nil, nil, errors.New("empty data")
+	}
+
+	switch data[0] & CborTypeMask {
+	case CborTypeArray:
+		tmpList, rest, err := d.decodeListNext(data)
+		if err != nil {
+			return nil, nil, err
+		}
+		return tmpList, rest, nil
+	case CborTypeMap:
+		tmpMap, rest, err := d.decodeMapNext(data)
+		if err != nil {
+			return nil, nil, err
+		}
+		return tmpMap, rest, nil
+	case CborTypeTag:
+		tagNumber, tagContent, err := decodeCBORTag(data)
+		if err != nil {
+			return nil, nil, err
+		}
+		switch {
+		case tagNumber == 102 || (tagNumber >= 121 && tagNumber <= 127) || (tagNumber >= 1280 && tagNumber <= 1400):
+			tmpConstr, rest, err := d.decodeConstrNext(tagNumber, tagContent)
+			if err != nil {
+				return nil, nil, err
+			}
+			return tmpConstr, rest, nil
+		}
+	}
+
+	item, rest, err := splitCBORItem(data)
+	if err != nil {
+		return nil, nil, err
+	}
+	tmp, err := d.decode(item)
+	if err != nil {
+		return nil, nil, err
+	}
+	return tmp, rest, nil
+}
+
+func (d *Decoder) decodeConstrNext(tagNumber uint64, data []byte) (*Constr, []byte, error) {
+	constr := d.constrs.alloc()
+	switch {
+	case tagNumber >= 121 && tagNumber <= 127:
+		tmpFields, tmpUseIndef, rest, err := d.decodeListItemsNext(data)
+		if err != nil {
+			return nil, nil, err
+		}
+		constr.Tag = uint(tagNumber) - 121
+		constr.Fields = tmpFields
+		constr.useIndef = tmpUseIndef
+		return constr, rest, nil
+	case tagNumber >= 1280 && tagNumber <= 1400:
+		tmpFields, tmpUseIndef, rest, err := d.decodeListItemsNext(data)
+		if err != nil {
+			return nil, nil, err
+		}
+		constr.Tag = uint(tagNumber) - 1280 + 7
+		constr.Fields = tmpFields
+		constr.useIndef = tmpUseIndef
+		return constr, rest, nil
+	case tagNumber == 102:
+		fieldCount, rest, useIndef, err := decodeCBORArray(data)
+		if err != nil {
+			return nil, nil, err
+		}
+		if !useIndef && fieldCount != 2 {
+			return nil, nil, fmt.Errorf("constructor 102 outer array has %d items, want 2", fieldCount)
+		}
+
+		alternative, next, err := decodeCBORUint(rest)
+		if err != nil {
+			return nil, nil, err
+		}
+		if alternative > math.MaxUint {
+			return nil, nil, fmt.Errorf("constructor alternative too large: %d", alternative)
+		}
+		rest = next
+
+		tmpFields, tmpUseIndef, next, err := d.decodeListItemsNext(rest)
+		if err != nil {
+			return nil, nil, err
+		}
+		rest = next
+
+		if useIndef {
+			if len(rest) == 0 || rest[0] != 0xff {
+				return nil, nil, errors.New("unterminated indefinite-length CBOR array")
+			}
+			rest = rest[1:]
+		}
+
+		constr.Tag = uint(alternative)
+		constr.Fields = tmpFields
+		constr.useIndef = tmpUseIndef
+		return constr, rest, nil
+	default:
+		return nil, nil, fmt.Errorf("unknown CBOR tag for PlutusData constructor: %d", tagNumber)
+	}
+}
+
+func (d *Decoder) decodeMapNext(data []byte) (*Map, []byte, error) {
+	pairCount, rest, useIndef, err := decodeCBORMap(data)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var (
+		smallPairs [4][2]PlutusData
+		pairs      [][2]PlutusData
+		pairLen    int
+	)
+	if !useIndef {
+		if pairCount > len(rest)/2 {
+			return nil, nil, fmt.Errorf("CBOR map claims %d pairs but only %d bytes remain", pairCount, len(rest))
+		}
+		pairs = d.pairs.alloc(pairCount)
+		pairLen = pairCount
+	}
+
+	for i := 0; useIndef || i < pairCount; i++ {
+		if useIndef {
+			if len(rest) == 0 {
+				return nil, nil, errors.New("unterminated indefinite-length CBOR map")
+			}
+			if rest[0] == 0xff {
+				rest = rest[1:]
+				break
+			}
+		}
+
+		tmpKey, next, err := d.decodeNextPlutusData(rest)
+		if err != nil {
+			return nil, nil, err
+		}
+		rest = next
+
+		tmpVal, next, err := d.decodeNextPlutusData(rest)
+		if err != nil {
+			return nil, nil, err
+		}
+		rest = next
+
+		pair := [2]PlutusData{tmpKey, tmpVal}
+		if !useIndef {
+			pairs[i] = pair
+			continue
+		}
+		if pairs != nil {
+			if pairLen == len(pairs) {
+				grown := d.pairs.alloc(max(pairLen*2, pairLen+1))
+				copy(grown, pairs[:pairLen])
+				pairs = grown
+			}
+			pairs[pairLen] = pair
+			pairLen++
+			continue
+		}
+		if pairLen < len(smallPairs) {
+			smallPairs[pairLen] = pair
+			pairLen++
+			continue
+		}
+		pairs = d.pairs.alloc(pairLen * 2)
+		copy(pairs, smallPairs[:pairLen])
+		pairs[pairLen] = pair
+		pairLen++
+	}
+
+	if useIndef {
+		if pairs == nil {
+			pairs = d.pairs.alloc(pairLen)
+			copy(pairs, smallPairs[:pairLen])
+		} else {
+			pairs = pairs[:pairLen]
+		}
+	}
+
+	decoded := d.maps.alloc()
+	decoded.Pairs = pairs
+	decoded.useIndef = useIndefPtr(useIndef)
+	return decoded, rest, nil
+}
+
+func (d *Decoder) decodeListNext(data []byte) (*List, []byte, error) {
+	tmpItems, tmpUseIndef, rest, err := d.decodeListItemsNext(data)
+	if err != nil {
+		return nil, nil, err
+	}
+	decoded := d.lists.alloc()
+	decoded.Items = tmpItems
+	decoded.useIndef = tmpUseIndef
+	return decoded, rest, nil
+}
+
+func (d *Decoder) decodeListItemsNext(data []byte) ([]PlutusData, *bool, []byte, error) {
+	itemCount, rest, useIndef, err := decodeCBORArray(data)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	if !useIndef {
+		tmpItems, rest, err := d.decodeListItemsDefinite(itemCount, rest)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		return tmpItems, useIndefPtr(false), rest, nil
+	}
+
+	var smallItems [4]PlutusData
+	var tmpItems []PlutusData
+	tmpLen := 0
+	for {
+		if len(rest) == 0 {
+			return nil, nil, nil, errors.New("unterminated indefinite-length CBOR array")
+		}
+		if rest[0] == 0xff {
+			rest = rest[1:]
+			break
+		}
+
+		tmp, next, err := d.decodeNextPlutusData(rest)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		rest = next
+
+		if tmpItems != nil {
+			if tmpLen == len(tmpItems) {
+				grown := d.items.alloc(max(tmpLen*2, tmpLen+1))
+				copy(grown, tmpItems[:tmpLen])
+				tmpItems = grown
+			}
+			tmpItems[tmpLen] = tmp
+			tmpLen++
+			continue
+		}
+		if tmpLen < len(smallItems) {
+			smallItems[tmpLen] = tmp
+			tmpLen++
+			continue
+		}
+		tmpItems = d.items.alloc(tmpLen * 2)
+		copy(tmpItems, smallItems[:tmpLen])
+		tmpItems[tmpLen] = tmp
+		tmpLen++
+	}
+
+	if tmpItems == nil {
+		tmpItems = d.items.alloc(tmpLen)
+		copy(tmpItems, smallItems[:tmpLen])
+	} else {
+		tmpItems = tmpItems[:tmpLen]
+	}
+	return tmpItems, useIndefPtr(true), rest, nil
+}
+
+func (d *Decoder) decodeListItemsDefinite(itemCount int, rest []byte) ([]PlutusData, []byte, error) {
+	if itemCount > len(rest) {
+		return nil, nil, fmt.Errorf("CBOR array claims %d items but only %d bytes remain", itemCount, len(rest))
+	}
+	tmpItems := d.items.alloc(itemCount)
+	for i := range itemCount {
+		tmp, next, err := d.decodeNextPlutusData(rest)
+		if err != nil {
+			return nil, nil, err
+		}
+		rest = next
+		tmpItems[i] = tmp
+	}
+	return tmpItems, rest, nil
+}
+
+var bigIntOne = big.NewInt(1)
+
+func (d *Decoder) allocBigInt() *big.Int {
+	return d.bigInts.alloc()
+}
+
+func (d *Decoder) allocInteger(inner *big.Int) *Integer {
+	integer := d.integers.alloc()
+	integer.Inner = inner
+	return integer
+}
+
+func (d *Decoder) decodeInteger(data []byte) (*Integer, error) {
+	cborType, value, rest, indefinite, err := decodeCBORHead(data)
+	if err != nil {
+		return nil, err
+	}
+
+	switch cborType {
+	case CborTypeUnsignedInt:
+		if indefinite {
+			return nil, errors.New("indefinite CBOR integer is not supported")
+		}
+		if len(rest) > 0 {
+			return nil, fmt.Errorf("unexpected %d trailing bytes", len(rest))
+		}
+		inner := d.allocBigInt()
+		inner.SetUint64(value)
+		return d.allocInteger(inner), nil
+	case CborTypeNegativeInt:
+		if indefinite {
+			return nil, errors.New("indefinite CBOR integer is not supported")
+		}
+		if len(rest) > 0 {
+			return nil, fmt.Errorf("unexpected %d trailing bytes", len(rest))
+		}
+		inner := d.allocBigInt()
+		inner.SetUint64(value)
+		inner.Add(inner, bigIntOne)
+		inner.Neg(inner)
+		return d.allocInteger(inner), nil
+	case CborTypeTag:
+		if indefinite {
+			return nil, errors.New("indefinite CBOR tags are not supported")
+		}
+		if value != 2 && value != 3 {
+			return nil, fmt.Errorf("unknown CBOR tag for PlutusData: %d", value)
+		}
+		bytes, rest, err := d.decodeByteStringContent(rest)
+		if err != nil {
+			return nil, err
+		}
+		if len(rest) > 0 {
+			return nil, fmt.Errorf("unexpected %d trailing bytes", len(rest))
+		}
+		inner := d.allocBigInt()
+		inner.SetBytes(bytes)
+		if value == 3 {
+			inner.Add(inner, bigIntOne)
+			inner.Neg(inner)
+		}
+		return d.allocInteger(inner), nil
+	default:
+		return nil, fmt.Errorf("unsupported CBOR type for PlutusData integer: 0x%02x", cborType)
+	}
+}
+
+func (d *Decoder) decodeByteString(data []byte) (*ByteString, error) {
+	inner, rest, err := d.decodeByteStringContent(data)
+	if err != nil {
+		return nil, err
+	}
+	if len(rest) > 0 {
+		return nil, fmt.Errorf("unexpected %d trailing bytes", len(rest))
+	}
+	value := d.byteStrings.alloc()
+	value.Inner = inner
+	return value, nil
+}
+
+func (d *Decoder) decodeByteStringContent(data []byte) ([]byte, []byte, error) {
+	value, rest, indefinite, err := decodeCBORHeadValue(data, CborTypeByteString)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !indefinite {
+		if value > uint64(len(rest)) {
+			return nil, nil, errors.New("truncated CBOR payload")
+		}
+		inner := d.bytes.alloc(int(value))
+		copy(inner, rest[:value])
+		return inner, rest[value:], nil
+	}
+
+	total := 0
+	scan := rest
+	for {
+		if len(scan) == 0 {
+			return nil, nil, errors.New("unterminated indefinite-length CBOR string")
+		}
+		if scan[0] == 0xff {
+			break
+		}
+		chunkType, chunkValue, chunkRest, chunkIndef, err := decodeCBORHead(scan)
+		if err != nil {
+			return nil, nil, err
+		}
+		if chunkIndef || chunkType != CborTypeByteString {
+			return nil, nil, fmt.Errorf("invalid CBOR chunk type 0x%02x", chunkType)
+		}
+		if chunkValue > uint64(len(chunkRest)) {
+			return nil, nil, errors.New("truncated CBOR payload")
+		}
+		if chunkValue > uint64(math.MaxInt-total) {
+			return nil, nil, fmt.Errorf("CBOR byte string too large: %d", chunkValue)
+		}
+		total += int(chunkValue)
+		scan = chunkRest[chunkValue:]
+	}
+
+	inner := d.bytes.alloc(total)
+	offset := 0
+	for {
+		if rest[0] == 0xff {
+			return inner, rest[1:], nil
+		}
+		_, chunkValue, chunkRest, _, err := decodeCBORHead(rest)
+		if err != nil {
+			return nil, nil, err
+		}
+		copy(inner[offset:], chunkRest[:chunkValue])
+		offset += int(chunkValue)
+		rest = chunkRest[chunkValue:]
+	}
+}

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -435,6 +435,58 @@ func TestPlutusDataDecode(t *testing.T) {
 	}
 }
 
+func TestDecoderReuseMatchesDecode(t *testing.T) {
+	decoder := NewDecoder()
+	decoded := make([]PlutusData, 0, len(testDefs))
+
+	t.Run("before-reset", func(t *testing.T) {
+		for _, testDef := range testDefs {
+			testDef := testDef
+			t.Run(testDef.CborHex, func(t *testing.T) {
+				tmpData, err := hex.DecodeString(testDef.CborHex)
+				if err != nil {
+					t.Fatalf("failed to decode hex %s: %v", testDef.CborHex, err)
+				}
+
+				got, err := decoder.Decode(tmpData)
+				if err != nil {
+					t.Fatalf("decoder.Decode() failed for %s: %v", testDef.CborHex, err)
+				}
+				if !got.Equal(testDef.Data) {
+					t.Fatalf("decoder.Decode() mismatch for %s: got %s, want %s", testDef.CborHex, got, testDef.Data)
+				}
+				decoded = append(decoded, got)
+			})
+		}
+	})
+
+	for i, got := range decoded {
+		if !got.Equal(testDefs[i].Data) {
+			t.Fatalf("decoded value %d changed before reset: got %s, want %s", i, got, testDefs[i].Data)
+		}
+	}
+
+	decoder.Reset()
+	t.Run("after-reset", func(t *testing.T) {
+		for _, testDef := range testDefs {
+			testDef := testDef
+			t.Run(testDef.CborHex, func(t *testing.T) {
+				tmpData, err := hex.DecodeString(testDef.CborHex)
+				if err != nil {
+					t.Fatalf("failed to decode hex %s after reset: %v", testDef.CborHex, err)
+				}
+				got, err := decoder.Decode(tmpData)
+				if err != nil {
+					t.Fatalf("decoder.Decode() after reset failed for %s: %v", testDef.CborHex, err)
+				}
+				if !got.Equal(testDef.Data) {
+					t.Fatalf("decoder.Decode() after reset mismatch for %s: got %s, want %s", testDef.CborHex, got, testDef.Data)
+				}
+			})
+		}
+	})
+}
+
 func TestDecodeCBORTag(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/syn/encode_test.go
+++ b/syn/encode_test.go
@@ -329,50 +329,100 @@ func TestFlatRoundtrip(t *testing.T) {
 }
 
 func TestDeBruijnDecoderReuse(t *testing.T) {
-	program := &Program[DeBruijn]{
-		Version: lang.LanguageVersionV3,
-		Term: &Apply[DeBruijn]{
-			Function: &Lambda[DeBruijn]{
-				ParameterName: DeBruijn(0),
-				Body: &Constr[DeBruijn]{
-					Tag: 1,
-					Fields: []Term[DeBruijn]{
-						&Var[DeBruijn]{Name: DeBruijn(1)},
-						&Constant{Con: &Data{Inner: &data.List{
-							Items: []data.PlutusData{
-								&data.Integer{Inner: big.NewInt(1)},
-								&data.ByteString{Inner: []byte{0xca, 0xfe}},
+	decoder := NewDeBruijnDecoder()
+	tests := []struct {
+		name    string
+		program *Program[DeBruijn]
+	}{
+		{
+			name: "nested_data_program",
+			program: &Program[DeBruijn]{
+				Version: lang.LanguageVersionV3,
+				Term: &Apply[DeBruijn]{
+					Function: &Lambda[DeBruijn]{
+						ParameterName: DeBruijn(0),
+						Body: &Constr[DeBruijn]{
+							Tag: 1,
+							Fields: []Term[DeBruijn]{
+								&Var[DeBruijn]{Name: DeBruijn(1)},
+								&Constant{Con: &Data{Inner: &data.List{
+									Items: []data.PlutusData{
+										&data.Integer{Inner: big.NewInt(1)},
+										&data.ByteString{Inner: []byte{0xca, 0xfe}},
+									},
+								}}},
 							},
-						}}},
+						},
+					},
+					Argument: &Force[DeBruijn]{
+						Term: &Delay[DeBruijn]{
+							Term: &Builtin{DefaultFunction: builtin.IfThenElse},
+						},
 					},
 				},
 			},
-			Argument: &Force[DeBruijn]{
-				Term: &Delay[DeBruijn]{
-					Term: &Builtin{DefaultFunction: builtin.IfThenElse},
-				},
+		},
+		{
+			name: "constant_heavy_program",
+			program: &Program[DeBruijn]{
+				Version: lang.LanguageVersionV3,
+				Term: &Constant{Con: &ProtoList{
+					LTyp: &TPair{First: &TInteger{}, Second: &TData{}},
+					List: []IConstant{
+						&ProtoPair{
+							FstType: &TInteger{},
+							SndType: &TData{},
+							First:   &Integer{Inner: big.NewInt(42)},
+							Second: &Data{Inner: &data.Map{
+								Pairs: [][2]data.PlutusData{
+									{
+										&data.Integer{Inner: big.NewInt(7)},
+										&data.ByteString{Inner: []byte{0xde, 0xad}},
+									},
+								},
+							}},
+						},
+						&ProtoPair{
+							FstType: &TInteger{},
+							SndType: &TData{},
+							First:   &Integer{Inner: big.NewInt(-5)},
+							Second: &Data{Inner: &data.Constr{
+								Tag: 2,
+								Fields: []data.PlutusData{
+									&data.Integer{Inner: big.NewInt(9)},
+									&data.List{Items: []data.PlutusData{
+										&data.ByteString{Inner: []byte{0xaa}},
+									}},
+								},
+							}},
+						},
+					},
+				}},
 			},
 		},
 	}
 
-	encoded, err := Encode(program)
-	if err != nil {
-		t.Fatalf("Encode failed: %v", err)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encoded, err := Encode(tt.program)
+			if err != nil {
+				t.Fatalf("Encode failed: %v", err)
+			}
 
-	decoder := NewDeBruijnDecoder()
-	for i := 0; i < 2; i++ {
-		decoded, err := decoder.Decode(encoded)
-		if err != nil {
-			t.Fatalf("Decode %d failed: %v", i, err)
-		}
-		reencoded, err := Encode(decoded)
-		if err != nil {
-			t.Fatalf("Re-encode %d failed: %v", i, err)
-		}
-		if !bytes.Equal(encoded, reencoded) {
-			t.Fatalf("Decode %d roundtrip mismatch", i)
-		}
+			for i := 0; i < 2; i++ {
+				decoded, err := decoder.Decode(encoded)
+				if err != nil {
+					t.Fatalf("Decode %d failed: %v", i, err)
+				}
+				reencoded, err := Encode(decoded)
+				if err != nil {
+					t.Fatalf("Re-encode %d failed: %v", i, err)
+				}
+				if !bytes.Equal(encoded, reencoded) {
+					t.Fatalf("Decode %d roundtrip mismatch", i)
+				}
+			}
+		})
 	}
 }
 

--- a/syn/flat_decode.go
+++ b/syn/flat_decode.go
@@ -21,6 +21,7 @@ const (
 type DeBruijnDecoder struct {
 	decoder decoder
 	arena   termArena[DeBruijn]
+	consts  constantArena
 }
 
 func NewDeBruijnDecoder() *DeBruijnDecoder {
@@ -31,13 +32,31 @@ func DecodeDeBruijn(bytes []byte) (*Program[DeBruijn], error) {
 	return NewDeBruijnDecoder().Decode(bytes)
 }
 
+func decodeDeBruijn(bytes []byte) (*Program[DeBruijn], error) {
+	d := newDecoder(bytes)
+	arena := newTermArena[DeBruijn]()
+	consts := &constantArena{}
+	return decodeDeBruijnProgram(d, arena, consts)
+}
+
 func (d *DeBruijnDecoder) Decode(bytes []byte) (*Program[DeBruijn], error) {
 	d.decoder.reset(bytes)
 	d.arena.reset()
-	return decodeDeBruijnProgram(&d.decoder, &d.arena)
+	d.consts.reset()
+	return decodeDeBruijnProgram(&d.decoder, &d.arena, &d.consts)
 }
 
 func Decode[T Binder](bytes []byte) (*Program[T], error) {
+	var zero T
+	switch any(zero).(type) {
+	case DeBruijn:
+		program, err := decodeDeBruijn(bytes)
+		if err != nil {
+			return nil, err
+		}
+		return any(program).(*Program[T]), nil
+	}
+
 	d := newDecoder(bytes)
 	arena := newTermArena[T]()
 
@@ -83,6 +102,7 @@ func Decode[T Binder](bytes []byte) (*Program[T], error) {
 func decodeDeBruijnProgram(
 	d *decoder,
 	arena *termArena[DeBruijn],
+	consts *constantArena,
 ) (*Program[DeBruijn], error) {
 	major, err := d.word()
 	if err != nil {
@@ -99,7 +119,7 @@ func decodeDeBruijnProgram(
 		return nil, err
 	}
 
-	terms, err := decodeTermDeBruijnWithArena(d, arena)
+	terms, err := decodeTermDeBruijnWithArena(d, arena, consts)
 	if err != nil {
 		return nil, err
 	}
@@ -128,6 +148,7 @@ func DecodeTerm[T Binder](d *decoder) (Term[T], error) {
 func decodeTermDeBruijnWithArena(
 	d *decoder,
 	arena *termArena[DeBruijn],
+	consts *constantArena,
 ) (Term[DeBruijn], error) {
 	tag, err := d.bits4()
 	if err != nil {
@@ -142,35 +163,35 @@ func decodeTermDeBruijnWithArena(
 		}
 		return arena.allocVar(name), nil
 	case DelayTag:
-		t, err := decodeTermDeBruijnWithArena(d, arena)
+		t, err := decodeTermDeBruijnWithArena(d, arena, consts)
 		if err != nil {
 			return nil, err
 		}
 		return arena.allocDelay(t), nil
 	case LambdaTag:
-		t, err := decodeTermDeBruijnWithArena(d, arena)
+		t, err := decodeTermDeBruijnWithArena(d, arena, consts)
 		if err != nil {
 			return nil, err
 		}
 		return arena.allocLambda(DeBruijn(0), t), nil
 	case ApplyTag:
-		function, err := decodeTermDeBruijnWithArena(d, arena)
+		function, err := decodeTermDeBruijnWithArena(d, arena, consts)
 		if err != nil {
 			return nil, err
 		}
-		argument, err := decodeTermDeBruijnWithArena(d, arena)
+		argument, err := decodeTermDeBruijnWithArena(d, arena, consts)
 		if err != nil {
 			return nil, err
 		}
 		return arena.allocApply(function, argument), nil
 	case ConstantTag:
-		constant, err := DecodeConstant(d)
+		constant, err := decodeConstantWithArena(d, consts)
 		if err != nil {
 			return nil, err
 		}
 		return arena.allocConstant(constant), nil
 	case ForceTag:
-		t, err := decodeTermDeBruijnWithArena(d, arena)
+		t, err := decodeTermDeBruijnWithArena(d, arena, consts)
 		if err != nil {
 			return nil, err
 		}
@@ -192,17 +213,17 @@ func decodeTermDeBruijnWithArena(
 		if err != nil {
 			return nil, err
 		}
-		fields, err := decodeTermListDeBruijnWithArena(d, arena)
+		fields, err := decodeTermListDeBruijnWithArena(d, arena, consts)
 		if err != nil {
 			return nil, err
 		}
 		return arena.allocConstr(constrTag, fields), nil
 	case CaseTag:
-		constr, err := decodeTermDeBruijnWithArena(d, arena)
+		constr, err := decodeTermDeBruijnWithArena(d, arena, consts)
 		if err != nil {
 			return nil, err
 		}
-		branches, err := decodeTermListDeBruijnWithArena(d, arena)
+		branches, err := decodeTermListDeBruijnWithArena(d, arena, consts)
 		if err != nil {
 			return nil, err
 		}
@@ -342,6 +363,7 @@ func decodeTermListWithArena[T Binder](d *decoder, arena *termArena[T]) ([]Term[
 func decodeTermListDeBruijnWithArena(
 	d *decoder,
 	arena *termArena[DeBruijn],
+	consts *constantArena,
 ) ([]Term[DeBruijn], error) {
 	result := make([]Term[DeBruijn], 0, 4)
 
@@ -353,7 +375,7 @@ func decodeTermListDeBruijnWithArena(
 		if !bit {
 			break
 		}
-		item, err := decodeTermDeBruijnWithArena(d, arena)
+		item, err := decodeTermDeBruijnWithArena(d, arena, consts)
 		if err != nil {
 			return nil, err
 		}
@@ -377,13 +399,14 @@ func (a *arenaChunks[S]) used() int {
 }
 
 func (a *arenaChunks[S]) alloc() *S {
-	if a.chunkIdx < len(a.chunks) {
-		chunk := a.chunks[a.chunkIdx]
-		if a.offset < len(chunk) {
-			slot := &chunk[a.offset]
+	for a.chunkIdx < len(a.chunks) {
+		if a.offset < len(a.chunks[a.chunkIdx]) {
+			slot := &a.chunks[a.chunkIdx][a.offset]
 			a.offset++
 			return slot
 		}
+		a.chunkIdx++
+		a.offset = 0
 	}
 
 	chunk := make([]S, decodeTermChunkSize)
@@ -520,6 +543,91 @@ func (a *termArena[T]) allocBuiltin(fn builtin.DefaultFunction) *Builtin {
 	return term
 }
 
+type constantArena struct {
+	bigInts     arenaChunks[big.Int]
+	integers    arenaChunks[Integer]
+	byteStrings arenaChunks[ByteString]
+	strings     arenaChunks[String]
+	units       arenaChunks[Unit]
+	bools       arenaChunks[Bool]
+	protoLists  arenaChunks[ProtoList]
+	protoPairs  arenaChunks[ProtoPair]
+	datas       arenaChunks[Data]
+	dataDecoder data.Decoder
+}
+
+func (a *constantArena) reset() {
+	a.bigInts.reset(decodeRetainVarCap)
+	a.integers.reset(decodeRetainVarCap)
+	a.byteStrings.reset(decodeRetainVarCap)
+	a.strings.reset(decodeRetainVarCap)
+	a.units.reset(1)
+	a.bools.reset(1)
+	a.protoLists.reset(decodeRetainVarCap)
+	a.protoPairs.reset(decodeRetainVarCap)
+	a.datas.reset(decodeRetainVarCap)
+	a.dataDecoder.Reset()
+}
+
+func (a *constantArena) allocBigInt() *big.Int {
+	return a.bigInts.alloc()
+}
+
+func (a *constantArena) allocInteger(inner *big.Int) *Integer {
+	integer := a.integers.alloc()
+	integer.SetInner(inner)
+	return integer
+}
+
+func (a *constantArena) allocByteString(inner []byte) *ByteString {
+	value := a.byteStrings.alloc()
+	value.Inner = inner
+	return value
+}
+
+func (a *constantArena) allocString(inner string) *String {
+	value := a.strings.alloc()
+	value.Inner = inner
+	return value
+}
+
+func (a *constantArena) allocUnit() *Unit {
+	return a.units.alloc()
+}
+
+func (a *constantArena) allocBool(inner bool) *Bool {
+	value := a.bools.alloc()
+	value.Inner = inner
+	return value
+}
+
+func (a *constantArena) allocProtoList(typ Typ, items []IConstant) *ProtoList {
+	value := a.protoLists.alloc()
+	value.LTyp = typ
+	value.List = items
+	return value
+}
+
+func (a *constantArena) allocProtoPair(
+	firstType Typ,
+	secondType Typ,
+	first IConstant,
+	second IConstant,
+) *ProtoPair {
+	value := a.protoPairs.alloc()
+	value.FstType = firstType
+	value.SndType = secondType
+	value.First = first
+	value.Second = second
+	return value
+}
+
+func (a *constantArena) allocData(inner data.PlutusData) *Data {
+	value := a.datas.alloc()
+	value.Inner = inner
+	return value
+}
+
 func decodeDeBruijnBinder(d *decoder) (DeBruijn, error) {
 	i, err := d.word()
 	if err != nil {
@@ -653,6 +761,124 @@ func DecodeConstant(d *decoder) (IConstant, error) {
 		return nil, err
 	}
 	return decodeConstantValue(d, typ)
+}
+
+func decodeConstantWithArena(d *decoder, arena *constantArena) (IConstant, error) {
+	var tags constantTagSeq
+	err := decodeConstantTags(d, &tags)
+	if err != nil {
+		return nil, err
+	}
+	typ, err := decodeConstantType(&tags)
+	if err != nil {
+		return nil, err
+	}
+	return decodeConstantValueWithArena(d, typ, arena)
+}
+
+func decodeConstantValueWithArena(
+	d *decoder,
+	typ Typ,
+	arena *constantArena,
+) (IConstant, error) {
+	switch t := typ.(type) {
+	case *TInteger:
+		return decodeIntegerWithArena(d, arena)
+	case *TByteString:
+		b, err := d.bytes()
+		if err != nil {
+			return nil, err
+		}
+		return arena.allocByteString(b), nil
+	case *TString:
+		s, err := d.utf8()
+		if err != nil {
+			return nil, err
+		}
+		return arena.allocString(s), nil
+	case *TUnit:
+		return arena.allocUnit(), nil
+	case *TBool:
+		v, err := d.bit()
+		if err != nil {
+			return nil, err
+		}
+		return arena.allocBool(v), nil
+	case *TList:
+		items, err := decodeConstantListWithArena(d, t.Typ, arena)
+		if err != nil {
+			return nil, err
+		}
+		return arena.allocProtoList(t.Typ, items), nil
+	case *TPair:
+		first, err := decodeConstantValueWithArena(d, t.First, arena)
+		if err != nil {
+			return nil, err
+		}
+		second, err := decodeConstantValueWithArena(d, t.Second, arena)
+		if err != nil {
+			return nil, err
+		}
+		return arena.allocProtoPair(t.First, t.Second, first, second), nil
+	case *TData:
+		cborBytes, err := d.bytes()
+		if err != nil {
+			return nil, err
+		}
+		pd, err := arena.dataDecoder.Decode(cborBytes)
+		if err != nil {
+			return nil, err
+		}
+		return arena.allocData(pd), nil
+	default:
+		return nil, errors.New("unknown constant constructor")
+	}
+}
+
+func decodeIntegerWithArena(
+	d *decoder,
+	arena *constantArena,
+) (*Integer, error) {
+	small, word, err := d.bigWordSmall()
+	if err != nil {
+		return nil, err
+	}
+
+	inner := arena.allocBigInt()
+	if word == nil {
+		if smallInt, ok := unzigzagUint64(small); ok {
+			inner.SetInt64(smallInt)
+			return arena.allocInteger(inner), nil
+		}
+		inner.SetUint64(small)
+	} else {
+		inner.Set(word)
+	}
+	unzigzagInPlace(inner)
+	return arena.allocInteger(inner), nil
+}
+
+func decodeConstantListWithArena(
+	d *decoder,
+	itemType Typ,
+	arena *constantArena,
+) ([]IConstant, error) {
+	result := make([]IConstant, 0, 4)
+
+	for {
+		bit, err := d.bit()
+		if err != nil {
+			return nil, err
+		}
+		if !bit {
+			return result, nil
+		}
+		item, err := decodeConstantValueWithArena(d, itemType, arena)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, item)
+	}
 }
 
 func decodeConstantValue(d *decoder, typ Typ) (IConstant, error) {
@@ -1361,6 +1587,15 @@ func unzigzagUint64(n uint64) (int64, bool) {
 		return int64(shifted), true
 	}
 	return -1 - int64(shifted), true
+}
+
+func unzigzagInPlace(n *big.Int) *big.Int {
+	if n.Bit(0) == 0 {
+		return n.Rsh(n, 1)
+	}
+	n.Rsh(n, 1)
+	n.Add(n, bigOne)
+	return n.Neg(n)
 }
 
 // Increment used bits by 1.

--- a/syn/zigzag.go
+++ b/syn/zigzag.go
@@ -2,6 +2,8 @@ package syn
 
 import "math/big"
 
+var bigOne = big.NewInt(1)
+
 // zigzag encodes a signed big.Int into an unsigned big.Int using zigzag encoding.
 func zigzag(n *big.Int) *big.Int {
 	result := new(big.Int)
@@ -22,7 +24,7 @@ func zigzag(n *big.Int) *big.Int {
 // unzigzag decodes an unsigned big.Int back to a signed big.Int using zigzag decoding.
 func unzigzag(n *big.Int) *big.Int {
 	// temp = n & 1
-	temp := new(big.Int).And(n, big.NewInt(1))
+	temp := new(big.Int).And(n, bigOne)
 
 	// (n >> 1) ^ (-temp)
 	result := new(big.Int).Rsh(n, 1)

--- a/tests/bench_test.go
+++ b/tests/bench_test.go
@@ -17,56 +17,31 @@ func BenchmarkFlatFiles(b *testing.B) {
 	benchFlatFiles(b, true, true)
 }
 
+func BenchmarkFlatFilesFresh(b *testing.B) {
+	benchFlatFilesFresh(b, true, true)
+}
+
 func BenchmarkFlatFilesDecode(b *testing.B) {
 	benchFlatFiles(b, true, false)
+}
+
+func BenchmarkFlatFilesDecodeFresh(b *testing.B) {
+	benchFlatFilesFresh(b, true, false)
 }
 
 func BenchmarkFlatFilesEval(b *testing.B) {
 	benchFlatFiles(b, false, true)
 }
 
+func BenchmarkFlatFilesEvalFresh(b *testing.B) {
+	benchFlatFilesFresh(b, false, true)
+}
+
 func benchFlatFiles(b *testing.B, includeDecode, includeEval bool) {
-	_, filename, _, ok := runtime.Caller(0)
-	if !ok {
-		b.Fatal("Could not get caller information")
-	}
-
-	testRoot := filepath.Join(filepath.Dir(filename), "bench")
-	testRoot = filepath.Clean(testRoot)
-
-	if _, err := os.Stat(testRoot); os.IsNotExist(err) {
-		b.Fatalf("Test directory not found: %s", testRoot)
-	}
-
-	// Get list of files in dataDir.
-	files, err := os.ReadDir(testRoot)
-	if err != nil {
-		b.Fatalf("failed to read directory %s: %v", testRoot, err)
-	}
-
-	for _, file := range files {
-		// Skip directories, only process files.
-		if file.IsDir() {
-			continue
-		}
-
-		// Get file path and name.
-		filePath := filepath.Join(testRoot, file.Name())
-
-		// Use file name (without extension) as benchmark name.
-		benchmarkName := strings.TrimSuffix(
-			file.Name(),
-			filepath.Ext(file.Name()),
-		)
-
-		// Load file contents before benchmark.
-		content, err := loadFile(filePath)
-		if err != nil {
-			b.Fatalf("failed to load file %s: %v", filePath, err)
-		}
-
+	forEachBenchFile(b, func(b *testing.B, benchmarkName string, content []byte) {
 		var decodedProgram *syn.Program[syn.DeBruijn]
 		if !includeDecode || includeEval {
+			var err error
 			decodedProgram, err = syn.Decode[syn.DeBruijn](content)
 			if err != nil {
 				b.Fatalf("decode error: %v", err)
@@ -112,13 +87,97 @@ func benchFlatFiles(b *testing.B, includeDecode, includeEval bool) {
 				if includeEval {
 					// Use an eval context with protocol major 200 so benchmark
 					// coverage includes every builtin without availability gating.
-					_, err = machine.Run(program.Term)
+					_, err := machine.Run(program.Term)
 					if err != nil {
 						b.Fatalf("eval error: %v", err)
 					}
 				}
 			}
 		})
+	})
+}
+
+func benchFlatFilesFresh(b *testing.B, includeDecode, includeEval bool) {
+	forEachBenchFile(b, func(b *testing.B, benchmarkName string, content []byte) {
+		var (
+			decodedProgram *syn.Program[syn.DeBruijn]
+			programVersion lang.LanguageVersion
+			evalContext    *cek.EvalContext
+		)
+		if includeEval {
+			var err error
+			decodedProgram, err = syn.Decode[syn.DeBruijn](content)
+			if err != nil {
+				b.Fatalf("decode error: %v", err)
+			}
+			programVersion = benchmarkProgramVersion(b, decodedProgram)
+			evalContext = benchmarkEvalContext(programVersion)
+		}
+
+		b.Run(benchmarkName, func(b *testing.B) {
+			for b.Loop() {
+				program := decodedProgram
+				if includeDecode {
+					var decodeErr error
+					program, decodeErr = syn.Decode[syn.DeBruijn](content)
+					if decodeErr != nil {
+						b.Fatalf("decode error: %v", decodeErr)
+					}
+				}
+
+				if includeEval {
+					machine := cek.NewMachine[syn.DeBruijn](
+						programVersion,
+						0,
+						evalContext,
+					)
+					_, err := machine.Run(program.Term)
+					if err != nil {
+						b.Fatalf("eval error: %v", err)
+					}
+				}
+			}
+		})
+	})
+}
+
+func forEachBenchFile(
+	b *testing.B,
+	fn func(b *testing.B, benchmarkName string, content []byte),
+) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		b.Fatal("Could not get caller information")
+	}
+
+	testRoot := filepath.Join(filepath.Dir(filename), "bench")
+	testRoot = filepath.Clean(testRoot)
+
+	if _, err := os.Stat(testRoot); os.IsNotExist(err) {
+		b.Fatalf("Test directory not found: %s", testRoot)
+	}
+
+	files, err := os.ReadDir(testRoot)
+	if err != nil {
+		b.Fatalf("failed to read directory %s: %v", testRoot, err)
+	}
+
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+
+		filePath := filepath.Join(testRoot, file.Name())
+		benchmarkName := strings.TrimSuffix(
+			file.Name(),
+			filepath.Ext(file.Name()),
+		)
+
+		content, err := loadFile(filePath)
+		if err != nil {
+			b.Fatalf("failed to load file %s: %v", filePath, err)
+		}
+		fn(b, benchmarkName, content)
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split wrapper arena sizes and added lazy runtime data/pair/list/map values to cut allocations and speed up decoding, builtins, case analysis, and discharge. Also integrated an arena-backed PlutusData decoder into the `syn` DeBruijn decoder and added “fresh” decode/eval benchmarks.

- **Performance**
  - Lazy runtime values (`dataValue`, `dataListValue`, `dataMapValue`, `pairValue`) power builtins and case evaluation without materializing constants (e.g. FstPair, SndPair, HeadList, TailList, NullList, ChooseList, MkCons, Un*Data, ConstrData, MapData, ListData, `IData`, `BData`) across CEK and stack machines.
  - Split arenas for values, value-elements, and wrapper values with smaller chunk sizes and retain caps; shared dynamic int cache across machines. Faster discharge and list/map/pair case handling.
  - Added arena-backed PlutusData decoder (`data/arena_decoder.go`) and wired it into the `syn` DeBruijn decoder via a constant arena for faster constant decoding; decoder supports `Reset()` and reuse with new tests. Added fresh decode-only/eval-only benchmarks.

- **Refactors**
  - `dischargeValue` and `withEnv` now return errors; added `splitPairValue`, `materializeConstantValue`, and `dataAwareConstantValue`. Bench helpers reorganized with fresh decode-only/eval-only variants.

<sup>Written for commit c5921f7b7ea0698d002f89bc5e8d8728e24fbbe6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance & Optimization**
  * Faster, lower‑memory handling for data/list/map/pair values and many builtins; faster case evaluation for lists/maps/pairs.

* **Decoder**
  * New reusable CBOR Decoder with Reset() and Decode() and arena-backed constant decoding; DeBruijn decoding improved for reuse.

* **Bug Fixes**
  * Builtins and case-evaluation now return proper out-of-bounds/branch-count errors for empty containers and pair cases.

* **Tests**
  * Expanded materialization tests, decoder reuse tests, and added fresh-file decode/eval benchmarks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->