### PR TITLE
fix: appease nilaway scanning

### DIFF
--- a/.github/workflows/nilaway.yml
+++ b/.github/workflows/nilaway.yml
@@ -2,6 +2,12 @@ name: nilaway
 
 on:
   workflow_dispatch:
+  push:
+    tags:
+      - v*
+    branches:
+      - main
+  pull_request:
 
 permissions:
   contents: read
@@ -20,4 +26,4 @@ jobs:
       - name: install nilaway
         run: go install go.uber.org/nilaway/cmd/nilaway@latest
       - name: run nilaway
-        run: nilaway ./...
+        run: nilaway -include-pkgs=github.com/blinklabs-io/plutigo -exclude-file-docstrings="<nilaway skip stack-machine>" ./...

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ BINARIES=$(shell cd $(ROOT_DIR)/cmd && ls -1 | grep -v ^common)
 
 # Common flags for fuzz tests
 FUZZ_FLAGS ?= -run=^$ -fuzztime=10s
+NILAWAY_FLAGS ?= -include-pkgs=github.com/blinklabs-io/plutigo -exclude-file-docstrings="<nilaway skip stack-machine>"
 
 .PHONY: mod-tidy test test-match test-cover bench bench-baseline bench-compare fuzz format golines clean download-plutus-tests validate validate-quick validate-fix nilaway
 
@@ -99,4 +100,4 @@ validate-fix: ## Run validation and auto-fix formatting issues
 	@./scripts/validate.sh --fix
 
 nilaway: mod-tidy ## Run nilaway nil safety analysis
-	go run go.uber.org/nilaway/cmd/nilaway@latest ./...
+	go run go.uber.org/nilaway/cmd/nilaway@latest $(NILAWAY_FLAGS) ./...

--- a/cek/stack_machine.go
+++ b/cek/stack_machine.go
@@ -1,3 +1,5 @@
+// <nilaway skip stack-machine>
+// The standalone NilAway driver times out on this large generic stack loop.
 package cek
 
 import (

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -92,11 +92,11 @@ fi
 # Step 4: Run nilaway
 echo_step "Running nilaway"
 if command -v nilaway &> /dev/null; then
-    if nilaway ./... 2>/dev/null; then
+    if nilaway -include-pkgs=github.com/blinklabs-io/plutigo -exclude-file-docstrings="<nilaway skip stack-machine>" ./... 2>/dev/null; then
         echo_pass "nilaway"
     else
         echo_fail "nilaway found nil safety issues"
-        echo "Run 'nilaway ./...' for details"
+        echo "Run 'nilaway -include-pkgs=github.com/blinklabs-io/plutigo -exclude-file-docstrings=\"<nilaway skip stack-machine>\" ./...' for details"
     fi
 else
     echo -e "${YELLOW}SKIP${NC}: nilaway not installed"

--- a/syn/flat_decode.go
+++ b/syn/flat_decode.go
@@ -473,6 +473,11 @@ func (a *arenaSlices[S]) alloc(n int) []S {
 
 	for a.chunkIdx < len(a.chunks) {
 		chunk := a.chunks[a.chunkIdx]
+		if chunk == nil {
+			a.chunkIdx++
+			a.offset = 0
+			continue
+		}
 		avail := len(chunk) - a.offset
 		if n <= avail {
 			start := a.offset
@@ -501,11 +506,15 @@ func (a *arenaSlices[S]) reset(retainCap int) {
 		retained = retainCap
 	}
 	for i := 0; i < retained; i++ {
+		chunk := a.chunks[i]
+		if chunk == nil {
+			continue
+		}
 		if i < a.chunkIdx {
-			clear(a.chunks[i])
+			clear(chunk)
 		} else if i == a.chunkIdx {
 			if a.offset > 0 {
-				clear(a.chunks[i][:a.offset])
+				clear(chunk[:a.offset])
 			}
 			break
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed potential nil-slice handling in memory allocation and reset operations to prevent runtime issues.

* **Chores**
  * Enhanced code quality analysis configuration in build system, CI workflows, and validation scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Configure `go.uber.org/nilaway` to run in CI (PRs, main, tags), scoped to `github.com/blinklabs-io/plutigo`, and skip the CEK stack machine to avoid timeouts. Add nil guards in `syn/flat_decode.go` (skip nil chunks in alloc/reset), and wire the same flags into the Makefile and validate script so local runs match CI.

<sup>Written for commit 24db8a1577db82ff2b34625dc2447cc6b843bc81. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

