### PR TITLE
perf(cek): stack machine DeBruijn optimizations

### DIFF
--- a/cek/stack_machine_debruijn.go
+++ b/cek/stack_machine_debruijn.go
@@ -1,14 +1,37 @@
 // <nilaway skip stack-machine>
 package cek
 
-import "github.com/blinklabs-io/plutigo/syn"
+import (
+	"unsafe"
+
+	"github.com/blinklabs-io/plutigo/syn"
+)
+
+var nilControlTermDeBruijn syn.Term[syn.DeBruijn] = &syn.Error{}
+
+type termInterfaceDeBruijn struct {
+	tab  unsafe.Pointer
+	data unsafe.Pointer
+}
+
+var (
+	applyTermTabDeBruijn  = termTabDeBruijn(&syn.Apply[syn.DeBruijn]{})
+	forceTermTabDeBruijn  = termTabDeBruijn(&syn.Force[syn.DeBruijn]{})
+	caseTermTabDeBruijn   = termTabDeBruijn(&syn.Case[syn.DeBruijn]{})
+	constrTermTabDeBruijn = termTabDeBruijn(&syn.Constr[syn.DeBruijn]{})
+)
+
+func termTabDeBruijn(term syn.Term[syn.DeBruijn]) unsafe.Pointer {
+	return (*termInterfaceDeBruijn)(unsafe.Pointer(&term)).tab
+}
 
 func isImmediateTermDeBruijn(term syn.Term[syn.DeBruijn]) bool {
-	switch t := term.(type) {
-	case *syn.Apply[syn.DeBruijn], *syn.Force[syn.DeBruijn], *syn.Case[syn.DeBruijn]:
+	termIface := (*termInterfaceDeBruijn)(unsafe.Pointer(&term))
+	switch termIface.tab {
+	case applyTermTabDeBruijn, forceTermTabDeBruijn, caseTermTabDeBruijn:
 		return false
-	case *syn.Constr[syn.DeBruijn]:
-		return len(t.Fields) == 0
+	case constrTermTabDeBruijn:
+		return len((*syn.Constr[syn.DeBruijn])(termIface.data).Fields) == 0
 	default:
 		return true
 	}
@@ -144,6 +167,47 @@ func advanceEnv4DeBruijn(env *Env[syn.DeBruijn]) *Env[syn.DeBruijn] {
 	return env
 }
 
+func pushFrameSlotDeBruijn(
+	frameStack []stackFrame[syn.DeBruijn],
+	frameStackUsed int,
+) ([]stackFrame[syn.DeBruijn], int, *stackFrame[syn.DeBruijn]) {
+	frameIdx := len(frameStack)
+	if frameIdx < cap(frameStack) {
+		frameStack = frameStack[:frameIdx+1]
+	} else {
+		frameStack = append(frameStack, stackFrame[syn.DeBruijn]{})
+	}
+	if len(frameStack) > frameStackUsed {
+		frameStackUsed = len(frameStack)
+	}
+	return frameStack, frameStackUsed, &frameStack[frameIdx]
+}
+
+func pushAwaitArgFrameDeBruijn(
+	frameStack []stackFrame[syn.DeBruijn],
+	frameStackUsed int,
+	funValue Value[syn.DeBruijn],
+) ([]stackFrame[syn.DeBruijn], int) {
+	var frame *stackFrame[syn.DeBruijn]
+	frameStack, frameStackUsed, frame = pushFrameSlotDeBruijn(
+		frameStack,
+		frameStackUsed,
+	)
+	switch f := funValue.(type) {
+	case *Lambda[syn.DeBruijn]:
+		frame.kind = frameAwaitArgLambda
+		frame.env = f.Env
+		frame.term = f.AST.Body
+	case *Builtin[syn.DeBruijn]:
+		frame.kind = frameAwaitArgBuiltin
+		frame.builtin = f
+	default:
+		frame.kind = frameAwaitArg
+		frame.value = funValue
+	}
+	return frameStack, frameStackUsed
+}
+
 func computeKnownImmediateValueNoSlippageDeBruijn(
 	m *Machine[syn.DeBruijn],
 	env *Env[syn.DeBruijn],
@@ -202,6 +266,53 @@ func runStackNoSlippageDeBruijn(
 	currentTerm := term
 	var currentValue Value[syn.DeBruijn]
 	returning := false
+	envChunkPos := m.envChunkPos
+	envActiveChunk := m.envActiveChunk
+	envActiveChunkLimit := m.envActiveChunkLimit
+	syncEnvArena := func() {
+		m.envChunkPos = envChunkPos
+		m.envActiveChunk = envActiveChunk
+		m.envActiveChunkLimit = envActiveChunkLimit
+	}
+	defer syncEnvArena()
+	extendEnvLocal := func(parent *Env[syn.DeBruijn], data Value[syn.DeBruijn]) *Env[syn.DeBruijn] {
+		pos := envChunkPos
+		chunk := envActiveChunk
+		if chunk == nil || pos == envActiveChunkLimit {
+			chunkIdx := pos / envChunkSize
+			if chunkIdx == len(m.envChunks) {
+				m.envChunks = append(m.envChunks, make([]Env[syn.DeBruijn], envChunkSize))
+			}
+			chunk = m.envChunks[chunkIdx]
+			if chunk == nil {
+				chunk = make([]Env[syn.DeBruijn], envChunkSize)
+				m.envChunks[chunkIdx] = chunk
+			}
+			envActiveChunk = chunk
+			envActiveChunkLimit = (chunkIdx + 1) * envChunkSize
+		}
+		env := &chunk[pos%envChunkSize]
+		envChunkPos = pos + 1
+		env.data = data
+		env.next = parent
+		if parent != nil {
+			skip := parent.next
+			if skip != nil {
+				skip = skip.next
+				if skip != nil {
+					env.skip4 = skip.next
+				}
+			}
+		}
+		return env
+	}
+	frameStack := m.frameStack
+	frameStackUsed := m.frameStackUsed
+	syncFrameStack := func() {
+		m.frameStack = frameStack
+		m.frameStackUsed = frameStackUsed
+	}
+	defer syncFrameStack()
 
 	for {
 		if !returning {
@@ -251,12 +362,16 @@ func runStackNoSlippageDeBruijn(
 							return nil, err
 						}
 						currentTerm = lambda.Body
-						currentEnv = m.extendEnv(currentEnv, argValue)
+						currentEnv = extendEnvLocal(currentEnv, argValue)
 						currentValue = nil
 						returning = false
 						continue
 					}
-					frame := m.pushFrameSlot()
+					var frame *stackFrame[syn.DeBruijn]
+					frameStack, frameStackUsed, frame = pushFrameSlotDeBruijn(
+						frameStack,
+						frameStackUsed,
+					)
 					frame.kind = frameAwaitArgLambda
 					frame.env = currentEnv
 					frame.term = lambda.Body
@@ -283,22 +398,46 @@ func runStackNoSlippageDeBruijn(
 						if err != nil {
 							return nil, err
 						}
-						currentTerm, currentEnv, currentValue, returning, err = m.applyEvaluateStack(
-							funValue,
-							argValue,
-						)
+						if lambdaValue, ok := funValue.(*Lambda[syn.DeBruijn]); ok {
+							currentTerm = lambdaValue.AST.Body
+							currentEnv = extendEnvLocal(lambdaValue.Env, argValue)
+							currentValue = nil
+							returning = false
+						} else {
+							currentTerm, currentEnv, currentValue, returning, err = m.applyEvaluateStack(
+								funValue,
+								argValue,
+							)
+						}
 						if err != nil {
 							return nil, err
+						}
+						if currentTerm == nil {
+							if !returning {
+								return nil, &InternalError{
+									Code:    ErrCodeInternalError,
+									Message: "nil control term in DeBruijn evaluator",
+								}
+							}
+							currentTerm = nilControlTermDeBruijn
 						}
 						continue
 					}
 
-					m.pushAwaitArgFrame(funValue)
+					frameStack, frameStackUsed = pushAwaitArgFrameDeBruijn(
+						frameStack,
+						frameStackUsed,
+						funValue,
+					)
 					currentTerm = t.Argument
 					continue
 				}
 
-				frame := m.pushFrameSlot()
+				var frame *stackFrame[syn.DeBruijn]
+				frameStack, frameStackUsed, frame = pushFrameSlotDeBruijn(
+					frameStack,
+					frameStackUsed,
+				)
 				frame.kind = frameAwaitFunTerm
 				frame.env = currentEnv
 				frame.term = t.Argument
@@ -326,6 +465,15 @@ func runStackNoSlippageDeBruijn(
 					if err != nil {
 						return nil, err
 					}
+					if currentTerm == nil {
+						if !returning {
+							return nil, &InternalError{
+								Code:    ErrCodeInternalError,
+								Message: "nil control term in DeBruijn evaluator",
+							}
+						}
+						currentTerm = nilControlTermDeBruijn
+					}
 					continue
 				}
 
@@ -344,10 +492,23 @@ func runStackNoSlippageDeBruijn(
 					if err != nil {
 						return nil, err
 					}
+					if currentTerm == nil {
+						if !returning {
+							return nil, &InternalError{
+								Code:    ErrCodeInternalError,
+								Message: "nil control term in DeBruijn evaluator",
+							}
+						}
+						currentTerm = nilControlTermDeBruijn
+					}
 					continue
 				}
 
-				frame := m.pushFrameSlot()
+				var frame *stackFrame[syn.DeBruijn]
+				frameStack, frameStackUsed, frame = pushFrameSlotDeBruijn(
+					frameStack,
+					frameStackUsed,
+				)
 				frame.kind = frameForce
 				currentTerm = t.Term
 			case *syn.Error:
@@ -370,7 +531,11 @@ func runStackNoSlippageDeBruijn(
 					continue
 				}
 
-				frame := m.pushFrameSlot()
+				var frame *stackFrame[syn.DeBruijn]
+				frameStack, frameStackUsed, frame = pushFrameSlotDeBruijn(
+					frameStack,
+					frameStackUsed,
+				)
 				frame.kind = frameConstr
 				frame.env = currentEnv
 				frame.tag = t.Tag
@@ -391,18 +556,34 @@ func runStackNoSlippageDeBruijn(
 					if err != nil {
 						return nil, err
 					}
+					syncFrameStack()
 					currentTerm, currentEnv, currentValue, returning, err = m.caseEvaluateStack(
 						currentEnv,
 						t.Branches,
 						scrutinee,
 					)
+					frameStack = m.frameStack
+					frameStackUsed = m.frameStackUsed
 					if err != nil {
 						return nil, err
+					}
+					if currentTerm == nil {
+						if !returning {
+							return nil, &InternalError{
+								Code:    ErrCodeInternalError,
+								Message: "nil control term in DeBruijn evaluator",
+							}
+						}
+						currentTerm = nilControlTermDeBruijn
 					}
 					continue
 				}
 
-				frame := m.pushFrameSlot()
+				var frame *stackFrame[syn.DeBruijn]
+				frameStack, frameStackUsed, frame = pushFrameSlotDeBruijn(
+					frameStack,
+					frameStackUsed,
+				)
 				frame.kind = frameCases
 				frame.env = currentEnv
 				frame.branches = t.Branches
@@ -417,37 +598,53 @@ func runStackNoSlippageDeBruijn(
 			continue
 		}
 
-		if len(m.frameStack) == 0 {
+		if len(frameStack) == 0 {
 			return m.finishValue(currentValue)
 		}
-		frameIdx := len(m.frameStack) - 1
-		frame := &m.frameStack[frameIdx]
+		frameIdx := len(frameStack) - 1
+		frame := &frameStack[frameIdx]
 
 		switch frame.kind {
 		case frameAwaitArg:
 			function := frame.value
-			m.frameStack = m.frameStack[:frameIdx]
+			frameStack = frameStack[:frameIdx]
 
 			var err error
-			currentTerm, currentEnv, currentValue, returning, err = m.applyEvaluateStack(
-				function,
-				currentValue,
-			)
+			if lambdaValue, ok := function.(*Lambda[syn.DeBruijn]); ok {
+				currentTerm = lambdaValue.AST.Body
+				currentEnv = extendEnvLocal(lambdaValue.Env, currentValue)
+				currentValue = nil
+				returning = false
+			} else {
+				currentTerm, currentEnv, currentValue, returning, err = m.applyEvaluateStack(
+					function,
+					currentValue,
+				)
+			}
 			if err != nil {
 				return nil, err
+			}
+			if currentTerm == nil {
+				if !returning {
+					return nil, &InternalError{
+						Code:    ErrCodeInternalError,
+						Message: "nil control term in DeBruijn evaluator",
+					}
+				}
+				currentTerm = nilControlTermDeBruijn
 			}
 		case frameAwaitArgLambda:
 			env := frame.env
 			body := frame.term
-			m.frameStack = m.frameStack[:frameIdx]
+			frameStack = frameStack[:frameIdx]
 
 			currentTerm = body
-			currentEnv = m.extendEnv(env, currentValue)
+			currentEnv = extendEnvLocal(env, currentValue)
 			currentValue = nil
 			returning = false
 		case frameAwaitArgBuiltin:
 			builtinValue := frame.builtin
-			m.frameStack = m.frameStack[:frameIdx]
+			frameStack = frameStack[:frameIdx]
 
 			var err error
 			currentTerm, currentEnv, currentValue, returning, err = m.applyEvaluateStack(
@@ -457,44 +654,89 @@ func runStackNoSlippageDeBruijn(
 			if err != nil {
 				return nil, err
 			}
+			if currentTerm == nil {
+				if !returning {
+					return nil, &InternalError{
+						Code:    ErrCodeInternalError,
+						Message: "nil control term in DeBruijn evaluator",
+					}
+				}
+				currentTerm = nilControlTermDeBruijn
+			}
 		case frameAwaitFunTerm:
 			env := frame.env
 			term := frame.term
-			m.frameStack = m.frameStack[:frameIdx]
+			frameStack = frameStack[:frameIdx]
 
 			if isImmediateTermDeBruijn(term) {
 				argValue, err := computeKnownImmediateValueNoSlippageDeBruijn(m, env, term)
 				if err != nil {
 					return nil, err
 				}
-				currentTerm, currentEnv, currentValue, returning, err = m.applyEvaluateStack(
-					currentValue,
-					argValue,
-				)
+				if lambdaValue, ok := currentValue.(*Lambda[syn.DeBruijn]); ok {
+					currentTerm = lambdaValue.AST.Body
+					currentEnv = extendEnvLocal(lambdaValue.Env, argValue)
+					currentValue = nil
+					returning = false
+				} else {
+					currentTerm, currentEnv, currentValue, returning, err = m.applyEvaluateStack(
+						currentValue,
+						argValue,
+					)
+				}
 				if err != nil {
 					return nil, err
+				}
+				if currentTerm == nil {
+					if !returning {
+						return nil, &InternalError{
+							Code:    ErrCodeInternalError,
+							Message: "nil control term in DeBruijn evaluator",
+						}
+					}
+					currentTerm = nilControlTermDeBruijn
 				}
 				continue
 			}
 
-			m.pushAwaitArgFrame(currentValue)
+			frameStack, frameStackUsed = pushAwaitArgFrameDeBruijn(
+				frameStack,
+				frameStackUsed,
+				currentValue,
+			)
 			currentEnv = env
 			currentTerm = term
 			returning = false
 		case frameAwaitFunValue:
 			arg := frame.value
-			m.frameStack = m.frameStack[:frameIdx]
+			frameStack = frameStack[:frameIdx]
 
 			var err error
-			currentTerm, currentEnv, currentValue, returning, err = m.applyEvaluateStack(
-				currentValue,
-				arg,
-			)
+			if lambdaValue, ok := currentValue.(*Lambda[syn.DeBruijn]); ok {
+				currentTerm = lambdaValue.AST.Body
+				currentEnv = extendEnvLocal(lambdaValue.Env, arg)
+				currentValue = nil
+				returning = false
+			} else {
+				currentTerm, currentEnv, currentValue, returning, err = m.applyEvaluateStack(
+					currentValue,
+					arg,
+				)
+			}
 			if err != nil {
 				return nil, err
 			}
+			if currentTerm == nil {
+				if !returning {
+					return nil, &InternalError{
+						Code:    ErrCodeInternalError,
+						Message: "nil control term in DeBruijn evaluator",
+					}
+				}
+				currentTerm = nilControlTermDeBruijn
+			}
 		case frameForce:
-			m.frameStack = m.frameStack[:frameIdx]
+			frameStack = frameStack[:frameIdx]
 
 			var err error
 			currentTerm, currentEnv, currentValue, returning, err = m.forceEvaluateStack(
@@ -503,12 +745,21 @@ func runStackNoSlippageDeBruijn(
 			if err != nil {
 				return nil, err
 			}
+			if currentTerm == nil {
+				if !returning {
+					return nil, &InternalError{
+						Code:    ErrCodeInternalError,
+						Message: "nil control term in DeBruijn evaluator",
+					}
+				}
+				currentTerm = nilControlTermDeBruijn
+			}
 		case frameConstr:
 			frame.resolvedFields = append(frame.resolvedFields, currentValue)
 			if len(frame.fields) == 0 {
 				resolvedFields := frame.resolvedFields
 				tag := frame.tag
-				m.frameStack = m.frameStack[:frameIdx]
+				frameStack = frameStack[:frameIdx]
 
 				currentValue = m.allocConstr(tag, resolvedFields)
 				returning = true
@@ -523,16 +774,28 @@ func runStackNoSlippageDeBruijn(
 		case frameCases:
 			env := frame.env
 			branches := frame.branches
-			m.frameStack = m.frameStack[:frameIdx]
+			frameStack = frameStack[:frameIdx]
 
 			var err error
+			syncFrameStack()
 			currentTerm, currentEnv, currentValue, returning, err = m.caseEvaluateStack(
 				env,
 				branches,
 				currentValue,
 			)
+			frameStack = m.frameStack
+			frameStackUsed = m.frameStackUsed
 			if err != nil {
 				return nil, err
+			}
+			if currentTerm == nil {
+				if !returning {
+					return nil, &InternalError{
+						Code:    ErrCodeInternalError,
+						Message: "nil control term in DeBruijn evaluator",
+					}
+				}
+				currentTerm = nilControlTermDeBruijn
 			}
 		default:
 			return nil, &InternalError{


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Optimized the DeBruijn stack-machine in `cek` to reduce allocations and branching, with fast paths for lambda application and tighter frame/env management. This improves performance on apply/force/case hot paths and speeds up immediate-term checks.

- **Performance**
  - Added local env arena with chunk reuse and deferred sync; replaces `extendEnv` calls to cut allocations.
  - Managed frame stack locally with `pushFrameSlotDeBruijn`/`pushAwaitArgFrameDeBruijn`; sync only around `caseEvaluateStack`.
  - Introduced fast-path for lambdas (apply directly into body with local env) and immediate arg handling, avoiding extra frames.
  - Replaced interface type-switch with cached `unsafe` term tab pointers for immediate-term detection.

- **Bug Fixes**
  - Added a sentinel control term and explicit `InternalError` if a nil control term is encountered unexpectedly.

<sup>Written for commit 298a4e0c5dc67326866eed05e78d4a36e487d79c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

