### PR TITLE
fix(cek): cost model handling

### DIFF
--- a/cek/builtins.go
+++ b/cek/builtins.go
@@ -3963,12 +3963,15 @@ func dropList[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 	// Additional CPU spending proportional to |n| to align with conformance budgets
 	// Empirically derived cost model parameters for dropList operation.
 	const (
-		dropListCpuPerElement    int64 = 1957   // CPU cost per element to drop
 		dropListBaseCpuApprox    int64 = 212811 // Base CPU cost approximation
-		dropListHugeBitLenThresh       = 40     // ~1e12 threshold for "huge" requests
+		dropListHugeBitLenThresh int   = 40     // ~1e12 threshold for "huge" requests
 	)
 	if origAbsN.Sign() != 0 {
-		per := big.NewInt(dropListCpuPerElement)
+		perElementCpu := int64(1957)
+		if dropListCost, ok := m.costs.builtinCosts[builtin.DropList].cpu.(*DropListCost); ok {
+			perElementCpu = dropListCost.slope
+		}
+		per := big.NewInt(perElementCpu)
 		extra := new(big.Int).Mul(per, origAbsN)
 		// For extremely large requests, spend just enough so base+extra ~= MaxInt64
 		if origAbsN.BitLen() > dropListHugeBitLenThresh {

--- a/cek/cost_model_builtins.go
+++ b/cek/cost_model_builtins.go
@@ -73,14 +73,24 @@ func (b *BuiltinCosts) update(param string, val int64) error {
 		paramIdx = 5
 	}
 
-	// For 3-part parameter names (builtin-cpu/memory-arguments), only ConstantCost is valid
+	// Some parameter lists use a single value for models that also have
+	// calibrated default slopes/coefficients. In that case, update the
+	// leading term and preserve the calibrated defaults for the rest.
 	if len(paramParts) == 3 {
-		if constCost, ok := args.(*ConstantCost); ok {
-			constCost.c = val
+		switch a := args.(type) {
+		case *ConstantCost:
+			a.c = val
 			return nil
-		} else {
-			// For non-ConstantCost types with 3-part names, throw an error
-			// This can happen when genesis file format differs from code expectations
+		case *LinearCost:
+			a.intercept = val
+			return nil
+		case *DropListCost:
+			a.intercept = val
+			return nil
+		case *QuadraticInXModel:
+			a.coeff0 = val
+			return nil
+		default:
 			return errors.New("cannot map parameter name to costing info: " + param)
 		}
 	}
@@ -119,7 +129,19 @@ func (b *BuiltinCosts) update(param string, val int64) error {
 	case *ConstAboveDiagonalModel:
 		if len(paramParts) > 5 && paramParts[3] == "model" && paramParts[4] == "arguments" {
 			// Accessing the nested model (e.g., divideInteger-cpu-arguments-model-arguments-intercept)
-			if model, ok := a.model.(*MultipliedSizesModel); ok {
+			switch model := a.model.(type) {
+			case *LinearInXAndY:
+				switch paramParts[5] {
+				case "intercept":
+					model.intercept = val
+				case "slope1":
+					model.slope1 = val
+				case "slope2":
+					model.slope2 = val
+				default:
+					return fmt.Errorf("unknown model param for builtin %s: %s", builtinName, paramParts[5])
+				}
+			case *MultipliedSizesModel:
 				switch paramParts[5] {
 				case "intercept":
 					model.intercept = val
@@ -128,7 +150,7 @@ func (b *BuiltinCosts) update(param string, val int64) error {
 				default:
 					return fmt.Errorf("unknown model param for builtin %s: %s", builtinName, paramParts[5])
 				}
-			} else {
+			default:
 				return errors.New("unexpected model type for builtin " + builtinName)
 			}
 		} else {
@@ -171,12 +193,30 @@ func (b *BuiltinCosts) update(param string, val int64) error {
 		}
 	case *ExpMod:
 		switch paramParts[paramIdx] {
-		case "coeff00":
+		case "coeff00", "coefficient00":
 			a.coeff00 = val
-		case "coeff11":
+		case "coeff11", "coefficient11":
 			a.coeff11 = val
-		case "coeff12":
+		case "coeff12", "coefficient12":
 			a.coeff12 = val
+		default:
+			return fmt.Errorf("unknown cost param for builtin %s: %s", builtinName, paramParts[paramIdx])
+		}
+	case *DropListCost:
+		switch paramParts[paramIdx] {
+		case "intercept":
+			a.intercept = val
+		case "slope":
+			a.slope = val
+		default:
+			return fmt.Errorf("unknown cost param for builtin %s: %s", builtinName, paramParts[paramIdx])
+		}
+	case *FourLinearInU:
+		switch paramParts[paramIdx] {
+		case "intercept":
+			a.intercept = val
+		case "slope":
+			a.slope = val
 		default:
 			return fmt.Errorf("unknown cost param for builtin %s: %s", builtinName, paramParts[paramIdx])
 		}
@@ -253,6 +293,17 @@ func (b *BuiltinCosts) update(param string, val int64) error {
 			a.intercept = val
 		case "slope":
 			a.slope = val
+		default:
+			return fmt.Errorf("unknown cost param for builtin %s: %s", builtinName, paramParts[paramIdx])
+		}
+	case *QuadraticInXModel:
+		switch paramParts[paramIdx] {
+		case "coeff0", "c0", "intercept":
+			a.coeff0 = val
+		case "coeff1", "c1", "slope":
+			a.coeff1 = val
+		case "coeff2", "c2":
+			a.coeff2 = val
 		default:
 			return fmt.Errorf("unknown cost param for builtin %s: %s", builtinName, paramParts[paramIdx])
 		}
@@ -351,6 +402,19 @@ func (b *BuiltinCosts) update(param string, val int64) error {
 			a.coeff1 = val
 		case "coeff2", "c2":
 			a.coeff2 = val
+		default:
+			return fmt.Errorf("unknown cost param for builtin %s: %s", builtinName, paramParts[paramIdx])
+		}
+	case *WithInteractionInXAndY:
+		switch paramParts[paramIdx] {
+		case "c00":
+			a.c00 = val
+		case "c01":
+			a.c01 = val
+		case "c10":
+			a.c10 = val
+		case "c11":
+			a.c11 = val
 		default:
 			return fmt.Errorf("unknown cost param for builtin %s: %s", builtinName, paramParts[paramIdx])
 		}
@@ -1003,8 +1067,10 @@ var DefaultBuiltinCosts = BuiltinCosts{
 	},
 	builtin.DropList: &CostingFunc[Arguments]{
 		mem: &ConstantCost{4},
-		// Raise baseline CPU so n=0 matches expected total budget better
-		cpu: &ConstantCost{116711},
+		cpu: &DropListCost{LinearCost{
+			intercept: 116711,
+			slope:     1957,
+		}},
 	},
 	builtin.LengthOfArray: &CostingFunc[Arguments]{
 		mem: &ConstantCost{10},
@@ -1298,6 +1364,7 @@ var (
 	hasConstantsFalse1            = []bool{false}
 	hasConstantsFalseTrue         = []bool{false, true}
 	hasConstantsTrueFalse         = []bool{true, false}
+	hasConstantsTrueTrue          = []bool{true, true}
 	hasConstantsFalseFalse        = []bool{false, false}
 	hasConstantsFalseFalseFalse   = []bool{false, false, false}
 	hasConstantsFalseTrueTrue     = []bool{false, true, true}
@@ -1340,6 +1407,20 @@ func (LinearCost) HasConstants() []bool {
 func (l LinearCost) Cost(x ExMem) int64 {
 	return l.slope*int64(x) + l.intercept
 }
+
+type DropListCost struct {
+	LinearCost
+}
+
+func (d DropListCost) CostTwo(x, y ExMem) int64 {
+	return d.intercept
+}
+
+func (DropListCost) HasConstants() []bool {
+	return hasConstantsTrueTrue
+}
+
+func (DropListCost) isArguments() {}
 
 // TwoArgument interface for costing functions with two arguments
 type TwoArgument interface {

--- a/cek/cost_model_test.go
+++ b/cek/cost_model_test.go
@@ -299,6 +299,45 @@ func TestUpdateV3CostModel(t *testing.T) {
 	}
 }
 
+func TestUpdateV3CostModelWithExpModCoefficientNames(t *testing.T) {
+	params := make([]int64, len(lang.CostModelParamNamesV3))
+	var expModIdx int
+	foundExpMod := false
+	for i, name := range lang.CostModelParamNamesV3 {
+		if name == "expModInteger-cpu-arguments-coefficient00" {
+			expModIdx = i
+			foundExpMod = true
+			break
+		}
+	}
+	if !foundExpMod {
+		t.Fatal("expModInteger coefficient parameters not found")
+	}
+	params[expModIdx] = 607153
+	params[expModIdx+1] = 231697
+	params[expModIdx+2] = 53144
+
+	updatedCM, err := costModelFromList(
+		lang.LanguageVersionV3,
+		SemanticsVariantC,
+		params,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error building cost model from list: %s", err)
+	}
+
+	expModCPU := updatedCM.builtinCosts[builtin.ExpModInteger].cpu.(*ExpMod)
+	if expModCPU.coeff00 != 607153 {
+		t.Fatalf("expected expMod coeff00 to be 607153, got %d", expModCPU.coeff00)
+	}
+	if expModCPU.coeff11 != 231697 {
+		t.Fatalf("expected expMod coeff11 to be 231697, got %d", expModCPU.coeff11)
+	}
+	if expModCPU.coeff12 != 53144 {
+		t.Fatalf("expected expMod coeff12 to be 53144, got %d", expModCPU.coeff12)
+	}
+}
+
 func TestUpdateV1CostModelFromMap(t *testing.T) {
 	// PlutusV1 cost model from preview network alonzo-genesis.json
 	// Source: https://github.com/blinklabs-io/docker-cardano-configs/blob/main/config/preview/alonzo-genesis.json


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix cost model updates in `cek` so genesis parameters map correctly and `dropList` uses a configurable per‑element CPU slope. This improves compatibility with V3 parameter names and aligns budgets for `dropList`.

- **Bug Fixes**
  - Handle 3-part params for non-constant models by setting the intercept (`LinearCost`, `QuadraticInXModel`, `DropListCost`).
  - Accept `coefficient00/11/12` for `expModInteger` CPU; added a test to verify V3 names.
  - Support nested model updates in `ConstAboveDiagonalModel` for `LinearInXAndY`; add handlers for `QuadraticInXModel`, `WithInteractionInXAndY`, and `FourLinearInU`.
  - Add `DropListCost` and use it by default; `dropList` now reads the per-element CPU slope from the cost model (defaults to 1957) while keeping the base CPU intercept.

<sup>Written for commit f175102ccceaa359dc9bfdcff177483a03394e5e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved CPU cost calculation system to derive costs from runtime configuration instead of compile-time fixed values. DropList operations and other builtins now support flexible cost configuration aligned with machine cost models.
  * Extended cost model parameter update system to support additional cost model types and parameter aliases for greater configuration flexibility.

* **Tests**
  * Added test coverage for ExpMod coefficient parameter naming in V3 cost model configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->