### PR TITLE
fix: appease nilaway scanner

### DIFF
--- a/cek/builtins.go
+++ b/cek/builtins.go
@@ -317,6 +317,10 @@ func (m *Machine[T]) evalUnaryBuiltinFast(
 	fn builtin.DefaultFunction,
 	arg Value[T],
 ) (Value[T], bool, error) {
+	if arg == nil {
+		return nil, true, internalError("unary builtin evaluated nil argument")
+	}
+
 	switch fn {
 	case builtin.FstPair:
 		if err := m.CostOne(&fn, valueExMem[T](arg)); err != nil {

--- a/cek/errors.go
+++ b/cek/errors.go
@@ -156,6 +156,13 @@ func (e *InternalError) Error() string {
 func (e *InternalError) IsRecoverable() bool  { return false }
 func (e *InternalError) ErrorCode() ErrorCode { return e.Code }
 
+func internalError(message string) *InternalError {
+	return &InternalError{
+		Code:    ErrCodeInternalError,
+		Message: message,
+	}
+}
+
 // Error classification helpers for consumers
 
 // IsBudgetError returns true if the error is a budget exhaustion error.

--- a/cek/machine.go
+++ b/cek/machine.go
@@ -334,7 +334,7 @@ func allocArenaSlot[S any](chunks *[][]S, pos *int, chunkSize int) *S {
 
 func allocArenaSlice[S any](chunks *[][]S, pos *int, n int, chunkSize int) []S {
 	if n == 0 {
-		return nil
+		return make([]S, 0)
 	}
 
 	remaining := *pos
@@ -1085,11 +1085,17 @@ func (m *Machine[T]) compute(
 			return nil, err
 		}
 		if ok {
+			if funValue == nil {
+				return nil, internalError("compute returned nil function value")
+			}
 			argValue, argImmediate, err := m.computeImmediateValue(env, t.Argument)
 			if err != nil {
 				return nil, err
 			}
 			if argImmediate {
+				if argValue == nil {
+					return nil, internalError("compute returned nil argument value")
+				}
 				return m.applyEvaluate(context, funValue, argValue)
 			}
 
@@ -1137,6 +1143,9 @@ func (m *Machine[T]) compute(
 			return nil, err
 		}
 		if ok {
+			if forcedValue == nil {
+				return nil, internalError("compute returned nil force value")
+			}
 			return m.forceEvaluate(context, forcedValue)
 		}
 
@@ -1209,6 +1218,9 @@ func (m *Machine[T]) compute(
 			return nil, err
 		}
 		if ok {
+			if scrutinee == nil {
+				return nil, internalError("compute returned nil case scrutinee")
+			}
 			return m.caseEvaluate(env, t.Branches, context, scrutinee)
 		}
 
@@ -1262,6 +1274,9 @@ func (m *Machine[T]) computeImmediateValue(
 		if !ok {
 			return nil, true, &TypeError{Code: ErrCodeOpenTerm, Message: "open term evaluated"}
 		}
+		if value == nil {
+			return nil, true, internalError("environment lookup returned nil value")
+		}
 		return value, true, nil
 	case *syn.Delay[T]:
 		if err := m.stepAndMaybeSpend(ExDelay); err != nil {
@@ -1304,6 +1319,10 @@ func (m *Machine[T]) caseEvaluate(
 	context MachineContext[T],
 	value Value[T],
 ) (MachineState[T], error) {
+	if value == nil {
+		return nil, internalError("case evaluated nil value")
+	}
+
 	switch v := value.(type) {
 	case *Constr[T]:
 		if v.Tag > math.MaxInt {
@@ -1497,6 +1516,10 @@ func (m *Machine[T]) returnCompute(
 			return nil, err
 		}
 		if ok {
+			if argValue == nil {
+				m.putFrameAwaitFunTerm(c)
+				return nil, internalError("compute returned nil argument value")
+			}
 			state, err = m.applyEvaluate(c.Ctx, value, argValue)
 			m.putFrameAwaitFunTerm(c)
 			if err != nil {
@@ -1592,6 +1615,10 @@ func (m *Machine[T]) forceEvaluate(
 	context MachineContext[T],
 	value Value[T],
 ) (MachineState[T], error) {
+	if value == nil {
+		return nil, internalError("force evaluated nil value")
+	}
+
 	var state MachineState[T]
 	var err error
 
@@ -1650,6 +1677,13 @@ func (m *Machine[T]) applyEvaluate(
 	function Value[T],
 	arg Value[T],
 ) (MachineState[T], error) {
+	if function == nil {
+		return nil, internalError("apply evaluated nil function")
+	}
+	if arg == nil {
+		return nil, internalError("apply evaluated nil argument")
+	}
+
 	var state MachineState[T]
 	var err error
 

--- a/cek/stack_machine.go
+++ b/cek/stack_machine.go
@@ -247,6 +247,9 @@ func (m *Machine[T]) runStackNoSlippage(term syn.Term[T]) (syn.Term[T], error) {
 
 	for {
 		if !returning {
+			if currentTerm == nil {
+				return nil, internalError("stack machine current term is nil")
+			}
 			switch t := currentTerm.(type) {
 			case *syn.Var[T]:
 				if !m.spendStepNoSlippage(ExVar) {
@@ -424,6 +427,9 @@ func (m *Machine[T]) runStackNoSlippage(term syn.Term[T]) (syn.Term[T], error) {
 			continue
 		}
 
+		if currentValue == nil {
+			return nil, internalError("stack machine current value is nil")
+		}
 		if len(m.frameStack) == 0 {
 			return m.finishValue(currentValue)
 		}
@@ -552,6 +558,9 @@ func (m *Machine[T]) runStack(term syn.Term[T]) (syn.Term[T], error) {
 
 	for {
 		if !returning {
+			if currentTerm == nil {
+				return nil, internalError("stack machine current term is nil")
+			}
 			switch t := currentTerm.(type) {
 			case *syn.Var[T]:
 				if err := m.stepAndMaybeSpend(ExVar); err != nil {
@@ -729,6 +738,9 @@ func (m *Machine[T]) runStack(term syn.Term[T]) (syn.Term[T], error) {
 			continue
 		}
 
+		if currentValue == nil {
+			return nil, internalError("stack machine current value is nil")
+		}
 		if len(m.frameStack) == 0 {
 			return m.finishValue(currentValue)
 		}
@@ -865,6 +877,13 @@ func (m *Machine[T]) applyEvaluateStack(
 	function Value[T],
 	arg Value[T],
 ) (syn.Term[T], *Env[T], Value[T], bool, error) {
+	if function == nil {
+		return nil, nil, nil, false, internalError("stack apply evaluated nil function")
+	}
+	if arg == nil {
+		return nil, nil, nil, false, internalError("stack apply evaluated nil argument")
+	}
+
 	switch f := function.(type) {
 	case *Lambda[T]:
 		return f.AST.Body, m.extendEnv(f.Env, arg), nil, false, nil
@@ -940,6 +959,10 @@ func (m *Machine[T]) applyEvaluateStack(
 func (m *Machine[T]) forceEvaluateStack(
 	value Value[T],
 ) (syn.Term[T], *Env[T], Value[T], bool, error) {
+	if value == nil {
+		return nil, nil, nil, false, internalError("stack force evaluated nil value")
+	}
+
 	switch v := value.(type) {
 	case *Delay[T]:
 		return v.AST.Term, v.Env, nil, false, nil
@@ -978,6 +1001,10 @@ func (m *Machine[T]) caseEvaluateStack(
 	branches []syn.Term[T],
 	value Value[T],
 ) (syn.Term[T], *Env[T], Value[T], bool, error) {
+	if value == nil {
+		return nil, nil, nil, false, internalError("stack case evaluated nil value")
+	}
+
 	switch v := value.(type) {
 	case *Constr[T]:
 		if v.Tag > math.MaxInt {

--- a/cek/stack_machine_debruijn.go
+++ b/cek/stack_machine_debruijn.go
@@ -232,6 +232,9 @@ func runStackNoSlippageDeBruijn(
 
 	for {
 		if !returning {
+			if currentTerm == nil {
+				return nil, internalError("DeBruijn stack machine current term is nil")
+			}
 			switch t := currentTerm.(type) {
 			case *syn.Var[syn.DeBruijn]:
 				if !m.spendStepNoSlippage(ExVar) {
@@ -241,6 +244,9 @@ func runStackNoSlippageDeBruijn(
 				value, ok := lookupEnvDeBruijn(currentEnv, int(t.Name))
 				if !ok {
 					return nil, &TypeError{Code: ErrCodeOpenTerm, Message: "open term evaluated"}
+				}
+				if value == nil {
+					return nil, internalError("DeBruijn environment lookup returned nil value")
 				}
 
 				currentValue = value
@@ -459,6 +465,9 @@ func runStackNoSlippageDeBruijn(
 			continue
 		}
 
+		if currentValue == nil {
+			return nil, internalError("DeBruijn stack machine current value is nil")
+		}
 		if len(m.frameStack) == 0 {
 			return m.finishValue(currentValue)
 		}

--- a/data/arena_decoder.go
+++ b/data/arena_decoder.go
@@ -123,7 +123,7 @@ type arenaSlices[S any] struct {
 
 func (a *arenaSlices[S]) alloc(n int) []S {
 	if n == 0 {
-		return nil
+		return make([]S, 0)
 	}
 
 	remaining := a.pos

--- a/syn/flat_decode.go
+++ b/syn/flat_decode.go
@@ -508,7 +508,7 @@ type arenaSlices[S any] struct {
 
 func (a *arenaSlices[S]) alloc(n int) []S {
 	if n == 0 {
-		return nil
+		return make([]S, 0)
 	}
 
 	for a.chunkIdx < len(a.chunks) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardened CEK and stack machine execution by adding nil checks and consistent internal error handling to prevent nil dereferences. Also return empty slices instead of nil from arena allocators to satisfy nilaway and avoid ambiguous slice states.

- **Bug Fixes**
  - Added `internalError` and guard checks for nil values in `cek` paths: unary builtins, `compute`, `applyEvaluate`, `forceEvaluate`, `caseEvaluate`, and return flows.
  - Validated `currentTerm`, `currentValue`, and environment lookups in `cek/stack_machine.go` and DeBruijn variant to catch unexpected nils early.
  - Updated `allocArenaSlice` and `arenaSlices.alloc` in `cek`, `data`, and `syn` to return empty slices when `n == 0`.

<sup>Written for commit 442d9fb8676584af25fd00c27780349ef921f24f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/plutigo/pull/315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

