### PR TITLE
perf: cache active chunks in decoders

### DIFF
--- a/data/arena_decoder.go
+++ b/data/arena_decoder.go
@@ -14,9 +14,10 @@ const (
 )
 
 type arenaChunks[S any] struct {
-	chunks   [][]S
-	chunkIdx int
-	offset   int
+	chunks      [][]S
+	chunkIdx    int
+	offset      int
+	activeChunk []S // cached pointer to chunks[chunkIdx]; nil when uninitialized
 }
 
 func (a *arenaChunks[S]) used() int {
@@ -26,32 +27,43 @@ func (a *arenaChunks[S]) used() int {
 	return a.chunkIdx*dataDecodeChunkSize + a.offset
 }
 
+// alloc returns the next free slot. The fast path uses the cached
+// activeChunk so we avoid reloading chunks[chunkIdx] on every call.
 func (a *arenaChunks[S]) alloc() *S {
-	if a.chunkIdx < len(a.chunks) {
-		chunk := a.chunks[a.chunkIdx]
-		if chunk != nil && a.offset < len(chunk) {
-			slot := &chunk[a.offset]
-			a.offset++
-			return slot
-		}
+	if a.offset < len(a.activeChunk) {
+		slot := &a.activeChunk[a.offset]
+		a.offset++
+		return slot
 	}
+	return a.allocSlow()
+}
 
+//go:noinline
+func (a *arenaChunks[S]) allocSlow() *S {
 	if nextIdx := a.chunkIdx + 1; nextIdx < len(a.chunks) {
 		chunk := a.chunks[nextIdx]
-		if chunk == nil {
-			goto allocNewChunk
+		if chunk != nil {
+			a.chunkIdx = nextIdx
+			a.activeChunk = chunk
+			a.offset = 1
+			return &chunk[0]
 		}
-		a.chunkIdx = nextIdx
-		a.offset = 1
-		return &chunk[0]
 	}
 
-allocNewChunk:
 	chunk := make([]S, dataDecodeChunkSize)
 	a.chunks = append(a.chunks, chunk)
 	a.chunkIdx = len(a.chunks) - 1
+	a.activeChunk = chunk
 	a.offset = 1
 	return &chunk[0]
+}
+
+func (a *arenaChunks[S]) setActiveChunkAfterReset() {
+	if len(a.chunks) > 0 {
+		a.activeChunk = a.chunks[0]
+	} else {
+		a.activeChunk = nil
+	}
 }
 
 func (a *arenaChunks[S]) reset(retainCap int) {
@@ -87,6 +99,7 @@ func (a *arenaChunks[S]) reset(retainCap int) {
 	}
 	a.chunkIdx = 0
 	a.offset = 0
+	a.setActiveChunkAfterReset()
 }
 
 func resetBigIntChunks(a *arenaChunks[big.Int], retainCap int) {
@@ -100,6 +113,7 @@ func resetBigIntChunks(a *arenaChunks[big.Int], retainCap int) {
 	}
 	a.chunkIdx = 0
 	a.offset = 0
+	a.setActiveChunkAfterReset()
 }
 
 type arenaSlices[S any] struct {

--- a/syn/flat_decode.go
+++ b/syn/flat_decode.go
@@ -398,9 +398,10 @@ func decodeTermListDeBruijnWithArena(
 }
 
 type arenaChunks[S any] struct {
-	chunks   [][]S
-	chunkIdx int
-	offset   int
+	chunks      [][]S
+	chunkIdx    int
+	offset      int
+	activeChunk []S // cached pointer to chunks[chunkIdx]; nil when chunkIdx >= len(chunks)
 }
 
 func (a *arenaChunks[S]) used() int {
@@ -410,32 +411,43 @@ func (a *arenaChunks[S]) used() int {
 	return a.chunkIdx*decodeTermChunkSize + a.offset
 }
 
+// alloc returns the next free slot. The fast path uses the cached
+// activeChunk so we avoid reloading chunks[chunkIdx] on every call.
 func (a *arenaChunks[S]) alloc() *S {
-	if a.chunkIdx < len(a.chunks) {
-		chunk := a.chunks[a.chunkIdx]
-		if chunk != nil && a.offset < len(chunk) {
-			slot := &chunk[a.offset]
-			a.offset++
-			return slot
-		}
+	if a.offset < len(a.activeChunk) {
+		slot := &a.activeChunk[a.offset]
+		a.offset++
+		return slot
 	}
+	return a.allocSlow()
+}
 
+//go:noinline
+func (a *arenaChunks[S]) allocSlow() *S {
 	if nextIdx := a.chunkIdx + 1; nextIdx < len(a.chunks) {
 		chunk := a.chunks[nextIdx]
-		if chunk == nil {
-			goto allocNewChunk
+		if chunk != nil {
+			a.chunkIdx = nextIdx
+			a.activeChunk = chunk
+			a.offset = 1
+			return &chunk[0]
 		}
-		a.chunkIdx = nextIdx
-		a.offset = 1
-		return &chunk[0]
 	}
 
-allocNewChunk:
 	chunk := make([]S, decodeTermChunkSize)
 	a.chunks = append(a.chunks, chunk)
 	a.chunkIdx = len(a.chunks) - 1
+	a.activeChunk = chunk
 	a.offset = 1
 	return &chunk[0]
+}
+
+func (a *arenaChunks[S]) setActiveChunkAfterReset() {
+	if len(a.chunks) > 0 {
+		a.activeChunk = a.chunks[0]
+	} else {
+		a.activeChunk = nil
+	}
 }
 
 func (a *arenaChunks[S]) reset(retainCap int) {
@@ -471,6 +483,7 @@ func (a *arenaChunks[S]) reset(retainCap int) {
 	}
 	a.chunkIdx = 0
 	a.offset = 0
+	a.setActiveChunkAfterReset()
 }
 
 func resetBigIntChunks(a *arenaChunks[big.Int], retainCap int) {
@@ -484,6 +497,7 @@ func resetBigIntChunks(a *arenaChunks[big.Int], retainCap int) {
 	}
 	a.chunkIdx = 0
 	a.offset = 0
+	a.setActiveChunkAfterReset()
 }
 
 type arenaSlices[S any] struct {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Cache the active chunk in decoder arenas to avoid slice lookups on each allocation, reducing overhead in tight decode loops. This speeds up `alloc` and keeps the cache consistent across chunk advances and resets.

- **Refactors**
  - Added `activeChunk` cache in `arenaChunks` and a fast path in `alloc`.
  - Introduced `allocSlow` (marked `//go:noinline`) for chunk rollover and allocation.
  - Updated chunk advancement and `reset` to keep `activeChunk` in sync via `setActiveChunkAfterReset`.

<sup>Written for commit 6d3321dda9fd675ac758a8d590223be36b215d23. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

