### PR TITLE
perf(cek): cache builtin force/arity lookups

### DIFF
--- a/cek/stack_machine.go
+++ b/cek/stack_machine.go
@@ -869,9 +869,13 @@ func (m *Machine[T]) applyEvaluateStack(
 	case *Lambda[T]:
 		return f.AST.Body, m.extendEnv(f.Env, arg), nil, false, nil
 	case *Builtin[T]:
-		if !f.NeedsForce() && f.IsArrow() {
+		// Cache the per-builtin force/arity table lookups so we don't repeat
+		// them for each branch below.
+		forceCount := f.Func.ForceCount()
+		arity := f.Func.Arity()
+		if forceCount <= f.Forces && arity > f.ArgCount {
 			nextArgCount := f.ArgCount + 1
-			if f.Func.ForceCount() == f.Forces {
+			if forceCount == f.Forces {
 				switch nextArgCount {
 				case 1:
 					if resolved, handled, err := m.evalUnaryBuiltinFast(f.Func, arg); handled {
@@ -904,19 +908,19 @@ func (m *Machine[T]) applyEvaluateStack(
 						}
 					}
 				}
-			}
-			if f.Func.Arity() == nextArgCount && f.Func.ForceCount() == f.Forces {
-				resolved, err := m.evalBuiltinAppWithArg(
-					f.Func,
-					f.Forces,
-					nextArgCount,
-					f.Args,
-					arg,
-				)
-				if err != nil {
-					return nil, nil, nil, false, err
+				if arity == nextArgCount {
+					resolved, err := m.evalBuiltinAppWithArg(
+						f.Func,
+						f.Forces,
+						nextArgCount,
+						f.Args,
+						arg,
+					)
+					if err != nil {
+						return nil, nil, nil, false, err
+					}
+					return nil, nil, resolved, true, nil
 				}
-				return nil, nil, resolved, true, nil
 			}
 			nextArgs := m.extendBuiltinArgs(f.Args, arg)
 			return nil, nil, m.allocBuiltin(f.Func, f.Forces, nextArgCount, nextArgs), true, nil
@@ -940,9 +944,10 @@ func (m *Machine[T]) forceEvaluateStack(
 	case *Delay[T]:
 		return v.AST.Term, v.Env, nil, false, nil
 	case *Builtin[T]:
-		if v.NeedsForce() {
+		forceCount := v.Func.ForceCount()
+		if forceCount > v.Forces {
 			nextForces := v.Forces + 1
-			if v.Func.ForceCount() == nextForces && v.Func.Arity() == v.ArgCount {
+			if forceCount == nextForces && v.Func.Arity() == v.ArgCount {
 				resolved, err := m.evalBuiltinAppReady(
 					v.Func,
 					nextForces,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Cache builtin force and arity lookups in the CEK evaluator to avoid repeated method calls during builtin application and forcing. This reduces overhead on hot paths when evaluating builtins.

- **Refactors**
  - Store force count and arity in locals and reuse them in `applyEvaluateStack` and `forceEvaluateStack`.
  - Preserve existing logic and outcomes; only eliminates repeated lookups in tight loops.

<sup>Written for commit 18bba15b98e0b72b2225fbc05f518d4765621ec9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal stack machine evaluation logic to reduce redundant operations and improve performance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/plutigo/pull/295)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->