### PR TITLE
fix(cek): unwrap constant type switch with new types

### DIFF
--- a/cek/builtins_test.go
+++ b/cek/builtins_test.go
@@ -3215,6 +3215,51 @@ func TestMkConsBuiltinOnDataListValue(t *testing.T) {
 	}
 }
 
+// TestMkConsDataValueOntoConstantList reproduces a regression where a dataValue
+// (optimized PlutusData wrapper) is consed onto a regular Constant ProtoList.
+// The unwrapConstant function must handle dataValue, not just *Constant.
+func TestMkConsDataValueOntoConstantList(t *testing.T) {
+	m := newTestMachine()
+	b := newTestBuiltin(builtin.MkCons)
+
+	// Left: a dataValue (the optimized type)
+	head := m.allocDataValue(&data.Integer{Inner: big.NewInt(42)})
+
+	// Right: a regular Constant ProtoList of Data
+	tail := &Constant{&syn.ProtoList{
+		LTyp: &syn.TData{},
+		List: []syn.IConstant{
+			&syn.Data{Inner: &data.Integer{Inner: big.NewInt(1)}},
+			&syn.Data{Inner: &data.Integer{Inner: big.NewInt(2)}},
+		},
+	}}
+
+	b = b.ApplyArg(head)
+	b = b.ApplyArg(tail)
+
+	val := evalBuiltin(t, m, b)
+	resultList := expectMaterializedProtoList(t, val)
+
+	expectedValues := []int64{42, 1, 2}
+	if len(resultList.List) != len(expectedValues) {
+		t.Fatalf("expected list with %d elements, got %d", len(expectedValues), len(resultList.List))
+	}
+
+	for i, expectedValue := range expectedValues {
+		dataElem, ok := resultList.List[i].(*syn.Data)
+		if !ok {
+			t.Fatalf("expected element %d to be Data, got %T", i, resultList.List[i])
+		}
+		intElem, ok := dataElem.Inner.(*data.Integer)
+		if !ok {
+			t.Fatalf("expected element %d inner to be Integer, got %T", i, dataElem.Inner)
+		}
+		if intElem.Inner.Cmp(big.NewInt(expectedValue)) != 0 {
+			t.Fatalf("expected element %d value %d, got %v", i, expectedValue, intElem.Inner)
+		}
+	}
+}
+
 func TestHeadListBuiltinOnDataMapValue(t *testing.T) {
 	m := newTestMachine()
 	b := newTestBuiltin(builtin.HeadList)

--- a/cek/runtime.go
+++ b/cek/runtime.go
@@ -446,17 +446,15 @@ func (m *Machine[T]) CostSix(
 }
 
 func unwrapConstant[T syn.Eval](value Value[T]) (*Constant, error) {
-	var i *Constant
-
 	switch v := value.(type) {
 	case *Constant:
-		i = v
-
+		return v, nil
 	default:
+		if c, ok := materializeConstantValue[T](value); ok {
+			return &Constant{Constant: c}, nil
+		}
 		return nil, &TypeError{Code: ErrCodeTypeMismatch, Expected: "Constant", Got: fmt.Sprintf("%T", value), Message: "type mismatch"}
 	}
-
-	return i, nil
 }
 
 func unwrapInteger[T syn.Eval](value Value[T]) (*big.Int, error) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a regression in `cek` where `unwrapConstant` didn’t handle optimized data values, restoring correct behavior for `MkCons` when consing a `dataValue` onto a `Constant` `ProtoList`.

- **Bug Fixes**
  - Updated `unwrapConstant` to materialize non-`*Constant` values via `materializeConstantValue`, avoiding type mismatch errors with optimized data types.
  - Added a regression test that conses a `dataValue` onto a `Constant` `ProtoList` and asserts the resulting list is correct.

<sup>Written for commit 47270db17faeda6eba101ba100a485929b5bcbc3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added targeted test coverage to exercise list construction with mixed value representations.

* **Improvements**
  * Streamlined constant handling in the runtime, improving robustness and modest performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->