### PR TITLE
fix(data): encode empty cbor bytestring as 40

### DIFF
--- a/data/data.go
+++ b/data/data.go
@@ -388,6 +388,9 @@ func (b ByteString) MarshalCBOR() ([]byte, error) {
 	// Haskell's Plutus encodes ByteStrings <= 64 bytes as definite-length,
 	// and ByteStrings > 64 bytes as indefinite-length with 64-byte chunks.
 	if len(b.Inner) <= 64 {
+		if b.Inner == nil {
+			return cborMarshal([]byte{})
+		}
 		return cborMarshal(b.Inner)
 	}
 	// Indefinite-length byte string with 64-byte chunks

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -688,6 +688,21 @@ func TestByteStringUnmarshalCBORIndefinite(t *testing.T) {
 	}
 }
 
+func TestByteStringMarshalCBOREmptyDecoded(t *testing.T) {
+	var decoded ByteString
+	if err := decoded.UnmarshalCBOR([]byte{0x40}); err != nil {
+		t.Fatalf("unmarshal empty bytestring: %v", err)
+	}
+
+	encoded, err := decoded.MarshalCBOR()
+	if err != nil {
+		t.Fatalf("marshal empty bytestring: %v", err)
+	}
+	if !bytes.Equal(encoded, []byte{0x40}) {
+		t.Fatalf("encoded empty bytestring = %x, want 40", encoded)
+	}
+}
+
 func TestEncodeDecodeRoundTrip(t *testing.T) {
 	for _, testDef := range testDefs {
 		// Encode
@@ -720,8 +735,30 @@ func FuzzDecodeCBOR(f *testing.F) {
 		f.Add(cborData)
 	}
 	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 4096 {
+			t.Skip()
+		}
+
 		var wrapper PlutusDataWrapper
-		_ = wrapper.UnmarshalCBOR(data) // Ignore errors, just check no panic
+		if err := wrapper.UnmarshalCBOR(data); err != nil {
+			return
+		}
+		if wrapper.Data == nil {
+			t.Fatal("decoded nil PlutusData without error")
+		}
+
+		encoded, err := wrapper.MarshalCBOR()
+		if err != nil {
+			t.Fatalf("failed to marshal decoded PlutusData: %v", err)
+		}
+
+		var decodedAgain PlutusDataWrapper
+		if err := decodedAgain.UnmarshalCBOR(encoded); err != nil {
+			t.Fatalf("failed to decode marshaled PlutusData: %v", err)
+		}
+		if !wrapper.Data.Equal(decodedAgain.Data) {
+			t.Fatalf("CBOR round-trip mismatch: got %v, want %v", decodedAgain.Data, wrapper.Data)
+		}
 	})
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Encode empty CBOR byte strings as 0x40 to match the CBOR spec and Plutus expectations, fixing round-trip mismatches and nil handling.

- **Bug Fixes**
  - Treat `nil` `ByteString` as empty and encode as definite-length `0x40`.
  - Add test to ensure decoding `0x40` re-encodes to `0x40`.
  - Strengthen fuzzing: cap input size, require non-nil after successful decode, and assert encode/decode round-trip equality.

<sup>Written for commit 8a9f2a34b0eb5fa35fe992dcfee483f92fa1880e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty data serialization to ensure consistent encoding and decoding operations.

* **Tests**
  * Enhanced fuzzing tests with stricter validation, improved error detection, and full encode-decode cycle verification.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/plutigo/pull/300)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->