### PR TITLE
fix(syn): escape control characters in pretty output

### DIFF
--- a/syn/pretty.go
+++ b/syn/pretty.go
@@ -472,8 +472,22 @@ func escapeString(s string) string {
 			builder.WriteString("\\n")
 		case '\t':
 			builder.WriteString("\\t")
+		case '\a':
+			builder.WriteString("\\a")
+		case '\b':
+			builder.WriteString("\\b")
+		case '\f':
+			builder.WriteString("\\f")
+		case '\r':
+			builder.WriteString("\\r")
+		case '\v':
+			builder.WriteString("\\v")
 		default:
-			builder.WriteRune(r)
+			if r < 0x20 || r == 0x7f {
+				fmt.Fprintf(&builder, "\\o%03o", r)
+			} else {
+				builder.WriteRune(r)
+			}
 		}
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Escape control characters in `syn` pretty output to keep logs and terminals readable and safe. Adds explicit escapes for \a, \b, \f, \r, \v and uses octal \oNNN for any non-printable ASCII (<0x20) or DEL (0x7f).

<sup>Written for commit d6ddc27a561ed99ee57f9c6a4e06ed1bf165e903. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

