### PR TITLE
perf(data): set dataDecodeChunkSize=64

### DIFF
--- a/data/arena_decoder.go
+++ b/data/arena_decoder.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	dataDecodeChunkSize = 256
+	dataDecodeChunkSize = 64
 	dataDecodeRetainCap = 2
 	dataSliceRetainCap  = 4
 )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reduced data decode chunk size from 256 to 64 to cut peak memory usage and improve cache locality in the arena decoder. No behavior or API changes.

<sup>Written for commit 97b90058f44f2e4c96468a11b549158b152d8210. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

