### PR TITLE
perf(syn): low-nibble bits4 fast path

### DIFF
--- a/syn/flat_decode.go
+++ b/syn/flat_decode.go
@@ -1443,6 +1443,11 @@ func (d *decoder) bits4() (byte, error) {
 		d.usedBits = 4
 		return b0 >> 4, nil
 	}
+	if d.usedBits == 4 {
+		d.usedBits = 0
+		d.pos++
+		return b0 & 0x0f, nil
+	}
 
 	unusedBits := 8 - d.usedBits
 	if unusedBits < 4 && d.pos+1 >= len(d.buffer) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved internal buffer handling for edge-case decoding scenarios to ensure accurate data processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a low-nibble fast path to the `syn` decoder’s bits4() to return the second nibble directly when usedBits == 4. This skips extra bounds checks and shifting, reducing per-byte overhead while preserving correctness.

<sup>Written for commit 76db3f811fcf006581d1b827de9cd109d13a8e9d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

