### PR TITLE
fix(cek): expmod budget overflow

### DIFF
--- a/cek/cost_model_builtins.go
+++ b/cek/cost_model_builtins.go
@@ -3,6 +3,7 @@ package cek
 import (
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/blinklabs-io/plutigo/builtin"
@@ -1777,6 +1778,19 @@ type ThreeArgument interface {
 	Arguments
 }
 
+type checkedThreeArgument interface {
+	costThreeChecked(x, y, z ExMem) (int64, bool)
+}
+
+func costThree(arg ThreeArgument, x, y, z ExMem) (int64, bool) {
+	if checked, ok := arg.(checkedThreeArgument); ok {
+		return checked.costThreeChecked(x, y, z)
+	}
+
+	cost := arg.CostThree(x, y, z)
+	return cost, cost >= 0
+}
+
 // Implementations for ThreeArguments variants
 
 // Using existing ConstantCost for three arguments
@@ -1973,23 +1987,77 @@ type ExpMod struct {
 func (ExpMod) isArguments() {}
 
 func (l ExpMod) CostThree(aa, ee, mm ExMem) int64 {
-	cost0 := l.coeff00 + l.coeff11*int64(
-		ee,
-	)*int64(
-		mm,
-	) + l.coeff12*int64(
-		ee,
-	)*int64(
-		mm,
-	)*int64(
-		mm,
-	)
-
-	if int64(aa) <= int64(mm) {
-		return cost0
-	} else {
-		return cost0 + (cost0 / 2)
+	cost, ok := l.costThreeChecked(aa, ee, mm)
+	if !ok {
+		return math.MaxInt64
 	}
+
+	return cost
+}
+
+func (l ExpMod) costThreeChecked(aa, ee, mm ExMem) (int64, bool) {
+	aaVal := int64(aa)
+	eeVal := int64(ee)
+	mmVal := int64(mm)
+	if aaVal < 0 || eeVal < 0 || mmVal < 0 {
+		return 0, false
+	}
+
+	term11, ok := checkedMulInt64(l.coeff11, eeVal)
+	if !ok {
+		return 0, false
+	}
+	term11, ok = checkedMulInt64(term11, mmVal)
+	if !ok {
+		return 0, false
+	}
+
+	term12, ok := checkedMulInt64(l.coeff12, eeVal)
+	if !ok {
+		return 0, false
+	}
+	term12, ok = checkedMulInt64(term12, mmVal)
+	if !ok {
+		return 0, false
+	}
+	term12, ok = checkedMulInt64(term12, mmVal)
+	if !ok {
+		return 0, false
+	}
+
+	cost0, ok := checkedAddInt64(l.coeff00, term11)
+	if !ok {
+		return 0, false
+	}
+	cost0, ok = checkedAddInt64(cost0, term12)
+	if !ok {
+		return 0, false
+	}
+
+	if aaVal <= mmVal {
+		return cost0, true
+	}
+
+	return checkedAddInt64(cost0, cost0/2)
+}
+
+func checkedAddInt64(x, y int64) (int64, bool) {
+	if x < 0 || y < 0 || x > math.MaxInt64-y {
+		return 0, false
+	}
+
+	return x + y, true
+}
+
+func checkedMulInt64(x, y int64) (int64, bool) {
+	if x < 0 || y < 0 {
+		return 0, false
+	}
+	if x != 0 && y > math.MaxInt64/x {
+		return 0, false
+	}
+
+	return x * y, true
 }
 
 func (ExpMod) HasConstants() []bool {

--- a/cek/cost_model_test.go
+++ b/cek/cost_model_test.go
@@ -1,6 +1,7 @@
 package cek
 
 import (
+	"math"
 	"math/big"
 	"testing"
 
@@ -335,6 +336,56 @@ func TestUpdateV3CostModelWithExpModCoefficientNames(t *testing.T) {
 	}
 	if expModCPU.coeff12 != 53144 {
 		t.Fatalf("expected expMod coeff12 to be 53144, got %d", expModCPU.coeff12)
+	}
+}
+
+func TestExpModIntegerCostOverflowReturnsBudgetError(t *testing.T) {
+	m := NewMachine[syn.DeBruijn](lang.LanguageVersionV3, 0, nil)
+	originalBudget := m.ExBudget
+
+	fn := builtin.ExpModInteger
+	err := m.CostThree(
+		&fn,
+		func() ExMem { return ExMem(1) },
+		func() ExMem { return ExMem(55_779) },
+		func() ExMem { return ExMem(55_779) },
+	)
+	if err == nil {
+		t.Fatal("expected budget error for overflowing expModInteger cost, got nil")
+	}
+	if !IsBudgetError(err) {
+		t.Fatalf("expected budget error, got %T: %v", err, err)
+	}
+	if m.ExBudget != originalBudget {
+		t.Fatalf("budget mutated after cost overflow: got %+v, want %+v", m.ExBudget, originalBudget)
+	}
+}
+
+func TestExpModCostThreeSaturatesOnOverflow(t *testing.T) {
+	cost := ExpMod{
+		coeff00: 607153,
+		coeff11: 231697,
+		coeff12: 53144,
+	}.CostThree(ExMem(1), ExMem(55_779), ExMem(55_779))
+
+	if cost != math.MaxInt64 {
+		t.Fatalf("overflowing expModInteger cost = %d, want %d", cost, int64(math.MaxInt64))
+	}
+}
+
+func TestSpendBudgetRejectsNegativeCost(t *testing.T) {
+	m := NewMachine[syn.DeBruijn](lang.LanguageVersionV3, 0, nil)
+	originalBudget := m.ExBudget
+
+	err := m.spendBudget(ExBudget{Cpu: -1})
+	if err == nil {
+		t.Fatal("expected budget error for negative cost, got nil")
+	}
+	if !IsBudgetError(err) {
+		t.Fatalf("expected budget error, got %T: %v", err, err)
+	}
+	if m.ExBudget != originalBudget {
+		t.Fatalf("budget mutated after negative cost: got %+v, want %+v", m.ExBudget, originalBudget)
 	}
 }
 

--- a/cek/machine.go
+++ b/cek/machine.go
@@ -2005,20 +2005,29 @@ func (m *Machine[T]) spendBudget(exBudget ExBudget) error {
 		)
 	}
 
+	if exBudget.Mem < 0 || exBudget.Cpu < 0 {
+		return m.budgetError(exBudget, "invalid negative budget cost")
+	}
+
+	if exBudget.Mem > m.ExBudget.Mem || exBudget.Cpu > m.ExBudget.Cpu {
+		return m.budgetError(exBudget, "out of budget")
+	}
+
 	m.ExBudget.Mem -= exBudget.Mem
 	m.ExBudget.Cpu -= exBudget.Cpu
 
-	if m.ExBudget.Mem < 0 || m.ExBudget.Cpu < 0 {
-		return &BudgetError{
-			Code:      ErrCodeBudgetExhausted,
-			Requested: exBudget,
-			Available: ExBudget{
-				Cpu: m.ExBudget.Cpu + exBudget.Cpu,
-				Mem: m.ExBudget.Mem + exBudget.Mem,
-			},
-			Message: "out of budget",
-		}
-	}
-
 	return nil
+}
+
+func (m *Machine[T]) budgetCostOverflowError(exBudget ExBudget) error {
+	return m.budgetError(exBudget, "budget cost overflow")
+}
+
+func (m *Machine[T]) budgetError(exBudget ExBudget, message string) error {
+	return &BudgetError{
+		Code:      ErrCodeBudgetExhausted,
+		Requested: exBudget,
+		Available: m.ExBudget,
+		Message:   message,
+	}
 }

--- a/cek/runtime.go
+++ b/cek/runtime.go
@@ -2,6 +2,7 @@ package cek
 
 import (
 	"fmt"
+	"math"
 	"math/big"
 
 	"github.com/blinklabs-io/plutigo/builtin"
@@ -476,10 +477,19 @@ func (m *Machine[T]) CostThree(
 	if !model.memConstZ || !model.cpuConstZ {
 		zMem = z()
 	}
-	return m.spendBudget(ExBudget{
-		Mem: int64(mem.CostThree(xMem, yMem, zMem)),
-		Cpu: int64(cpu.CostThree(xMem, yMem, zMem)),
-	})
+	memCost, ok := costThree(mem, xMem, yMem, zMem)
+	if !ok {
+		return m.budgetCostOverflowError(ExBudget{Mem: math.MaxInt64})
+	}
+	cpuCost, ok := costThree(cpu, xMem, yMem, zMem)
+	if !ok {
+		return m.budgetCostOverflowError(ExBudget{
+			Mem: memCost,
+			Cpu: math.MaxInt64,
+		})
+	}
+
+	return m.spendBudget(ExBudget{Mem: memCost, Cpu: cpuCost})
 }
 
 func (m *Machine[T]) CostThreeExMem(
@@ -506,10 +516,19 @@ func (m *Machine[T]) CostThreeExMem(
 		zMem = ExMem(0)
 	}
 
-	return m.spendBudget(ExBudget{
-		Mem: int64(mem.CostThree(xMem, yMem, zMem)),
-		Cpu: int64(cpu.CostThree(xMem, yMem, zMem)),
-	})
+	memCost, ok := costThree(mem, xMem, yMem, zMem)
+	if !ok {
+		return m.budgetCostOverflowError(ExBudget{Mem: math.MaxInt64})
+	}
+	cpuCost, ok := costThree(cpu, xMem, yMem, zMem)
+	if !ok {
+		return m.budgetCostOverflowError(ExBudget{
+			Mem: memCost,
+			Cpu: math.MaxInt64,
+		})
+	}
+
+	return m.spendBudget(ExBudget{Mem: memCost, Cpu: cpuCost})
 }
 
 func (m *Machine[T]) CostFour(


### PR DESCRIPTION
This was reported by logcavq02@gmail.com

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an overflow in the `expModInteger` cost model that could corrupt budgeting. Costs now use checked math; on overflow we return a budget error and do not mutate the budget.

- **Bug Fixes**
  - Added overflow-checked cost path for three-arg models and used it in `CostThree`/`CostThreeExMem`.
  - Implemented checked arithmetic in `ExpMod`; overflow saturates to `math.MaxInt64` and is flagged.
  - Hardened `spendBudget` to reject negative costs and check limits before mutation; added consistent budget error helpers.
  - Added tests covering overflow handling and negative cost rejection.

<sup>Written for commit c0e76e5275627e337870e056ba6f934440ba613f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Implemented overflow protection for cost calculations to maintain system stability and prevent undefined behavior
  * Enhanced budget validation to prevent state corruption when operations exceed available resources

* **Tests**
  * Added comprehensive tests for overflow handling and budget constraint enforcement

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/plutigo/pull/304)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->