### PR TITLE
fix(data): plutus data decode limits

### DIFF
--- a/data/arena_decoder.go
+++ b/data/arena_decoder.go
@@ -222,56 +222,39 @@ func (d *Decoder) Reset() {
 
 // Decode decodes CBOR bytes into PlutusData; the Decoder is not safe for concurrent use.
 func (d *Decoder) Decode(data []byte) (PlutusData, error) {
-	v, err := d.decode(data)
+	v, err := d.decode(data, newDecodeState())
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode CBOR: %w", err)
 	}
 	return v, nil
 }
 
-func (d *Decoder) decode(data []byte) (PlutusData, error) {
-	if len(data) == 0 {
-		return nil, errors.New("empty data")
+func (d *Decoder) decode(data []byte, state *decodeState) (PlutusData, error) {
+	v, rest, err := d.decodeNextPlutusData(data, state)
+	if err != nil {
+		return nil, err
 	}
+	if len(rest) > 0 {
+		return nil, fmt.Errorf("unexpected %d trailing bytes", len(rest))
+	}
+	return v, nil
+}
+
+func (d *Decoder) decodePrimitive(data []byte) (PlutusData, error) {
 	cborType := data[0] & CborTypeMask
 	switch cborType {
 	case CborTypeUnsignedInt, CborTypeNegativeInt:
 		return d.decodeInteger(data)
 	case CborTypeByteString:
 		return d.decodeByteString(data)
-	case CborTypeArray:
-		tmpList, rest, err := d.decodeListNext(data)
-		if err != nil {
-			return nil, err
-		}
-		if len(rest) > 0 {
-			return nil, fmt.Errorf("unexpected %d trailing bytes", len(rest))
-		}
-		return tmpList, nil
-	case CborTypeMap:
-		tmpMap, rest, err := d.decodeMapNext(data)
-		if err != nil {
-			return nil, err
-		}
-		if len(rest) > 0 {
-			return nil, fmt.Errorf("unexpected %d trailing bytes", len(rest))
-		}
-		return tmpMap, nil
 	case CborTypeTag:
-		tagNumber, tagContent, err := decodeCBORTag(data)
+		tagNumber, _, err := decodeCBORTag(data)
 		if err != nil {
 			return nil, err
 		}
 		switch {
 		case tagNumber == 102 || (tagNumber >= 121 && tagNumber <= 127) || (tagNumber >= 1280 && tagNumber <= 1400):
-			tmpConstr, rest, err := d.decodeConstrNext(tagNumber, tagContent)
-			if err != nil {
-				return nil, err
-			}
-			if len(rest) > 0 {
-				return nil, fmt.Errorf("unexpected %d trailing bytes", len(rest))
-			}
-			return tmpConstr, nil
+			return nil, fmt.Errorf("unexpected constructor tag in scalar decoder: %d", tagNumber)
 		case tagNumber == 2 || tagNumber == 3:
 			return d.decodeInteger(data)
 		default:
@@ -281,20 +264,27 @@ func (d *Decoder) decode(data []byte) (PlutusData, error) {
 	return nil, fmt.Errorf("unsupported CBOR major type 0x%02x for PlutusData", cborType)
 }
 
-func (d *Decoder) decodeNextPlutusData(data []byte) (PlutusData, []byte, error) {
+func (d *Decoder) decodeNextPlutusData(
+	data []byte,
+	state *decodeState,
+) (PlutusData, []byte, error) {
 	if len(data) == 0 {
 		return nil, nil, errors.New("empty data")
 	}
+	if err := state.enterValue(); err != nil {
+		return nil, nil, err
+	}
+	defer state.leaveValue()
 
 	switch data[0] & CborTypeMask {
 	case CborTypeArray:
-		tmpList, rest, err := d.decodeListNext(data)
+		tmpList, rest, err := d.decodeListNextEntered(data, state)
 		if err != nil {
 			return nil, nil, err
 		}
 		return tmpList, rest, nil
 	case CborTypeMap:
-		tmpMap, rest, err := d.decodeMapNext(data)
+		tmpMap, rest, err := d.decodeMapNextEntered(data, state)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -306,7 +296,11 @@ func (d *Decoder) decodeNextPlutusData(data []byte) (PlutusData, []byte, error) 
 		}
 		switch {
 		case tagNumber == 102 || (tagNumber >= 121 && tagNumber <= 127) || (tagNumber >= 1280 && tagNumber <= 1400):
-			tmpConstr, rest, err := d.decodeConstrNext(tagNumber, tagContent)
+			tmpConstr, rest, err := d.decodeConstrNextEntered(
+				tagNumber,
+				tagContent,
+				state,
+			)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -314,22 +308,29 @@ func (d *Decoder) decodeNextPlutusData(data []byte) (PlutusData, []byte, error) 
 		}
 	}
 
-	item, rest, err := splitCBORItem(data)
+	item, rest, err := splitCBORItemEntered(data, state)
 	if err != nil {
 		return nil, nil, err
 	}
-	tmp, err := d.decode(item)
+	tmp, err := d.decodePrimitive(item)
 	if err != nil {
 		return nil, nil, err
 	}
 	return tmp, rest, nil
 }
 
-func (d *Decoder) decodeConstrNext(tagNumber uint64, data []byte) (*Constr, []byte, error) {
+func (d *Decoder) decodeConstrNextEntered(
+	tagNumber uint64,
+	data []byte,
+	state *decodeState,
+) (*Constr, []byte, error) {
 	constr := d.constrs.alloc()
 	switch {
 	case tagNumber >= 121 && tagNumber <= 127:
-		tmpFields, tmpUseIndef, rest, err := d.decodeListItemsNext(data)
+		tmpFields, tmpUseIndef, rest, err := d.decodeListItemsNextEntered(
+			data,
+			state,
+		)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -338,7 +339,10 @@ func (d *Decoder) decodeConstrNext(tagNumber uint64, data []byte) (*Constr, []by
 		constr.useIndef = tmpUseIndef
 		return constr, rest, nil
 	case tagNumber >= 1280 && tagNumber <= 1400:
-		tmpFields, tmpUseIndef, rest, err := d.decodeListItemsNext(data)
+		tmpFields, tmpUseIndef, rest, err := d.decodeListItemsNextEntered(
+			data,
+			state,
+		)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -364,7 +368,10 @@ func (d *Decoder) decodeConstrNext(tagNumber uint64, data []byte) (*Constr, []by
 		}
 		rest = next
 
-		tmpFields, tmpUseIndef, next, err := d.decodeListItemsNext(rest)
+		tmpFields, tmpUseIndef, next, err := d.decodeListItemsNextEntered(
+			rest,
+			state,
+		)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -386,7 +393,7 @@ func (d *Decoder) decodeConstrNext(tagNumber uint64, data []byte) (*Constr, []by
 	}
 }
 
-func (d *Decoder) decodeMapNext(data []byte) (*Map, []byte, error) {
+func (d *Decoder) decodeMapNextEntered(data []byte, state *decodeState) (*Map, []byte, error) {
 	pairCount, rest, useIndef, err := decodeCBORMap(data)
 	if err != nil {
 		return nil, nil, err
@@ -400,6 +407,9 @@ func (d *Decoder) decodeMapNext(data []byte) (*Map, []byte, error) {
 	if !useIndef {
 		if pairCount > len(rest)/2 {
 			return nil, nil, fmt.Errorf("CBOR map claims %d pairs but only %d bytes remain", pairCount, len(rest))
+		}
+		if err := state.checkAdditionalNodes(pairCount * 2); err != nil {
+			return nil, nil, err
 		}
 		pairs = d.pairs.alloc(pairCount)
 		pairLen = pairCount
@@ -416,13 +426,13 @@ func (d *Decoder) decodeMapNext(data []byte) (*Map, []byte, error) {
 			}
 		}
 
-		tmpKey, next, err := d.decodeNextPlutusData(rest)
+		tmpKey, next, err := d.decodeNextPlutusData(rest, state)
 		if err != nil {
 			return nil, nil, err
 		}
 		rest = next
 
-		tmpVal, next, err := d.decodeNextPlutusData(rest)
+		tmpVal, next, err := d.decodeNextPlutusData(rest, state)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -469,8 +479,11 @@ func (d *Decoder) decodeMapNext(data []byte) (*Map, []byte, error) {
 	return decoded, rest, nil
 }
 
-func (d *Decoder) decodeListNext(data []byte) (*List, []byte, error) {
-	tmpItems, tmpUseIndef, rest, err := d.decodeListItemsNext(data)
+func (d *Decoder) decodeListNextEntered(data []byte, state *decodeState) (*List, []byte, error) {
+	tmpItems, tmpUseIndef, rest, err := d.decodeListItemsNextEntered(
+		data,
+		state,
+	)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -480,14 +493,21 @@ func (d *Decoder) decodeListNext(data []byte) (*List, []byte, error) {
 	return decoded, rest, nil
 }
 
-func (d *Decoder) decodeListItemsNext(data []byte) ([]PlutusData, *bool, []byte, error) {
+func (d *Decoder) decodeListItemsNextEntered(
+	data []byte,
+	state *decodeState,
+) ([]PlutusData, *bool, []byte, error) {
 	itemCount, rest, useIndef, err := decodeCBORArray(data)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
 	if !useIndef {
-		tmpItems, rest, err := d.decodeListItemsDefinite(itemCount, rest)
+		tmpItems, rest, err := d.decodeListItemsDefiniteEntered(
+			itemCount,
+			rest,
+			state,
+		)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -506,7 +526,7 @@ func (d *Decoder) decodeListItemsNext(data []byte) ([]PlutusData, *bool, []byte,
 			break
 		}
 
-		tmp, next, err := d.decodeNextPlutusData(rest)
+		tmp, next, err := d.decodeNextPlutusData(rest, state)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -542,13 +562,20 @@ func (d *Decoder) decodeListItemsNext(data []byte) ([]PlutusData, *bool, []byte,
 	return tmpItems, useIndefPtr(true), rest, nil
 }
 
-func (d *Decoder) decodeListItemsDefinite(itemCount int, rest []byte) ([]PlutusData, []byte, error) {
+func (d *Decoder) decodeListItemsDefiniteEntered(
+	itemCount int,
+	rest []byte,
+	state *decodeState,
+) ([]PlutusData, []byte, error) {
 	if itemCount > len(rest) {
 		return nil, nil, fmt.Errorf("CBOR array claims %d items but only %d bytes remain", itemCount, len(rest))
 	}
+	if err := state.checkAdditionalNodes(itemCount); err != nil {
+		return nil, nil, err
+	}
 	tmpItems := d.items.alloc(itemCount)
 	for i := range itemCount {
-		tmp, next, err := d.decodeNextPlutusData(rest)
+		tmp, next, err := d.decodeNextPlutusData(rest, state)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/data/data.go
+++ b/data/data.go
@@ -462,17 +462,36 @@ func (l *List) UnmarshalCBOR(data []byte) error {
 }
 
 func decodeConstrFromData(data []byte) (*Constr, []byte, error) {
+	state := newDecodeState()
+	if err := state.enterValue(); err != nil {
+		return nil, nil, err
+	}
+	defer state.leaveValue()
+	return decodeConstrFromDataEntered(data, state)
+}
+
+func decodeConstrFromDataEntered(
+	data []byte,
+	state *decodeState,
+) (*Constr, []byte, error) {
 	tagNumber, tagContent, err := decodeCBORTag(data)
 	if err != nil {
 		return nil, nil, err
 	}
-	return decodeConstrNext(tagNumber, tagContent)
+	return decodeConstrNextEntered(tagNumber, tagContent, state)
 }
 
-func decodeConstrNext(tagNumber uint64, data []byte) (*Constr, []byte, error) {
+func decodeConstrNextEntered(
+	tagNumber uint64,
+	data []byte,
+	state *decodeState,
+) (*Constr, []byte, error) {
 	switch {
 	case tagNumber >= 121 && tagNumber <= 127:
-		tmpFields, tmpUseIndef, rest, err := decodeListItemsNext(data)
+		tmpFields, tmpUseIndef, rest, err := decodeListItemsNextEntered(
+			data,
+			state,
+		)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -482,7 +501,10 @@ func decodeConstrNext(tagNumber uint64, data []byte) (*Constr, []byte, error) {
 			useIndef: tmpUseIndef,
 		}, rest, nil
 	case tagNumber >= 1280 && tagNumber <= 1400:
-		tmpFields, tmpUseIndef, rest, err := decodeListItemsNext(data)
+		tmpFields, tmpUseIndef, rest, err := decodeListItemsNextEntered(
+			data,
+			state,
+		)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -509,7 +531,10 @@ func decodeConstrNext(tagNumber uint64, data []byte) (*Constr, []byte, error) {
 		}
 		rest = next
 
-		tmpFields, tmpUseIndef, next, err := decodeListItemsNext(rest)
+		tmpFields, tmpUseIndef, next, err := decodeListItemsNextEntered(
+			rest,
+			state,
+		)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -536,6 +561,15 @@ func decodeConstrNext(tagNumber uint64, data []byte) (*Constr, []byte, error) {
 }
 
 func decodeMapNext(data []byte) (*Map, []byte, error) {
+	state := newDecodeState()
+	if err := state.enterValue(); err != nil {
+		return nil, nil, err
+	}
+	defer state.leaveValue()
+	return decodeMapNextEntered(data, state)
+}
+
+func decodeMapNextEntered(data []byte, state *decodeState) (*Map, []byte, error) {
 	pairCount, rest, useIndef, err := decodeCBORMap(data)
 	if err != nil {
 		return nil, nil, err
@@ -548,6 +582,9 @@ func decodeMapNext(data []byte) (*Map, []byte, error) {
 		// Each pair needs at least 2 bytes (one per key/value CBOR head).
 		if pairCount > len(rest)/2 {
 			return nil, nil, fmt.Errorf("CBOR map claims %d pairs but only %d bytes remain", pairCount, len(rest))
+		}
+		if err := state.checkAdditionalNodes(pairCount * 2); err != nil {
+			return nil, nil, err
 		}
 		pairs = make([][2]PlutusData, pairCount)
 	}
@@ -563,13 +600,13 @@ func decodeMapNext(data []byte) (*Map, []byte, error) {
 			}
 		}
 
-		tmpKey, next, err := decodeNextPlutusData(rest)
+		tmpKey, next, err := decodeNextPlutusDataWithState(rest, state)
 		if err != nil {
 			return nil, nil, err
 		}
 		rest = next
 
-		tmpVal, next, err := decodeNextPlutusData(rest)
+		tmpVal, next, err := decodeNextPlutusDataWithState(rest, state)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -586,7 +623,16 @@ func decodeMapNext(data []byte) (*Map, []byte, error) {
 }
 
 func decodeListNext(data []byte) (*List, []byte, error) {
-	tmpItems, tmpUseIndef, rest, err := decodeListItemsNext(data)
+	state := newDecodeState()
+	if err := state.enterValue(); err != nil {
+		return nil, nil, err
+	}
+	defer state.leaveValue()
+	return decodeListNextEntered(data, state)
+}
+
+func decodeListNextEntered(data []byte, state *decodeState) (*List, []byte, error) {
+	tmpItems, tmpUseIndef, rest, err := decodeListItemsNextEntered(data, state)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -594,13 +640,24 @@ func decodeListNext(data []byte) (*List, []byte, error) {
 }
 
 func decodeListItemsNext(data []byte) ([]PlutusData, *bool, []byte, error) {
+	return decodeListItemsNextEntered(data, newDecodeState())
+}
+
+func decodeListItemsNextEntered(
+	data []byte,
+	state *decodeState,
+) ([]PlutusData, *bool, []byte, error) {
 	itemCount, rest, useIndef, err := decodeCBORArray(data)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
 	if !useIndef {
-		tmpItems, rest, err := decodeListItemsDefinite(itemCount, rest)
+		tmpItems, rest, err := decodeListItemsDefiniteEntered(
+			itemCount,
+			rest,
+			state,
+		)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -619,7 +676,7 @@ func decodeListItemsNext(data []byte) ([]PlutusData, *bool, []byte, error) {
 			break
 		}
 
-		tmp, next, err := decodeNextPlutusData(rest)
+		tmp, next, err := decodeNextPlutusDataWithState(rest, state)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -656,13 +713,24 @@ func decodeListItemsNext(data []byte) ([]PlutusData, *bool, []byte, error) {
 }
 
 func decodeListItemsDefinite(itemCount int, rest []byte) ([]PlutusData, []byte, error) {
+	return decodeListItemsDefiniteEntered(itemCount, rest, newDecodeState())
+}
+
+func decodeListItemsDefiniteEntered(
+	itemCount int,
+	rest []byte,
+	state *decodeState,
+) ([]PlutusData, []byte, error) {
 	// Each item needs at least 1 byte for a CBOR head.
 	if itemCount > len(rest) {
 		return nil, nil, fmt.Errorf("CBOR array claims %d items but only %d bytes remain", itemCount, len(rest))
 	}
+	if err := state.checkAdditionalNodes(itemCount); err != nil {
+		return nil, nil, err
+	}
 	tmpItems := make([]PlutusData, itemCount)
 	for i := range itemCount {
-		tmp, next, err := decodeNextPlutusData(rest)
+		tmp, next, err := decodeNextPlutusDataWithState(rest, state)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -3,6 +3,7 @@ package data
 import (
 	"bytes"
 	"encoding/hex"
+	"errors"
 	"math/big"
 	"reflect"
 	"testing"
@@ -485,6 +486,56 @@ func TestDecoderReuseMatchesDecode(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestDecodeRejectsExcessiveNesting(t *testing.T) {
+	encoded := nestedListCBOR(MaxDecodeNestingDepth + 1)
+
+	_, err := Decode(encoded)
+	assertDecodeLimitError(t, err, "nesting depth")
+
+	decoder := NewDecoder()
+	_, err = decoder.Decode(encoded)
+	assertDecodeLimitError(t, err, "nesting depth")
+
+	var list List
+	err = list.UnmarshalCBOR(encoded)
+	assertDecodeLimitError(t, err, "nesting depth")
+}
+
+func TestDecodeRejectsExcessiveNodeCount(t *testing.T) {
+	encoded := []byte{0x84, 0x00, 0x00, 0x00, 0x00}
+	limits := decodeLimits{maxDepth: MaxDecodeNestingDepth, maxNodes: 4}
+
+	_, err := decodeWithState(encoded, newDecodeStateWithLimits(limits))
+	assertDecodeLimitError(t, err, "node count")
+
+	decoder := NewDecoder()
+	_, err = decoder.decode(encoded, newDecodeStateWithLimits(limits))
+	assertDecodeLimitError(t, err, "node count")
+}
+
+func nestedListCBOR(depth int) []byte {
+	encoded := make([]byte, depth+1)
+	for i := 0; i < depth; i++ {
+		encoded[i] = 0x81
+	}
+	encoded[depth] = 0x00
+	return encoded
+}
+
+func assertDecodeLimitError(t *testing.T, err error, limit string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected %s limit error, got nil", limit)
+	}
+	var limitErr *DecodeLimitError
+	if !errors.As(err, &limitErr) {
+		t.Fatalf("expected DecodeLimitError, got %T: %v", err, err)
+	}
+	if limitErr.Limit != limit {
+		t.Fatalf("DecodeLimitError limit = %q, want %q", limitErr.Limit, limit)
+	}
 }
 
 func TestDecoderResetOverwritesRetainedBigInts(t *testing.T) {

--- a/data/decode.go
+++ b/data/decode.go
@@ -23,10 +23,89 @@ const (
 	CborTypeMask uint8 = 0xe0
 
 	CborIndefFlag uint8 = 0x1f
+
+	MaxDecodeNestingDepth = 256
+	MaxDecodeNodes        = 1_000_000
 )
 
 // decMode is cached at package level to avoid recreation on every decode call
 var decMode cbor.DecMode
+
+type DecodeLimitError struct {
+	Limit  string
+	Max    int
+	Actual int
+}
+
+func (e *DecodeLimitError) Error() string {
+	return fmt.Sprintf(
+		"PlutusData CBOR %s limit exceeded: %d > %d",
+		e.Limit,
+		e.Actual,
+		e.Max,
+	)
+}
+
+type decodeLimits struct {
+	maxDepth int
+	maxNodes int
+}
+
+type decodeState struct {
+	limits decodeLimits
+	depth  int
+	nodes  int
+}
+
+func newDecodeState() *decodeState {
+	return newDecodeStateWithLimits(decodeLimits{
+		maxDepth: MaxDecodeNestingDepth,
+		maxNodes: MaxDecodeNodes,
+	})
+}
+
+func newDecodeStateWithLimits(limits decodeLimits) *decodeState {
+	return &decodeState{limits: limits}
+}
+
+func (s *decodeState) enterValue() error {
+	if s.depth >= s.limits.maxDepth {
+		return &DecodeLimitError{
+			Limit:  "nesting depth",
+			Max:    s.limits.maxDepth,
+			Actual: s.depth + 1,
+		}
+	}
+	s.depth++
+
+	s.nodes++
+	if s.nodes > s.limits.maxNodes {
+		s.depth--
+		return &DecodeLimitError{
+			Limit:  "node count",
+			Max:    s.limits.maxNodes,
+			Actual: s.nodes,
+		}
+	}
+
+	return nil
+}
+
+func (s *decodeState) leaveValue() {
+	s.depth--
+}
+
+func (s *decodeState) checkAdditionalNodes(n int) error {
+	if n < 0 || n > s.limits.maxNodes-s.nodes {
+		return &DecodeLimitError{
+			Limit:  "node count",
+			Max:    s.limits.maxNodes,
+			Actual: s.nodes + n,
+		}
+	}
+
+	return nil
+}
 
 func init() {
 	decOptions := cbor.DecOptions{
@@ -62,6 +141,21 @@ func cborUnmarshal(dataBytes []byte, dest any) error {
 // decode is a low-level decode function that detects the CBOR type and uses the correct
 // PlutusData type to decode it
 func decode(data []byte) (PlutusData, error) {
+	return decodeWithState(data, newDecodeState())
+}
+
+func decodeWithState(data []byte, state *decodeState) (PlutusData, error) {
+	v, rest, err := decodeNextPlutusDataWithState(data, state)
+	if err != nil {
+		return nil, err
+	}
+	if len(rest) > 0 {
+		return nil, fmt.Errorf("unexpected %d trailing bytes", len(rest))
+	}
+	return v, nil
+}
+
+func decodePrimitive(data []byte) (PlutusData, error) {
 	if len(data) == 0 {
 		return nil, errors.New("empty data")
 	}
@@ -76,18 +170,6 @@ func decode(data []byte) (PlutusData, error) {
 	case CborTypeByteString:
 		var tmpData ByteString
 		if err := cborUnmarshal(data, &tmpData); err != nil {
-			return nil, err
-		}
-		return &tmpData, nil
-	case CborTypeArray:
-		var tmpData List
-		if err := tmpData.UnmarshalCBOR(data); err != nil {
-			return nil, err
-		}
-		return &tmpData, nil
-	case CborTypeMap:
-		var tmpData Map
-		if err := tmpData.UnmarshalCBOR(data); err != nil {
 			return nil, err
 		}
 		return &tmpData, nil
@@ -236,19 +318,30 @@ func decodeCBORHead(data []byte) (uint8, uint64, []byte, bool, error) {
 }
 
 func decodeNextPlutusData(data []byte) (PlutusData, []byte, error) {
+	return decodeNextPlutusDataWithState(data, newDecodeState())
+}
+
+func decodeNextPlutusDataWithState(
+	data []byte,
+	state *decodeState,
+) (PlutusData, []byte, error) {
 	if len(data) == 0 {
 		return nil, nil, errors.New("empty data")
 	}
+	if err := state.enterValue(); err != nil {
+		return nil, nil, err
+	}
+	defer state.leaveValue()
 
 	switch data[0] & CborTypeMask {
 	case CborTypeArray:
-		tmpList, rest, err := decodeListNext(data)
+		tmpList, rest, err := decodeListNextEntered(data, state)
 		if err != nil {
 			return nil, nil, err
 		}
 		return tmpList, rest, nil
 	case CborTypeMap:
-		tmpMap, rest, err := decodeMapNext(data)
+		tmpMap, rest, err := decodeMapNextEntered(data, state)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -260,7 +353,11 @@ func decodeNextPlutusData(data []byte) (PlutusData, []byte, error) {
 		}
 		switch {
 		case tagNumber == 102 || (tagNumber >= 121 && tagNumber <= 127) || (tagNumber >= 1280 && tagNumber <= 1400):
-			tmpConstr, rest, err := decodeConstrNext(tagNumber, tagContent)
+			tmpConstr, rest, err := decodeConstrNextEntered(
+				tagNumber,
+				tagContent,
+				state,
+			)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -268,11 +365,11 @@ func decodeNextPlutusData(data []byte) (PlutusData, []byte, error) {
 		}
 	}
 
-	item, rest, err := splitCBORItem(data)
+	item, rest, err := splitCBORItemEntered(data, state)
 	if err != nil {
 		return nil, nil, err
 	}
-	tmp, err := decode(item)
+	tmp, err := decodePrimitive(item)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -280,7 +377,19 @@ func decodeNextPlutusData(data []byte) (PlutusData, []byte, error) {
 }
 
 func splitCBORItem(data []byte) ([]byte, []byte, error) {
-	rest, err := skipCBORItem(data)
+	state := newDecodeState()
+	if err := state.enterValue(); err != nil {
+		return nil, nil, err
+	}
+	defer state.leaveValue()
+	return splitCBORItemEntered(data, state)
+}
+
+func splitCBORItemEntered(
+	data []byte,
+	state *decodeState,
+) ([]byte, []byte, error) {
+	rest, err := skipCBORItemEntered(data, state)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -289,6 +398,19 @@ func splitCBORItem(data []byte) ([]byte, []byte, error) {
 }
 
 func skipCBORItem(data []byte) ([]byte, error) {
+	state := newDecodeState()
+	return skipCBORItemWithState(data, state)
+}
+
+func skipCBORItemWithState(data []byte, state *decodeState) ([]byte, error) {
+	if err := state.enterValue(); err != nil {
+		return nil, err
+	}
+	defer state.leaveValue()
+	return skipCBORItemEntered(data, state)
+}
+
+func skipCBORItemEntered(data []byte, state *decodeState) ([]byte, error) {
 	cborType, value, rest, indefinite, err := decodeCBORHead(data)
 	if err != nil {
 		return nil, err
@@ -304,25 +426,25 @@ func skipCBORItem(data []byte) ([]byte, error) {
 		return skipCBORBytesLike(rest, value, indefinite, cborType)
 	case CborTypeArray:
 		if indefinite {
-			return skipCBORSequence(rest, 1, true)
+			return skipCBORSequenceWithState(rest, 1, true, state)
 		}
 		if value > math.MaxInt {
 			return nil, fmt.Errorf("CBOR array too large: %d", value)
 		}
-		return skipCBORSequence(rest, int(value), false)
+		return skipCBORSequenceWithState(rest, int(value), false, state)
 	case CborTypeMap:
 		if indefinite {
-			return skipCBORSequence(rest, 2, true)
+			return skipCBORSequenceWithState(rest, 2, true, state)
 		}
 		if value > math.MaxInt/2 {
 			return nil, fmt.Errorf("CBOR map too large: %d", value)
 		}
-		return skipCBORSequence(rest, int(value)*2, false)
+		return skipCBORSequenceWithState(rest, int(value)*2, false, state)
 	case CborTypeTag:
 		if indefinite {
 			return nil, errors.New("indefinite CBOR tags are not supported")
 		}
-		return skipCBORItem(rest)
+		return skipCBORItemWithState(rest, state)
 	case CborTypeSimple:
 		if indefinite {
 			return nil, errors.New("unexpected CBOR break")
@@ -369,6 +491,15 @@ func skipCBORBytesLike(
 }
 
 func skipCBORSequence(rest []byte, count int, indefinite bool) ([]byte, error) {
+	return skipCBORSequenceWithState(rest, count, indefinite, newDecodeState())
+}
+
+func skipCBORSequenceWithState(
+	rest []byte,
+	count int,
+	indefinite bool,
+	state *decodeState,
+) ([]byte, error) {
 	if indefinite {
 		for {
 			if len(rest) == 0 {
@@ -379,7 +510,7 @@ func skipCBORSequence(rest []byte, count int, indefinite bool) ([]byte, error) {
 			}
 			var err error
 			for range count {
-				rest, err = skipCBORItem(rest)
+				rest, err = skipCBORItemWithState(rest, state)
 				if err != nil {
 					return nil, err
 				}
@@ -389,7 +520,7 @@ func skipCBORSequence(rest []byte, count int, indefinite bool) ([]byte, error) {
 
 	for range count {
 		var err error
-		rest, err = skipCBORItem(rest)
+		rest, err = skipCBORItemWithState(rest, state)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This was reported by logcavq02@gmail.com

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add hard limits to PlutusData CBOR decoding to block excessively deep or large inputs and fail fast with clear errors. Applies to `Decode`, `Decoder.Decode`, `UnmarshalCBOR`, and low-level helpers.

- **Bug Fixes**
  - Enforce `MaxDecodeNestingDepth` (256) and `MaxDecodeNodes` (1,000,000) via a shared decode state; return `DecodeLimitError` with details.
  - Track depth and node count across arrays, maps, constructors, and skip/split helpers; pre-check definite-length sequences.
  - Tighten scalar decoding: reject constructor tags in primitive paths; consistently error on trailing bytes.
  - Add tests for nesting and node-count limits and decoder reuse.

<sup>Written for commit 55c714c1189e19a2391357c816315baa19419e32. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

