### PR TITLE
fix(cek): support skipping final slippage flush

### DIFF
--- a/cek/eval_context.go
+++ b/cek/eval_context.go
@@ -10,6 +10,11 @@ type EvalContext struct {
 	CostModel        CostModel
 	SemanticsVariant SemanticsVariant
 	ProtoMajor       uint
+
+	// SkipFinalSlippageFlush leaves a successful evaluation's trailing
+	// unbudgeted machine-step batch unspent. This matches Cardano ledger's
+	// restricting validation mode; exact cost evaluation should leave it false.
+	SkipFinalSlippageFlush bool
 }
 
 // NewDefaultEvalContext builds an EvalContext using the default cost model

--- a/cek/machine.go
+++ b/cek/machine.go
@@ -61,23 +61,24 @@ func getFilteredBuiltins[T syn.Eval](
 }
 
 type Machine[T syn.Eval] struct {
-	costs              CostModel
-	stepCosts          [9]ExBudget
-	stepCostCpu        [9]int64
-	stepCostMem        [9]int64
-	builtins           *Builtins[T]
-	builtinValues      *[builtin.TotalBuiltinCount]*Builtin[T]
-	builtinNoArgValues *[builtin.TotalBuiltinCount][3]*Builtin[T]
-	oneArgCosts        [builtin.TotalBuiltinCount]oneArgCost
-	twoArgCosts        [builtin.TotalBuiltinCount]twoArgCost
-	threeArgCosts      [builtin.TotalBuiltinCount]threeArgCost
-	available          *[builtin.TotalBuiltinCount]bool
-	slippage           uint32
-	version            lang.LanguageVersion
-	semantics          SemanticsVariant
-	protoMajor         uint
-	ExBudget           ExBudget
-	Logs               []string
+	costs                  CostModel
+	stepCosts              [9]ExBudget
+	stepCostCpu            [9]int64
+	stepCostMem            [9]int64
+	builtins               *Builtins[T]
+	builtinValues          *[builtin.TotalBuiltinCount]*Builtin[T]
+	builtinNoArgValues     *[builtin.TotalBuiltinCount][3]*Builtin[T]
+	oneArgCosts            [builtin.TotalBuiltinCount]oneArgCost
+	twoArgCosts            [builtin.TotalBuiltinCount]twoArgCost
+	threeArgCosts          [builtin.TotalBuiltinCount]threeArgCost
+	available              *[builtin.TotalBuiltinCount]bool
+	slippage               uint32
+	version                lang.LanguageVersion
+	semantics              SemanticsVariant
+	protoMajor             uint
+	skipFinalSlippageFlush bool
+	ExBudget               ExBudget
+	Logs                   []string
 
 	argHolder       argHolder[T]
 	frameStack      []stackFrame[T]
@@ -681,23 +682,24 @@ func NewMachine[T syn.Eval](
 		stepCostMem[i] = s.Mem
 	}
 	return &Machine[T]{
-		costs:              evalContext.CostModel,
-		stepCosts:          stepCosts,
-		stepCostCpu:        stepCostCpu,
-		stepCostMem:        stepCostMem,
-		builtins:           chooseBuiltins[T](version, evalContext.ProtoMajor),
-		builtinValues:      getSharedBuiltinValues[T](),
-		builtinNoArgValues: getSharedBuiltinNoArgValues[T](),
-		oneArgCosts:        newOneArgCostCache(evalContext.CostModel.builtinCosts),
-		twoArgCosts:        newTwoArgCostCache(evalContext.CostModel.builtinCosts),
-		threeArgCosts:      newThreeArgCostCache(evalContext.CostModel.builtinCosts),
-		available:          chooseAvailableBuiltins(version, evalContext.ProtoMajor),
-		slippage:           slippage,
-		version:            version,
-		semantics:          evalContext.SemanticsVariant,
-		protoMajor:         evalContext.ProtoMajor,
-		ExBudget:           DefaultExBudget,
-		Logs:               make([]string, 0),
+		costs:                  evalContext.CostModel,
+		stepCosts:              stepCosts,
+		stepCostCpu:            stepCostCpu,
+		stepCostMem:            stepCostMem,
+		builtins:               chooseBuiltins[T](version, evalContext.ProtoMajor),
+		builtinValues:          getSharedBuiltinValues[T](),
+		builtinNoArgValues:     getSharedBuiltinNoArgValues[T](),
+		oneArgCosts:            newOneArgCostCache(evalContext.CostModel.builtinCosts),
+		twoArgCosts:            newTwoArgCostCache(evalContext.CostModel.builtinCosts),
+		threeArgCosts:          newThreeArgCostCache(evalContext.CostModel.builtinCosts),
+		available:              chooseAvailableBuiltins(version, evalContext.ProtoMajor),
+		slippage:               slippage,
+		version:                version,
+		semantics:              evalContext.SemanticsVariant,
+		protoMajor:             evalContext.ProtoMajor,
+		skipFinalSlippageFlush: evalContext.SkipFinalSlippageFlush,
+		ExBudget:               DefaultExBudget,
+		Logs:                   make([]string, 0),
 
 		argHolder:       newArgHolder[T](),
 		frameStack:      make([]stackFrame[T], 0, 32),
@@ -918,8 +920,13 @@ func (m *Machine[T]) finishReturn(ret *Return[T]) (syn.Term[T], error) {
 
 func (m *Machine[T]) finishValue(value Value[T]) (syn.Term[T], error) {
 	if m.unbudgetedTotal > 0 {
-		if err := m.spendUnbudgetedSteps(); err != nil {
-			return nil, err
+		if m.skipFinalSlippageFlush {
+			clear(m.unbudgetedSteps[:])
+			m.unbudgetedTotal = 0
+		} else {
+			if err := m.spendUnbudgetedSteps(); err != nil {
+				return nil, err
+			}
 		}
 	}
 	return dischargeValue[T](value)

--- a/cek/machine_test.go
+++ b/cek/machine_test.go
@@ -1,6 +1,7 @@
 package cek
 
 import (
+	"errors"
 	"math/big"
 	"strings"
 	"testing"
@@ -273,6 +274,50 @@ func TestRunStackLambdaImmediateFastPathSkipsLambdaArena(t *testing.T) {
 
 	if got := len(m.lambdaChunks); got != 0 {
 		t.Fatalf("len(lambdaChunks) after lambda immediate fast path = %d, want 0", got)
+	}
+}
+
+func TestRunRestrictingModeSkipsSuccessfulFinalSlippageFlush(t *testing.T) {
+	ctx := NewDefaultEvalContext(
+		lang.LanguageVersionV3,
+		ProtoVersion{},
+	)
+	ctx.SkipFinalSlippageFlush = true
+	m := NewMachine[syn.DeBruijn](lang.LanguageVersionV3, 200, ctx)
+	startupBudget := m.costs.machineCosts.startup
+	m.ExBudget = startupBudget
+
+	term := &syn.Constant{Con: &syn.Integer{Inner: big.NewInt(42)}}
+	if _, err := m.Run(term); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if m.ExBudget != (ExBudget{}) {
+		t.Fatalf("remaining budget = %+v, want zero after startup only", m.ExBudget)
+	}
+	if got := m.unbudgetedTotal; got != 0 {
+		t.Fatalf("unbudgetedTotal after Run = %d, want 0", got)
+	}
+	if got := m.unbudgetedSteps; got != [9]uint32{} {
+		t.Fatalf("unbudgetedSteps after Run = %v, want zeroed", got)
+	}
+}
+
+func TestRunDefaultModeFlushesSuccessfulFinalSlippageBatch(t *testing.T) {
+	ctx := NewDefaultEvalContext(
+		lang.LanguageVersionV3,
+		ProtoVersion{},
+	)
+	m := NewMachine[syn.DeBruijn](lang.LanguageVersionV3, 200, ctx)
+	m.ExBudget = m.costs.machineCosts.startup
+
+	term := &syn.Constant{Con: &syn.Integer{Inner: big.NewInt(42)}}
+	_, err := m.Run(term)
+	if err == nil {
+		t.Fatal("expected final slippage flush to exhaust budget")
+	}
+	var budgetErr *BudgetError
+	if !errors.As(err, &budgetErr) {
+		t.Fatalf("Run error = %T %v, want BudgetError", err, err)
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an option to skip the final slippage flush in the CEK machine to match Cardano ledger restricting validation mode. Default behavior is unchanged; when enabled, successful evaluations won’t charge the trailing unbudgeted step batch.

- New Features
  - Introduced `EvalContext.SkipFinalSlippageFlush`, wired into the machine as `skipFinalSlippageFlush`.
  - On successful runs, if enabled, unbudgeted steps are cleared instead of spent.
  - Added tests for both modes: restricting mode skips the flush; default mode flushes and errors when budget is exhausted.

<sup>Written for commit f182aa763e25cd1c5463428c13c65259a17f43b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/plutigo/pull/316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to control the handling of unbudgeted machine steps accumulated at the end of successful script evaluation, supporting both flush and skip modes.

* **Tests**
  * Added tests verifying both final budget flushing and skipping behaviors under different execution configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->