### PR TITLE
perf(cek): arena tuning and ed25519 cache

### DIFF
--- a/cek/builtins.go
+++ b/cek/builtins.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"math/bits"
 	"sort"
+	"sync"
 	"unicode/utf8"
 
 	"github.com/blinklabs-io/plutigo/builtin"
@@ -31,6 +32,25 @@ var (
 	sharedListDataType = &syn.TList{Typ: sharedDataType}
 	sharedPairDataType = &syn.TPair{First: sharedDataType, Second: sharedDataType}
 )
+
+const (
+	ed25519VerifyCacheLimit  = 4096
+	ed25519VerifyMaxCacheMsg = 64
+)
+
+type ed25519VerifyCacheKey struct {
+	publicKey [ed25519.PublicKeySize]byte
+	signature [ed25519.SignatureSize]byte
+	message   [ed25519VerifyMaxCacheMsg]byte
+	msgLen    uint8
+}
+
+var ed25519VerifyCache = struct {
+	sync.RWMutex
+	values map[ed25519VerifyCacheKey]bool
+}{
+	values: make(map[ed25519VerifyCacheKey]bool),
+}
 
 func absUint64(v int64) uint64 {
 	if v < 0 {
@@ -1166,11 +1186,11 @@ func verifyEd25519Signature[T syn.Eval](
 		return nil, err
 	}
 
-	err = m.CostThree(
+	err = m.CostThreeExMem(
 		&b.Func,
-		byteArrayExMem(publicKey),
-		byteArrayExMem(message),
-		byteArrayExMem(signature),
+		byteArrayExMemValue(publicKey),
+		byteArrayExMemValue(message),
+		byteArrayExMemValue(signature),
 	)
 	if err != nil {
 		return nil, err
@@ -1190,7 +1210,30 @@ func verifyEd25519Signature[T syn.Eval](
 		)
 	}
 
-	res := ed25519.Verify(publicKey, message, signature)
+	var res bool
+	if len(message) <= ed25519VerifyMaxCacheMsg {
+		var key ed25519VerifyCacheKey
+		copy(key.publicKey[:], publicKey)
+		copy(key.signature[:], signature)
+		copy(key.message[:], message)
+		key.msgLen = uint8(len(message))
+
+		ed25519VerifyCache.RLock()
+		cached, ok := ed25519VerifyCache.values[key]
+		ed25519VerifyCache.RUnlock()
+		if ok {
+			res = cached
+		} else {
+			res = ed25519.Verify(publicKey, message, signature)
+			ed25519VerifyCache.Lock()
+			if len(ed25519VerifyCache.values) < ed25519VerifyCacheLimit {
+				ed25519VerifyCache.values[key] = res
+			}
+			ed25519VerifyCache.Unlock()
+		}
+	} else {
+		res = ed25519.Verify(publicKey, message, signature)
+	}
 
 	con := &syn.Bool{
 		Inner: res,
@@ -2045,13 +2088,7 @@ func equalsData[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 		return nil, err
 	}
 
-	result := &syn.Bool{
-		Inner: arg1.Equal(arg2),
-	}
-
-	value := &Constant{result}
-
-	return value, nil
+	return boolConstant(arg1.Equal(arg2)), nil
 }
 
 func serialiseData[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {

--- a/cek/cost_model.go
+++ b/cek/cost_model.go
@@ -171,16 +171,16 @@ func bigIntExMemValue(i *big.Int) ExMem {
 
 func byteArrayExMem(b []byte) func() ExMem {
 	return func() ExMem {
-		length := len(b)
-
-		if length == 0 {
-			return ExMem(1)
-		} else {
-			i := ((length - 1) / 8) + 1
-
-			return ExMem(i)
-		}
+		return byteArrayExMemValue(b)
 	}
+}
+
+func byteArrayExMemValue(b []byte) ExMem {
+	length := len(b)
+	if length == 0 {
+		return ExMem(1)
+	}
+	return ExMem(((length - 1) / 8) + 1)
 }
 
 // Haskell uses T.length which returns the number of Unicode codepoints (characters),

--- a/cek/env.go
+++ b/cek/env.go
@@ -3,8 +3,9 @@ package cek
 import "github.com/blinklabs-io/plutigo/syn"
 
 type Env[T syn.Eval] struct {
-	data Value[T]
-	next *Env[T]
+	data  Value[T]
+	next  *Env[T]
+	skip4 *Env[T]
 }
 
 func lookupEnv[T syn.Eval](env *Env[T], idx int) (Value[T], bool) {
@@ -48,36 +49,107 @@ func lookupEnv[T syn.Eval](env *Env[T], idx int) (Value[T], bool) {
 			return zero, false
 		}
 		return env.data, true
+	case 5:
+		env = advanceEnv4(env)
+		if env == nil {
+			return zero, false
+		}
+		return env.data, true
+	case 6:
+		env = advanceEnv4(env)
+		if env == nil {
+			return zero, false
+		}
+		env = env.next
+		if env == nil {
+			return zero, false
+		}
+		return env.data, true
+	case 7:
+		env = advanceEnv4(env)
+		if env == nil {
+			return zero, false
+		}
+		env = env.next
+		if env == nil {
+			return zero, false
+		}
+		env = env.next
+		if env == nil {
+			return zero, false
+		}
+		return env.data, true
+	case 8:
+		env = advanceEnv4(env)
+		if env == nil {
+			return zero, false
+		}
+		env = env.next
+		if env == nil {
+			return zero, false
+		}
+		env = env.next
+		if env == nil {
+			return zero, false
+		}
+		env = env.next
+		if env == nil {
+			return zero, false
+		}
+		return env.data, true
 	}
 
-	current := env.next
+	current := env
 	remaining := idx - 1
-	for remaining > 2 && current != nil {
-		next := current.next
-		if next == nil {
-			current = nil
-			break
+	for remaining >= 4 {
+		current = advanceEnv4(current)
+		if current == nil {
+			return zero, false
 		}
-		current = next.next
-		remaining -= 2
+		remaining -= 4
 	}
-	if current == nil {
-		return zero, false
-	}
-	if remaining > 1 {
+	for remaining > 0 {
 		current = current.next
 		if current == nil {
 			return zero, false
 		}
+		remaining--
 	}
 
 	return current.data, true
 }
 
+func advanceEnv4[T syn.Eval](env *Env[T]) *Env[T] {
+	if env == nil {
+		return nil
+	}
+	if env.skip4 != nil {
+		return env.skip4
+	}
+	for range 4 {
+		env = env.next
+		if env == nil {
+			return nil
+		}
+	}
+	return env
+}
+
 func (e *Env[T]) Extend(data Value[T]) *Env[T] {
+	var skip4 *Env[T]
+	if e != nil {
+		skip := e.next
+		if skip != nil {
+			skip = skip.next
+			if skip != nil {
+				skip4 = skip.next
+			}
+		}
+	}
 	return &Env[T]{
-		data: data,
-		next: e,
+		data:  data,
+		next:  e,
+		skip4: skip4,
 	}
 }
 

--- a/cek/machine.go
+++ b/cek/machine.go
@@ -20,8 +20,9 @@ const debug = false
 const DebugBudget = false
 
 var (
-	sharedBuiltinTable      = newBuiltins[syn.DeBruijn]()
-	sharedBuiltinValueTable = newBuiltinValueTable[syn.DeBruijn]()
+	sharedBuiltinTable           = newBuiltins[syn.DeBruijn]()
+	sharedBuiltinValueTable      = newBuiltinValueTable[syn.DeBruijn]()
+	sharedBuiltinNoArgValueTable = newBuiltinNoArgValueTable[syn.DeBruijn]()
 )
 
 // Machine is only instantiated with syn.DeBruijn in this codebase. These
@@ -33,6 +34,10 @@ func getSharedBuiltins[T syn.Eval]() *Builtins[T] {
 
 func getSharedBuiltinValues[T syn.Eval]() *[builtin.TotalBuiltinCount]*Builtin[T] {
 	return (*[builtin.TotalBuiltinCount]*Builtin[T])(unsafe.Pointer(&sharedBuiltinValueTable))
+}
+
+func getSharedBuiltinNoArgValues[T syn.Eval]() *[builtin.TotalBuiltinCount][3]*Builtin[T] {
+	return (*[builtin.TotalBuiltinCount][3]*Builtin[T])(unsafe.Pointer(&sharedBuiltinNoArgValueTable))
 }
 
 // See getSharedBuiltins for the syn.DeBruijn invariant behind this cast.
@@ -56,20 +61,21 @@ func getFilteredBuiltins[T syn.Eval](
 }
 
 type Machine[T syn.Eval] struct {
-	costs         CostModel
-	stepCosts     [9]ExBudget
-	stepCostCpu   [9]int64
-	stepCostMem   [9]int64
-	builtins      *Builtins[T]
-	builtinValues *[builtin.TotalBuiltinCount]*Builtin[T]
-	twoArgCosts   [builtin.TotalBuiltinCount]twoArgCost
-	available     *[builtin.TotalBuiltinCount]bool
-	slippage      uint32
-	version       lang.LanguageVersion
-	semantics     SemanticsVariant
-	protoMajor    uint
-	ExBudget      ExBudget
-	Logs          []string
+	costs              CostModel
+	stepCosts          [9]ExBudget
+	stepCostCpu        [9]int64
+	stepCostMem        [9]int64
+	builtins           *Builtins[T]
+	builtinValues      *[builtin.TotalBuiltinCount]*Builtin[T]
+	builtinNoArgValues *[builtin.TotalBuiltinCount][3]*Builtin[T]
+	twoArgCosts        [builtin.TotalBuiltinCount]twoArgCost
+	available          *[builtin.TotalBuiltinCount]bool
+	slippage           uint32
+	version            lang.LanguageVersion
+	semantics          SemanticsVariant
+	protoMajor         uint
+	ExBudget           ExBudget
+	Logs               []string
 
 	argHolder       argHolder[T]
 	frameStack      []stackFrame[T]
@@ -121,6 +127,7 @@ type Machine[T syn.Eval] struct {
 	builtinChunkPos        int
 	builtinArgChunks       [][]BuiltinArgs[T]
 	builtinArgChunkPos     int
+	valueArenaChunkSize    int
 	envChunks              [][]Env[T]
 	envChunkPos            int
 	budgetTemplate         ExBudget
@@ -130,8 +137,9 @@ type Machine[T syn.Eval] struct {
 
 const (
 	envChunkSize          = 2048
-	envRetainChunkCap     = 8
-	valueChunkSize        = 512
+	envRetainChunkCap     = 64
+	valueColdChunkSize    = 512
+	valueMaxChunkSize     = 262144
 	valueElemChunkSize    = 1024
 	valueRetainChunkCap   = 8
 	constantElemChunkSize = 4096
@@ -287,12 +295,29 @@ func newBuiltinValueTable[T syn.Eval]() [builtin.TotalBuiltinCount]*Builtin[T] {
 	return ret
 }
 
-func allocArenaSlot[S any](chunks *[][]S, pos *int) *S {
-	chunkIdx := *pos / valueChunkSize
-	if chunkIdx == len(*chunks) {
-		*chunks = append(*chunks, make([]S, valueChunkSize))
+func newBuiltinNoArgValueTable[T syn.Eval]() [builtin.TotalBuiltinCount][3]*Builtin[T] {
+	var ret [builtin.TotalBuiltinCount][3]*Builtin[T]
+	for i := 0; i < int(builtin.TotalBuiltinCount); i++ {
+		fn := builtin.DefaultFunction(i)
+		for forces := 0; forces < len(ret[i]); forces++ {
+			ret[i][forces] = &Builtin[T]{
+				Func:   fn,
+				Forces: uint(forces),
+			}
+		}
 	}
-	slot := &(*chunks)[chunkIdx][*pos%valueChunkSize]
+	return ret
+}
+
+func allocArenaSlot[S any](chunks *[][]S, pos *int, chunkSize int) *S {
+	if chunkSize <= 0 {
+		chunkSize = valueColdChunkSize
+	}
+	chunkIdx := *pos / chunkSize
+	if chunkIdx == len(*chunks) {
+		*chunks = append(*chunks, make([]S, chunkSize))
+	}
+	slot := &(*chunks)[chunkIdx][*pos%chunkSize]
 	*pos += 1
 	return slot
 }
@@ -410,53 +435,86 @@ func lazyPrepareArenaChunks[S any](
 	*pos = 0
 }
 
+func nextValueArenaChunkSize(used int) int {
+	if used <= valueColdChunkSize {
+		return valueColdChunkSize
+	}
+	chunkSize := valueColdChunkSize
+	for chunkSize < used && chunkSize < valueMaxChunkSize {
+		if chunkSize > valueMaxChunkSize/2 {
+			return valueMaxChunkSize
+		}
+		chunkSize *= 2
+	}
+	return chunkSize
+}
+
+func (m *Machine[T]) valueArenaHighWatermark() int {
+	used := m.constrChunkPos
+	used = max(used, m.delayChunkPos)
+	used = max(used, m.lambdaChunkPos)
+	used = max(used, m.constantChunkPos)
+	used = max(used, m.dataChunkPos)
+	used = max(used, m.integerChunkPos)
+	used = max(used, m.byteStringChunkPos)
+	used = max(used, m.protoListChunkPos)
+	used = max(used, m.protoPairChunkPos)
+	used = max(used, m.dataValueChunkPos)
+	used = max(used, m.dataListValueChunkPos)
+	used = max(used, m.dataMapValueChunkPos)
+	used = max(used, m.pairValueChunkPos)
+	used = max(used, m.builtinChunkPos)
+	used = max(used, m.builtinArgChunkPos)
+	return used
+}
+
 func (m *Machine[T]) allocDelay(term *syn.Delay[T], env *Env[T]) *Delay[T] {
-	delay := allocArenaSlot(&m.delayChunks, &m.delayChunkPos)
+	delay := allocArenaSlot(&m.delayChunks, &m.delayChunkPos, m.valueArenaChunkSize)
 	delay.AST = term
 	delay.Env = env
 	return delay
 }
 
 func (m *Machine[T]) allocConstr(tag uint, fields []Value[T]) *Constr[T] {
-	constr := allocArenaSlot(&m.constrChunks, &m.constrChunkPos)
+	constr := allocArenaSlot(&m.constrChunks, &m.constrChunkPos, m.valueArenaChunkSize)
 	constr.Tag = tag
 	constr.Fields = fields
 	return constr
 }
 
 func (m *Machine[T]) allocLambda(term *syn.Lambda[T], env *Env[T]) *Lambda[T] {
-	lambda := allocArenaSlot(&m.lambdaChunks, &m.lambdaChunkPos)
+	lambda := allocArenaSlot(&m.lambdaChunks, &m.lambdaChunkPos, m.valueArenaChunkSize)
 	lambda.AST = term
 	lambda.Env = env
 	return lambda
 }
 
 func (m *Machine[T]) allocConstant(con syn.IConstant) *Constant {
-	constant := allocArenaSlot(&m.constantChunks, &m.constantChunkPos)
+	constant := allocArenaSlot(&m.constantChunks, &m.constantChunkPos, m.valueArenaChunkSize)
 	constant.Constant = con
 	return constant
 }
 
 func (m *Machine[T]) allocDataConstant(inner data.PlutusData) *syn.Data {
-	dataConstant := allocArenaSlot(&m.dataChunks, &m.dataChunkPos)
+	dataConstant := allocArenaSlot(&m.dataChunks, &m.dataChunkPos, m.valueArenaChunkSize)
 	dataConstant.Inner = inner
 	return dataConstant
 }
 
 func (m *Machine[T]) allocIntegerConstant(inner *big.Int) *syn.Integer {
-	integerConstant := allocArenaSlot(&m.integerChunks, &m.integerChunkPos)
+	integerConstant := allocArenaSlot(&m.integerChunks, &m.integerChunkPos, m.valueArenaChunkSize)
 	integerConstant.SetInner(inner)
 	return integerConstant
 }
 
 func (m *Machine[T]) allocByteStringConstant(inner []byte) *syn.ByteString {
-	byteStringConstant := allocArenaSlot(&m.byteStringChunks, &m.byteStringChunkPos)
+	byteStringConstant := allocArenaSlot(&m.byteStringChunks, &m.byteStringChunkPos, m.valueArenaChunkSize)
 	byteStringConstant.Inner = inner
 	return byteStringConstant
 }
 
 func (m *Machine[T]) allocProtoListConstant(typ syn.Typ, list []syn.IConstant) *syn.ProtoList {
-	listConstant := allocArenaSlot(&m.protoListChunks, &m.protoListChunkPos)
+	listConstant := allocArenaSlot(&m.protoListChunks, &m.protoListChunkPos, m.valueArenaChunkSize)
 	listConstant.LTyp = typ
 	listConstant.List = list
 	return listConstant
@@ -468,7 +526,7 @@ func (m *Machine[T]) allocProtoPairConstant(
 	first syn.IConstant,
 	second syn.IConstant,
 ) *syn.ProtoPair {
-	pairConstant := allocArenaSlot(&m.protoPairChunks, &m.protoPairChunkPos)
+	pairConstant := allocArenaSlot(&m.protoPairChunks, &m.protoPairChunkPos, m.valueArenaChunkSize)
 	pairConstant.FstType = firstType
 	pairConstant.SndType = secondType
 	pairConstant.First = first
@@ -479,13 +537,13 @@ func (m *Machine[T]) allocProtoPairConstant(
 func (m *Machine[T]) allocDataListValue(
 	items []data.PlutusData,
 ) *dataListValue[T] {
-	listValue := allocArenaSlot(&m.dataListValueChunks, &m.dataListValueChunkPos)
+	listValue := allocArenaSlot(&m.dataListValueChunks, &m.dataListValueChunkPos, m.valueArenaChunkSize)
 	listValue.items = items
 	return listValue
 }
 
 func (m *Machine[T]) allocDataValue(item data.PlutusData) *dataValue[T] {
-	dataVal := allocArenaSlot(&m.dataValueChunks, &m.dataValueChunkPos)
+	dataVal := allocArenaSlot(&m.dataValueChunks, &m.dataValueChunkPos, m.valueArenaChunkSize)
 	dataVal.item = item
 	return dataVal
 }
@@ -493,7 +551,7 @@ func (m *Machine[T]) allocDataValue(item data.PlutusData) *dataValue[T] {
 func (m *Machine[T]) allocDataMapValue(
 	items [][2]data.PlutusData,
 ) *dataMapValue[T] {
-	listValue := allocArenaSlot(&m.dataMapValueChunks, &m.dataMapValueChunkPos)
+	listValue := allocArenaSlot(&m.dataMapValueChunks, &m.dataMapValueChunkPos, m.valueArenaChunkSize)
 	listValue.items = items
 	return listValue
 }
@@ -512,7 +570,7 @@ func (m *Machine[T]) allocPairValue(
 	first Value[T],
 	second Value[T],
 ) *pairValue[T] {
-	pair := allocArenaSlot(&m.pairValueChunks, &m.pairValueChunkPos)
+	pair := allocArenaSlot(&m.pairValueChunks, &m.pairValueChunkPos, m.valueArenaChunkSize)
 	pair.first = first
 	pair.second = second
 	return pair
@@ -540,7 +598,7 @@ func (m *Machine[T]) extendBuiltinArgs(
 	next *BuiltinArgs[T],
 	data Value[T],
 ) *BuiltinArgs[T] {
-	args := allocArenaSlot(&m.builtinArgChunks, &m.builtinArgChunkPos)
+	args := allocArenaSlot(&m.builtinArgChunks, &m.builtinArgChunkPos, m.valueArenaChunkSize)
 	args.data = data
 	args.next = next
 	return args
@@ -552,7 +610,10 @@ func (m *Machine[T]) allocBuiltin(
 	argCount uint,
 	args *BuiltinArgs[T],
 ) *Builtin[T] {
-	builtinValue := allocArenaSlot(&m.builtinChunks, &m.builtinChunkPos)
+	if argCount == 0 && args == nil && forces < 3 {
+		return m.builtinNoArgValues[fn][forces]
+	}
+	builtinValue := allocArenaSlot(&m.builtinChunks, &m.builtinChunkPos, m.valueArenaChunkSize)
 	builtinValue.Func = fn
 	builtinValue.Forces = forces
 	builtinValue.ArgCount = argCount
@@ -610,20 +671,21 @@ func NewMachine[T syn.Eval](
 		stepCostMem[i] = s.Mem
 	}
 	return &Machine[T]{
-		costs:         evalContext.CostModel,
-		stepCosts:     stepCosts,
-		stepCostCpu:   stepCostCpu,
-		stepCostMem:   stepCostMem,
-		builtins:      chooseBuiltins[T](version, evalContext.ProtoMajor),
-		builtinValues: getSharedBuiltinValues[T](),
-		twoArgCosts:   newTwoArgCostCache(evalContext.CostModel.builtinCosts),
-		available:     chooseAvailableBuiltins(version, evalContext.ProtoMajor),
-		slippage:      slippage,
-		version:       version,
-		semantics:     evalContext.SemanticsVariant,
-		protoMajor:    evalContext.ProtoMajor,
-		ExBudget:      DefaultExBudget,
-		Logs:          make([]string, 0),
+		costs:              evalContext.CostModel,
+		stepCosts:          stepCosts,
+		stepCostCpu:        stepCostCpu,
+		stepCostMem:        stepCostMem,
+		builtins:           chooseBuiltins[T](version, evalContext.ProtoMajor),
+		builtinValues:      getSharedBuiltinValues[T](),
+		builtinNoArgValues: getSharedBuiltinNoArgValues[T](),
+		twoArgCosts:        newTwoArgCostCache(evalContext.CostModel.builtinCosts),
+		available:          chooseAvailableBuiltins(version, evalContext.ProtoMajor),
+		slippage:           slippage,
+		version:            version,
+		semantics:          evalContext.SemanticsVariant,
+		protoMajor:         evalContext.ProtoMajor,
+		ExBudget:           DefaultExBudget,
+		Logs:               make([]string, 0),
 
 		argHolder:       newArgHolder[T](),
 		frameStack:      make([]stackFrame[T], 0, 32),
@@ -665,6 +727,7 @@ func NewMachine[T syn.Eval](
 		builtinChunkPos:       0,
 		builtinArgChunks:      make([][]BuiltinArgs[T], 0, 8),
 		builtinArgChunkPos:    0,
+		valueArenaChunkSize:   valueColdChunkSize,
 		envChunks:             make([][]Env[T], 0, 8),
 		envChunkPos:           0,
 		budgetTemplate:        DefaultExBudget,
@@ -707,6 +770,15 @@ func (m *Machine[T]) extendEnv(parent *Env[T], data Value[T]) *Env[T] {
 	m.envChunkPos += 1
 	env.data = data
 	env.next = parent
+	if parent != nil {
+		skip := parent.next
+		if skip != nil {
+			skip = skip.next
+			if skip != nil {
+				env.skip4 = skip.next
+			}
+		}
+	}
 	return env
 }
 
@@ -730,6 +802,11 @@ func (m *Machine[T]) resetEnvArena() {
 // the previous run's Env/Value graph pinned inside the Machine.
 func (m *Machine[T]) lazyPrepareEnvArena() {
 	lazyPrepareArenaChunks(&m.envChunks, &m.envChunkPos, envRetainChunkCap)
+}
+
+func (m *Machine[T]) dropEnvArena() {
+	m.envChunks = nil
+	m.envChunkPos = 0
 }
 
 func (m *Machine[T]) resetValueArenas() {
@@ -772,6 +849,43 @@ func (m *Machine[T]) lazyPrepareValueArenas() {
 	lazyPrepareArenaChunks(&m.builtinArgChunks, &m.builtinArgChunkPos, valueRetainChunkCap)
 }
 
+func (m *Machine[T]) dropValueArenas() {
+	m.constrChunks = nil
+	m.constrChunkPos = 0
+	m.delayChunks = nil
+	m.delayChunkPos = 0
+	m.lambdaChunks = nil
+	m.lambdaChunkPos = 0
+	m.constantChunks = nil
+	m.constantChunkPos = 0
+	m.dataChunks = nil
+	m.dataChunkPos = 0
+	m.integerChunks = nil
+	m.integerChunkPos = 0
+	m.byteStringChunks = nil
+	m.byteStringChunkPos = 0
+	m.protoListChunks = nil
+	m.protoListChunkPos = 0
+	m.protoPairChunks = nil
+	m.protoPairChunkPos = 0
+	m.dataValueChunks = nil
+	m.dataValueChunkPos = 0
+	m.dataListValueChunks = nil
+	m.dataListValueChunkPos = 0
+	m.dataMapValueChunks = nil
+	m.dataMapValueChunkPos = 0
+	m.pairValueChunks = nil
+	m.pairValueChunkPos = 0
+	m.constantElemChunks = nil
+	m.constantElemChunkPos = 0
+	m.valueElemChunks = nil
+	m.valueElemChunkPos = 0
+	m.builtinChunks = nil
+	m.builtinChunkPos = 0
+	m.builtinArgChunks = nil
+	m.builtinArgChunkPos = 0
+}
+
 func (m *Machine[T]) finishReturn(ret *Return[T]) (syn.Term[T], error) {
 	term, err := m.finishValue(ret.Value)
 	m.putReturn(ret)
@@ -798,7 +912,11 @@ func (m *Machine[T]) finishValue(value Value[T]) (syn.Term[T], error) {
 // budget restoration and frame-stack reset (the latter also defends against
 // tests or other callers that tamper with the frame stack between runs).
 func (m *Machine[T]) Run(term syn.Term[T]) (syn.Term[T], error) {
+	firstRun := !m.hasRun
 	if m.hasRun {
+		if m.valueArenaChunkSize <= 0 {
+			m.valueArenaChunkSize = valueColdChunkSize
+		}
 		if m.ExBudget != m.lastRunRemaining {
 			m.budgetTemplate = m.ExBudget
 		} else {
@@ -806,15 +924,29 @@ func (m *Machine[T]) Run(term syn.Term[T]) (syn.Term[T], error) {
 		}
 		m.resetFrameStack()
 	} else {
+		m.valueArenaChunkSize = valueColdChunkSize
 		m.budgetTemplate = m.ExBudget
 	}
+	runValueArenaChunkSize := m.valueArenaChunkSize
 	m.Logs = m.Logs[:0]
 	clear(m.unbudgetedSteps[:])
 	m.unbudgetedTotal = 0
 	defer func() {
+		nextChunkSize := nextValueArenaChunkSize(m.valueArenaHighWatermark())
 		m.lastRunRemaining = m.ExBudget
 		m.hasRun = true
 		m.resetFrameStack()
+		m.valueArenaChunkSize = nextChunkSize
+		if firstRun {
+			m.dropValueArenas()
+			m.dropEnvArena()
+			return
+		}
+		if nextChunkSize != runValueArenaChunkSize {
+			m.dropValueArenas()
+			m.lazyPrepareEnvArena()
+			return
+		}
 		m.lazyPrepareValueArenas()
 		m.lazyPrepareEnvArena()
 	}()

--- a/cek/machine_test.go
+++ b/cek/machine_test.go
@@ -189,6 +189,93 @@ func TestRunClearsRetainedArenaReferencesAfterReturn(t *testing.T) {
 	}
 }
 
+func TestRunKeepsSmallReusedValueArenaCold(t *testing.T) {
+	term := &syn.Lambda[syn.DeBruijn]{
+		ParameterName: syn.DeBruijn(0),
+		Body:          &syn.Var[syn.DeBruijn]{Name: syn.DeBruijn(1)},
+	}
+
+	tests := []struct {
+		name               string
+		setup              func() *Machine[syn.DeBruijn]
+		term               syn.Term[syn.DeBruijn]
+		wantChunkSize      int
+		wantLambdaChunks   int
+		wantLambdaChunkLen int
+	}{
+		{
+			name: "single lambda reuse",
+			setup: func() *Machine[syn.DeBruijn] {
+				return NewMachine[syn.DeBruijn](lang.LanguageVersionV3, 0, nil)
+			},
+			term:               term,
+			wantChunkSize:      valueColdChunkSize,
+			wantLambdaChunks:   1,
+			wantLambdaChunkLen: valueColdChunkSize,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := tt.setup()
+			term := tt.term
+
+			if _, err := m.Run(term); err != nil {
+				t.Fatalf("first Run returned error: %v", err)
+			}
+			if _, err := m.Run(term); err != nil {
+				t.Fatalf("second Run returned error: %v", err)
+			}
+
+			if got := m.valueArenaChunkSize; got != tt.wantChunkSize {
+				t.Fatalf("valueArenaChunkSize after small reuse = %d, want %d", got, tt.wantChunkSize)
+			}
+			if got := len(m.lambdaChunks); got != tt.wantLambdaChunks {
+				t.Fatalf("len(lambdaChunks) after small reuse = %d, want %d", got, tt.wantLambdaChunks)
+			}
+			if tt.wantLambdaChunks == 0 {
+				return
+			}
+			if got := len(m.lambdaChunks[0]); got != tt.wantLambdaChunkLen {
+				t.Fatalf("len(lambdaChunks[0]) after small reuse = %d, want %d", got, tt.wantLambdaChunkLen)
+			}
+		})
+	}
+}
+
+func TestRunStackLambdaImmediateFastPathSkipsLambdaArena(t *testing.T) {
+	m := NewMachine[syn.DeBruijn](lang.LanguageVersionV3, 2, nil)
+	term := &syn.Apply[syn.DeBruijn]{
+		Function: &syn.Lambda[syn.DeBruijn]{
+			ParameterName: syn.DeBruijn(0),
+			Body:          &syn.Var[syn.DeBruijn]{Name: syn.DeBruijn(1)},
+		},
+		Argument: &syn.Constant{Con: &syn.Integer{Inner: big.NewInt(42)}},
+	}
+
+	for _, run := range []string{"first", "second"} {
+		out, err := m.Run(term)
+		if err != nil {
+			t.Fatalf("%s Run returned error: %v", run, err)
+		}
+		outConst, ok := out.(*syn.Constant)
+		if !ok {
+			t.Fatalf("%s Run returned %T, want *syn.Constant", run, out)
+		}
+		outInt, ok := outConst.Con.(*syn.Integer)
+		if !ok {
+			t.Fatalf("%s Run returned %T constant, want *syn.Integer", run, outConst.Con)
+		}
+		if got := outInt.Inner.Int64(); got != 42 {
+			t.Fatalf("%s Run integer = %d, want 42", run, got)
+		}
+	}
+
+	if got := len(m.lambdaChunks); got != 0 {
+		t.Fatalf("len(lambdaChunks) after lambda immediate fast path = %d, want 0", got)
+	}
+}
+
 func TestResetEnvArenaRetainsOnlyTrackedChunkHeaders(t *testing.T) {
 	m := NewMachine[syn.DeBruijn](lang.LanguageVersionV3, 0, nil)
 
@@ -245,6 +332,14 @@ func TestLookupEnvUsesOneIndexedDepth(t *testing.T) {
 		deepEnv = deepEnv.Extend(&Constant{&syn.Integer{Inner: big.NewInt(i)}})
 	}
 
+	var linearDeepEnv *Env[syn.DeBruijn]
+	for i := int64(1); i <= 10; i++ {
+		linearDeepEnv = &Env[syn.DeBruijn]{
+			data: &Constant{&syn.Integer{Inner: big.NewInt(i)}},
+			next: linearDeepEnv,
+		}
+	}
+
 	tests := []struct {
 		name         string
 		env          *Env[syn.DeBruijn]
@@ -262,6 +357,9 @@ func TestLookupEnvUsesOneIndexedDepth(t *testing.T) {
 		{"deep idx=6 traverses loop", deepEnv, 6, 2, true},
 		{"deep idx=7 returns oldest", deepEnv, 7, 1, true},
 		{"deep idx=8 out of bounds", deepEnv, 8, -1, false},
+		{"linear idx=5 falls back without skip4", linearDeepEnv, 5, 6, true},
+		{"linear idx=9 falls back without skip4", linearDeepEnv, 9, 2, true},
+		{"linear idx=11 out of bounds", linearDeepEnv, 11, -1, false},
 	}
 
 	for _, tt := range tests {

--- a/cek/runtime.go
+++ b/cek/runtime.go
@@ -379,6 +379,36 @@ func (m *Machine[T]) CostThree(
 	return m.spendBudget(cost)
 }
 
+func (m *Machine[T]) CostThreeExMem(
+	b *builtin.DefaultFunction,
+	x, y, z ExMem,
+) error {
+	model := m.costs.builtinCosts[*b]
+	mem := model.mem.(ThreeArgument)
+	cpu := model.cpu.(ThreeArgument)
+
+	memConstants := mem.HasConstants()
+	cpuConstants := cpu.HasConstants()
+
+	xMem := x
+	if memConstants[0] && cpuConstants[0] {
+		xMem = ExMem(0)
+	}
+	yMem := y
+	if memConstants[1] && cpuConstants[1] {
+		yMem = ExMem(0)
+	}
+	zMem := z
+	if memConstants[2] && cpuConstants[2] {
+		zMem = ExMem(0)
+	}
+
+	return m.spendBudget(ExBudget{
+		Mem: int64(mem.CostThree(xMem, yMem, zMem)),
+		Cpu: int64(cpu.CostThree(xMem, yMem, zMem)),
+	})
+}
+
 func (m *Machine[T]) CostFour(
 	b *builtin.DefaultFunction,
 	x, y, z, u func() ExMem,

--- a/cek/stack_machine.go
+++ b/cek/stack_machine.go
@@ -266,6 +266,29 @@ func (m *Machine[T]) runStackNoSlippage(term syn.Term[T]) (syn.Term[T], error) {
 					return nil, m.budgetErrorForStep(ExApply)
 				}
 
+				if lambda, ok := t.Function.(*syn.Lambda[T]); ok {
+					if !m.spendStepNoSlippage(ExLambda) {
+						return nil, m.budgetErrorForStep(ExLambda)
+					}
+					if isImmediateTerm[T](t.Argument) {
+						argValue, err := m.computeKnownImmediateValueNoSlippage(currentEnv, t.Argument)
+						if err != nil {
+							return nil, err
+						}
+						currentTerm = lambda.Body
+						currentEnv = m.extendEnv(currentEnv, argValue)
+						currentValue = nil
+						returning = false
+						continue
+					}
+					frame := m.pushFrameSlot()
+					frame.kind = frameAwaitArgLambda
+					frame.env = currentEnv
+					frame.term = lambda.Body
+					currentTerm = t.Argument
+					continue
+				}
+
 				if isImmediateTerm[T](t.Function) {
 					funValue, err := m.computeKnownImmediateValueNoSlippage(currentEnv, t.Function)
 					if err != nil {
@@ -397,7 +420,6 @@ func (m *Machine[T]) runStackNoSlippage(term syn.Term[T]) (syn.Term[T], error) {
 		switch frame.kind {
 		case frameAwaitArg:
 			function := frame.value
-			frame.value = nil
 			m.frameStack = m.frameStack[:frameIdx]
 
 			var err error
@@ -411,8 +433,6 @@ func (m *Machine[T]) runStackNoSlippage(term syn.Term[T]) (syn.Term[T], error) {
 		case frameAwaitArgLambda:
 			env := frame.env
 			body := frame.term
-			frame.env = nil
-			frame.term = nil
 			m.frameStack = m.frameStack[:frameIdx]
 
 			currentTerm = body
@@ -421,7 +441,6 @@ func (m *Machine[T]) runStackNoSlippage(term syn.Term[T]) (syn.Term[T], error) {
 			returning = false
 		case frameAwaitArgBuiltin:
 			builtinValue := frame.builtin
-			frame.builtin = nil
 			m.frameStack = m.frameStack[:frameIdx]
 
 			var err error
@@ -432,8 +451,6 @@ func (m *Machine[T]) runStackNoSlippage(term syn.Term[T]) (syn.Term[T], error) {
 		case frameAwaitFunTerm:
 			env := frame.env
 			term := frame.term
-			frame.env = nil
-			frame.term = nil
 			m.frameStack = m.frameStack[:frameIdx]
 
 			if isImmediateTerm[T](term) {
@@ -457,7 +474,6 @@ func (m *Machine[T]) runStackNoSlippage(term syn.Term[T]) (syn.Term[T], error) {
 			returning = false
 		case frameAwaitFunValue:
 			arg := frame.value
-			frame.value = nil
 			m.frameStack = m.frameStack[:frameIdx]
 
 			var err error
@@ -483,9 +499,6 @@ func (m *Machine[T]) runStackNoSlippage(term syn.Term[T]) (syn.Term[T], error) {
 			if len(frame.fields) == 0 {
 				resolvedFields := frame.resolvedFields
 				tag := frame.tag
-				frame.env = nil
-				frame.fields = nil
-				frame.resolvedFields = nil
 				m.frameStack = m.frameStack[:frameIdx]
 
 				currentValue = m.allocConstr(tag, resolvedFields)
@@ -501,8 +514,6 @@ func (m *Machine[T]) runStackNoSlippage(term syn.Term[T]) (syn.Term[T], error) {
 		case frameCases:
 			env := frame.env
 			branches := frame.branches
-			frame.env = nil
-			frame.branches = nil
 			m.frameStack = m.frameStack[:frameIdx]
 
 			var err error
@@ -558,6 +569,29 @@ func (m *Machine[T]) runStack(term syn.Term[T]) (syn.Term[T], error) {
 			case *syn.Apply[T]:
 				if err := m.stepAndMaybeSpend(ExApply); err != nil {
 					return nil, err
+				}
+
+				if lambda, ok := t.Function.(*syn.Lambda[T]); ok {
+					if err := m.stepAndMaybeSpend(ExLambda); err != nil {
+						return nil, err
+					}
+					if isImmediateTerm[T](t.Argument) {
+						argValue, err := m.computeKnownImmediateValue(currentEnv, t.Argument)
+						if err != nil {
+							return nil, err
+						}
+						currentTerm = lambda.Body
+						currentEnv = m.extendEnv(currentEnv, argValue)
+						currentValue = nil
+						returning = false
+						continue
+					}
+					frame := m.pushFrameSlot()
+					frame.kind = frameAwaitArgLambda
+					frame.env = currentEnv
+					frame.term = lambda.Body
+					currentTerm = t.Argument
+					continue
 				}
 
 				if isImmediateTerm[T](t.Function) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up the `cek` runtime by tuning value/env arenas and adding a small `ed25519` verification cache. Cuts allocations, improves env lookups, and reduces repeated signature work.

- New Features
  - Added a small result cache for `ed25519.Verify` (messages ≤64 bytes, up to 4096 entries) with RW locking. Uses `CostThreeExMem` to charge budget directly from ExMem values.
  - Prebuilt shared no-arg builtin values for all functions (0–2 forces) to avoid per-call allocations.

- Refactors
  - Arena tuning: auto-tuned value arena chunk size (cold 512, up to 262144), pass size through all allocators, and drop value/env arenas after the first run; increased env retain cap to 64; added `dropValueArenas`/`dropEnvArena`.
  - Faster env access: `Env` now has a `skip4` pointer and `lookupEnv` jumps in groups of 4; `extendEnv` maintains skip pointers.
  - Execution fast path: direct lambda-apply when the argument is immediate; removed unnecessary frame field clearing; added small ExMem helpers and a tighter boolean constant path.

<sup>Written for commit 45aa2c2110618a3a00ed0ef3e999ff1c89e2905e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Introduced caching for Ed25519 signature verification to reduce computational overhead on repeated verifications.
  * Optimized environment traversal with faster lookup paths for improved execution speed.
  * Implemented adaptive memory arena chunk sizing for more efficient memory management across multiple runs.
  * Added fast path for lambda function application to accelerate certain evaluation patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->