### PR TITLE
test: updated fuzzer tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GO_FILES=$(shell find $(ROOT_DIR) -name '*.go')
 BINARIES=$(shell cd $(ROOT_DIR)/cmd && ls -1 | grep -v ^common)
 
 # Common flags for fuzz tests
-FUZZ_FLAGS ?= -run=^$ -fuzztime=10s
+FUZZ_FLAGS ?= -run='^$$' -fuzztime=10s
 NILAWAY_FLAGS ?= -include-pkgs=github.com/blinklabs-io/plutigo -exclude-file-docstrings="<nilaway skip stack-machine>"
 
 .PHONY: mod-tidy test test-match test-cover bench bench-baseline bench-compare fuzz format golines clean download-plutus-tests validate validate-quick validate-fix nilaway
@@ -61,6 +61,7 @@ fuzz: ## Run fuzz tests
 	@go test $(FUZZ_FLAGS) -fuzz=FuzzDecodeCBOR ./data
 	@go test $(FUZZ_FLAGS) -fuzz=FuzzParse ./syn
 	@go test $(FUZZ_FLAGS) -fuzz=FuzzPretty ./syn
+	@go test $(FUZZ_FLAGS) -fuzz=FuzzDecodeFlatDeBruijn ./syn
 	@go test $(FUZZ_FLAGS) -fuzz=FuzzLexerNextToken ./syn/lex
 	@go test $(FUZZ_FLAGS) -fuzz=FuzzMachineRun ./cek
 

--- a/builtin/default_function_test.go
+++ b/builtin/default_function_test.go
@@ -151,8 +151,8 @@ func TestConstants(t *testing.T) {
 }
 
 func FuzzFromByte(f *testing.F) {
-	validBytes := []byte{0, 1, 10, 20, 50, 90}
-	invalidBytes := []byte{94, 255}
+	validBytes := []byte{0, 1, 10, 20, 50, 87, 88, 89, 90, MaxDefaultFunction - 1, MaxDefaultFunction}
+	invalidBytes := []byte{MaxDefaultFunction + 1, 255}
 	for _, b := range validBytes {
 		f.Add(b)
 	}
@@ -176,6 +176,12 @@ func FuzzFromByte(f *testing.F) {
 					b,
 					df,
 				)
+			}
+			name := df.String()
+			if name != "" {
+				if got, ok := Builtins[name]; !ok || got != df {
+					t.Errorf("builtin reverse lookup for %q = %v, %v; want %v, true", name, got, ok, df)
+				}
 			}
 		} else {
 			if err == nil {

--- a/cek/fuzz_test.go
+++ b/cek/fuzz_test.go
@@ -1,0 +1,46 @@
+package cek
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/plutigo/syn"
+)
+
+func FuzzMachineRun(f *testing.F) {
+	for _, input := range fuzzMachineProgramSeeds() {
+		f.Add(input)
+	}
+
+	f.Fuzz(func(t *testing.T, input string) {
+		if len(input) > 2048 {
+			t.Skip()
+		}
+
+		program, err := syn.Parse(input)
+		if err != nil {
+			return
+		}
+
+		dbProgram, err := syn.NameToDeBruijn(program)
+		if err != nil {
+			return
+		}
+
+		machine := NewMachine[syn.DeBruijn](dbProgram.Version, 0, nil)
+		machine.ExBudget = ExBudget{Mem: 500_000, Cpu: 5_000_000}
+		_, _ = machine.Run(dbProgram.Term)
+	})
+}
+
+func fuzzMachineProgramSeeds() []string {
+	return []string{
+		"(program 1.0.0 (con integer 42))",
+		"(program 1.2.0 [(builtin addInteger) (con integer 1) (con integer 2)])",
+		"(program 1.2.0 [(lam x x) (con integer 7)])",
+		"(program 1.2.0 (force (delay (con integer 1))))",
+		"(program 1.2.0 [(builtin equalsInteger) (con integer 1) (con integer 1)])",
+		"(program 1.2.0 (constr 0 (con integer 1)))",
+		"(program 1.2.0 (case (constr 0 (con integer 1)) (lam x x)))",
+		"(program 1.2.0 (error))",
+	}
+}

--- a/syn/flat_fuzz_test.go
+++ b/syn/flat_fuzz_test.go
@@ -1,0 +1,76 @@
+package syn
+
+import (
+	"bytes"
+	"testing"
+)
+
+func FuzzDecodeFlatDeBruijn(f *testing.F) {
+	for _, input := range fuzzFlatProgramSeeds() {
+		program, err := Parse(input)
+		if err != nil {
+			f.Fatalf("failed to parse seed %q: %v", input, err)
+		}
+		dbProgram, err := NameToDeBruijn(program)
+		if err != nil {
+			f.Fatalf("failed to convert seed %q to De Bruijn: %v", input, err)
+		}
+		encoded, err := Encode(dbProgram)
+		if err != nil {
+			f.Fatalf("failed to encode seed %q: %v", input, err)
+		}
+		f.Add(encoded)
+	}
+
+	f.Fuzz(func(t *testing.T, input []byte) {
+		if len(input) > 4096 {
+			t.Skip()
+		}
+
+		genericProgram, genericErr := Decode[DeBruijn](input)
+		fastProgram, fastErr := DecodeDeBruijn(input)
+		if (genericErr != nil) != (fastErr != nil) {
+			t.Fatalf("Decode and DecodeDeBruijn error mismatch: generic=%v fast=%v", genericErr, fastErr)
+		}
+		if genericErr != nil {
+			return
+		}
+
+		genericEncoded, err := Encode(genericProgram)
+		if err != nil {
+			t.Fatalf("failed to re-encode generic decoded program: %v", err)
+		}
+		fastEncoded, err := Encode(fastProgram)
+		if err != nil {
+			t.Fatalf("failed to re-encode fast decoded program: %v", err)
+		}
+		if !bytes.Equal(genericEncoded, fastEncoded) {
+			t.Fatalf("Decode and DecodeDeBruijn re-encoded to different bytes")
+		}
+
+		decodedAgain, err := DecodeDeBruijn(fastEncoded)
+		if err != nil {
+			t.Fatalf("failed to decode re-encoded program: %v", err)
+		}
+		encodedAgain, err := Encode(decodedAgain)
+		if err != nil {
+			t.Fatalf("failed to encode decoded re-encoded program: %v", err)
+		}
+		if !bytes.Equal(fastEncoded, encodedAgain) {
+			t.Fatalf("FLAT encode/decode round-trip was not stable")
+		}
+	})
+}
+
+func fuzzFlatProgramSeeds() []string {
+	return []string{
+		"(program 1.0.0 (con integer 42))",
+		"(program 1.2.0 [(builtin addInteger) (con integer 1) (con integer 2)])",
+		"(program 1.2.0 (force (delay (con integer 1))))",
+		"(program 1.2.0 (con bytestring #deadbeef))",
+		"(program 1.2.0 (con string \"hello\\nworld\"))",
+		"(program 1.2.0 (con bool True))",
+		"(program 1.2.0 (constr 0 (con integer 1) (con bytestring #00)))",
+		"(program 1.2.0 (case (constr 0 (con integer 1)) (lam x x)))",
+	}
+}

--- a/syn/lex/lexer_test.go
+++ b/syn/lex/lexer_test.go
@@ -221,13 +221,18 @@ func FuzzLexerNextToken(f *testing.F) {
 		f.Add(input)
 	}
 	f.Fuzz(func(t *testing.T, input string) {
+		if len(input) > 4096 {
+			t.Skip()
+		}
+
 		lexer := NewLexer(input)
-		for {
+		maxTokens := len([]rune(input)) + 1
+		for i := 0; i < maxTokens; i++ {
 			token := lexer.NextToken()
 			if token.Type == TokenEOF {
-				break
+				return
 			}
-			// Just ensure no panic
 		}
+		t.Fatalf("lexer did not reach EOF after %d tokens", maxTokens)
 	})
 }

--- a/syn/parser_test.go
+++ b/syn/parser_test.go
@@ -40,22 +40,25 @@ func TestParsePrettyRoundTrip(t *testing.T) {
 }
 
 func FuzzParse(f *testing.F) {
-	f.Add("(program 1.2.0 (con integer 42))")
-	f.Add(
-		"(program 1.2.0 [(builtin addInteger) (con integer 1) (con integer 2)])",
-	)
+	for _, input := range fuzzProgramSeeds() {
+		f.Add(input)
+	}
 	f.Fuzz(func(t *testing.T, input string) {
-		// Just try to parse, don't care about result
-		Parse(input)
+		if len(input) > 4096 {
+			t.Skip()
+		}
+
+		program, err := Parse(input)
+		if err != nil {
+			return
+		}
+
+		_, _ = NameToDeBruijn(program)
 	})
 }
 
 func FuzzPretty(f *testing.F) {
-	testPrograms := []string{
-		"(program 1.2.0 (con integer 42))",
-		"(program 1.2.0 [(builtin addInteger) (con integer 1) (con integer 2)])",
-	}
-	for _, prog := range testPrograms {
+	for _, prog := range fuzzProgramSeeds() {
 		parsed, err := Parse(prog)
 		if err != nil {
 			f.Fatal("Failed to parse canonical program:", err)
@@ -63,7 +66,40 @@ func FuzzPretty(f *testing.F) {
 		f.Add(Pretty(parsed))
 	}
 	f.Fuzz(func(t *testing.T, pretty string) {
-		// Try to parse the pretty output
-		Parse(pretty)
+		if len(pretty) > 4096 {
+			t.Skip()
+		}
+
+		parsed, err := Parse(pretty)
+		if err != nil {
+			return
+		}
+
+		prettyAgain := Pretty(parsed)
+		parsedAgain, err := Parse(prettyAgain)
+		if err != nil {
+			t.Fatalf("failed to parse pretty output %q: %v", prettyAgain, err)
+		}
+
+		if stable := Pretty(parsedAgain); stable != prettyAgain {
+			t.Fatalf("pretty output was not stable:\nfirst:\n%s\nsecond:\n%s", prettyAgain, stable)
+		}
 	})
+}
+
+func fuzzProgramSeeds() []string {
+	return []string{
+		"(program 1.0.0 (con integer 42))",
+		"(program 1.2.0 [(builtin addInteger) (con integer 1) (con integer 2)])",
+		"(program 1.2.0 (lam x x))",
+		"(program 1.2.0 [(lam x x) (con integer 7)])",
+		"(program 1.2.0 (force (delay (con integer 1))))",
+		"(program 1.2.0 (con bytestring #deadbeef))",
+		"(program 1.2.0 (con string \"hello\\nworld\"))",
+		"(program 1.2.0 (con string \"nul\\0del\\DEL\"))",
+		"(program 1.2.0 (con bool True))",
+		"(program 1.2.0 (con unit ()))",
+		"(program 1.3.0 (constr 0 (con integer 1) (con bytestring #00)))",
+		"(program 1.3.0 (case (constr 0 (con integer 1)) (lam x x)))",
+	}
 }

--- a/syn/testdata/fuzz/FuzzDecodeFlatDeBruijn/e61d65308b39ce81
+++ b/syn/testdata/fuzz/FuzzDecodeFlatDeBruijn/e61d65308b39ce81
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("000L\x01\x01@\x000")

--- a/syn/testdata/fuzz/FuzzPretty/384d0948dcb207e0
+++ b/syn/testdata/fuzz/FuzzPretty/384d0948dcb207e0
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("(program 0.0.0(con string\"0\\00\"))")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expanded and hardened fuzz testing across `syn` and `cek` to catch parser/lexer/encoder regressions and ensure stable round-trips. Also updated `make fuzz` to run the new targets and fixed its regex.

- **New Features**
  - Added `cek` `FuzzMachineRun` to execute parsed De Bruijn programs with budgets.
  - Added `syn` `FuzzDecodeFlatDeBruijn` to compare generic vs fast decode and enforce FLAT round-trip stability; included corpus files.
  - Strengthened `FuzzParse`/`FuzzPretty` with more seeds, pretty-print stability checks, De Bruijn conversion, and input size caps.
  - Tightened `FuzzLexerNextToken` to bound tokens and require EOF.
  - Expanded `FuzzFromByte` to cover boundary values and verify reverse lookup in `Builtins`.

- **Bug Fixes**
  - Fixed `-run='^$$'` quoting in `make fuzz` and added the `FuzzDecodeFlatDeBruijn` target.

<sup>Written for commit 7704e3c0732c14b183b61ebb85836e88ee867fa8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

