### PR TITLE
perf(cek): direct DeBruijn `force (builtin ...)` path

### DIFF
--- a/cek/stack_machine_debruijn.go
+++ b/cek/stack_machine_debruijn.go
@@ -315,6 +315,20 @@ func runStackNoSlippageDeBruijn(
 					return nil, m.budgetErrorForStep(ExForce)
 				}
 
+				if builtinTerm, ok := t.Term.(*syn.Builtin); ok {
+					if !m.spendStepNoSlippage(ExBuiltin) {
+						return nil, m.budgetErrorForStep(ExBuiltin)
+					}
+					var err error
+					currentTerm, currentEnv, currentValue, returning, err = m.forceEvaluateStack(
+						m.builtinValues[builtinTerm.DefaultFunction],
+					)
+					if err != nil {
+						return nil, err
+					}
+					continue
+				}
+
 				if isImmediateTermDeBruijn(t.Term) {
 					forcedValue, err := computeKnownImmediateValueNoSlippageDeBruijn(
 						m,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a direct path for `force (builtin ...)` in the DeBruijn CEK machine. It resolves the builtin and calls `forceEvaluateStack` immediately, skipping general evaluation, reducing steps, and correctly charging `ExBuiltin` along with `ExForce`.

<sup>Written for commit 7ba9f9a31d197dd5fd0005df5e46e16c3383ecdb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

