### PR TITLE
perf(syn): use switch for hot bits4 usedBits checks

### DIFF
--- a/syn/flat_decode.go
+++ b/syn/flat_decode.go
@@ -1439,11 +1439,11 @@ func (d *decoder) bits4() (byte, error) {
 	}
 
 	b0 := d.buffer[d.pos]
-	if d.usedBits == 0 {
+	switch d.usedBits {
+	case 0:
 		d.usedBits = 4
 		return b0 >> 4, nil
-	}
-	if d.usedBits == 4 {
+	case 4:
 		d.usedBits = 0
 		d.pos++
 		return b0 & 0x0f, nil


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Optimized the `syn` decoder’s `bits4()` hot path by replacing consecutive `if` checks with a `switch` on `usedBits` to reduce branching and improve performance. No functional changes.

<sup>Written for commit acfbc6e94efce09d69a9ff49812c7a90dd5af198. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal decoding logic efficiency through optimized control flow handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->