### PR TITLE
perf(cek): active env chunk cache with a boundary limit

### DIFF
--- a/cek/machine.go
+++ b/cek/machine.go
@@ -131,6 +131,8 @@ type Machine[T syn.Eval] struct {
 	builtinArgChunkPos     int
 	valueArenaChunkSize    int
 	envChunks              [][]Env[T]
+	envActiveChunk         []Env[T]
+	envActiveChunkLimit    int
 	envChunkPos            int
 	budgetTemplate         ExBudget
 	lastRunRemaining       ExBudget
@@ -762,17 +764,23 @@ func chooseAvailableBuiltins(
 }
 
 func (m *Machine[T]) extendEnv(parent *Env[T], data Value[T]) *Env[T] {
-	chunkIdx := m.envChunkPos / envChunkSize
-	if chunkIdx == len(m.envChunks) {
-		m.envChunks = append(m.envChunks, make([]Env[T], envChunkSize))
+	pos := m.envChunkPos
+	chunk := m.envActiveChunk
+	if chunk == nil || pos == m.envActiveChunkLimit {
+		chunkIdx := pos / envChunkSize
+		if chunkIdx == len(m.envChunks) {
+			m.envChunks = append(m.envChunks, make([]Env[T], envChunkSize))
+		}
+		chunk = m.envChunks[chunkIdx]
+		if chunk == nil {
+			chunk = make([]Env[T], envChunkSize)
+			m.envChunks[chunkIdx] = chunk
+		}
+		m.envActiveChunk = chunk
+		m.envActiveChunkLimit = (chunkIdx + 1) * envChunkSize
 	}
-	chunk := m.envChunks[chunkIdx]
-	if chunk == nil {
-		chunk = make([]Env[T], envChunkSize)
-		m.envChunks[chunkIdx] = chunk
-	}
-	env := &chunk[m.envChunkPos%envChunkSize]
-	m.envChunkPos += 1
+	env := &chunk[pos%envChunkSize]
+	m.envChunkPos = pos + 1
 	env.data = data
 	env.next = parent
 	if parent != nil {
@@ -799,6 +807,8 @@ func (m *Machine[T]) resetEnvArena() {
 		copy(retained, m.envChunks[:envRetainChunkCap])
 		m.envChunks = retained
 	}
+	m.envActiveChunk = nil
+	m.envActiveChunkLimit = 0
 	m.envChunkPos = 0
 }
 
@@ -807,10 +817,14 @@ func (m *Machine[T]) resetEnvArena() {
 // the previous run's Env/Value graph pinned inside the Machine.
 func (m *Machine[T]) lazyPrepareEnvArena() {
 	lazyPrepareArenaChunks(&m.envChunks, &m.envChunkPos, envRetainChunkCap)
+	m.envActiveChunk = nil
+	m.envActiveChunkLimit = 0
 }
 
 func (m *Machine[T]) dropEnvArena() {
 	m.envChunks = nil
+	m.envActiveChunk = nil
+	m.envActiveChunkLimit = 0
 	m.envChunkPos = 0
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added an active environment chunk cache with a boundary limit in `cek` to reduce allocations and index work when extending envs. This speeds up the hot path in `extendEnv` during evaluation.

- **Performance**
  - Added `envActiveChunk` and `envActiveChunkLimit` to reuse the current chunk until its boundary.
  - Updated `extendEnv` to use the cached chunk and only compute/allocate when moving to a new chunk.
  - Cleared the cache in `resetEnvArena`, `lazyPrepareEnvArena`, and `dropEnvArena` to avoid stale state.

<sup>Written for commit 8003004ceb020f5113361fea78dad8f4ea984df4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

