### PR TITLE
fix(cek): measure frame stack len once

### DIFF
--- a/cek/stack_machine_debruijn.go
+++ b/cek/stack_machine_debruijn.go
@@ -598,10 +598,11 @@ func runStackNoSlippageDeBruijn(
 			continue
 		}
 
-		if len(frameStack) == 0 {
+		n := len(frameStack)
+		if n == 0 {
 			return m.finishValue(currentValue)
 		}
-		frameIdx := len(frameStack) - 1
+		frameIdx := n - 1
 		frame := &frameStack[frameIdx]
 
 		switch frame.kind {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Measure `frameStack` length once in `runStackNoSlippageDeBruijn` and reuse it for the empty check and frame index to avoid redundant reads and ensure consistent indexing. This is a small correctness and readability improvement in the `cek` stack machine.

<sup>Written for commit 59992419dcec5c2292a95dc20a84d671c5d7b432. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized internal stack-machine logic for improved code efficiency.

**Note:** This release contains internal improvements with no end-user facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->