### PR TITLE
test(benchmark): allow specifying benchmark source data dir

### DIFF
--- a/tests/bench_test.go
+++ b/tests/bench_test.go
@@ -152,8 +152,11 @@ func forEachBenchFile(
 
 	testRoot := filepath.Join(filepath.Dir(filename), "bench")
 	testRoot = filepath.Clean(testRoot)
-	if benchDir := os.Getenv("PLUTIGO_BENCH_DIR"); benchDir != "" {
-		testRoot = filepath.Clean(benchDir)
+	if benchDir, ok := os.LookupEnv("PLUTIGO_BENCH_DIR"); ok {
+		benchDir = strings.TrimSpace(benchDir)
+		if benchDir != "" {
+			testRoot = filepath.Clean(benchDir)
+		}
 	}
 
 	if _, err := os.Stat(testRoot); os.IsNotExist(err) {

--- a/tests/bench_test.go
+++ b/tests/bench_test.go
@@ -152,6 +152,9 @@ func forEachBenchFile(
 
 	testRoot := filepath.Join(filepath.Dir(filename), "bench")
 	testRoot = filepath.Clean(testRoot)
+	if benchDir := os.Getenv("PLUTIGO_BENCH_DIR"); benchDir != "" {
+		testRoot = filepath.Clean(benchDir)
+	}
 
 	if _, err := os.Stat(testRoot); os.IsNotExist(err) {
 		b.Fatalf("Test directory not found: %s", testRoot)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow overriding the benchmark source data directory via the `PLUTIGO_BENCH_DIR` env var, trimming whitespace and ignoring empty values. Defaults to the `bench` directory next to the test file when unset or empty.

<sup>Written for commit 51656f29b2cde4186740e50321f808b52e155024. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added environment variable support to configure the benchmark directory path. The `PLUTIGO_BENCH_DIR` environment variable can now override the default benchmark root location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->