### PR TITLE
fix(cek): support 32-bit targets

### DIFF
--- a/cek/builtins.go
+++ b/cek/builtins.go
@@ -479,7 +479,12 @@ func (m *Machine[T]) evalUnaryBuiltinFast(
 				Message: "data is not a constr",
 			}
 		}
-		if constr.Tag > math.MaxInt64 {
+		// constr.Tag is a uint, whose width is platform-dependent. Compare via
+		// uint64 so this builds on 32-bit targets (where the untyped MaxInt64
+		// constant would otherwise overflow the uint comparison type). On 32-bit
+		// a uint tag can never exceed MaxInt64, so the guard is a no-op there; on
+		// 64-bit it behaves exactly as before.
+		if uint64(constr.Tag) > math.MaxInt64 {
 			return nil, true, &BuiltinError{
 				Code:    ErrCodeOverflow,
 				Builtin: "unConstrData",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix 32-bit builds by preventing overflow in the `cek` builtin tag check. Cast `constr.Tag` to `uint64` before comparing to `math.MaxInt64`, preserving 64-bit behavior and making the guard a no-op on 32-bit.

<sup>Written for commit 18b92865f7ed4961c702c38696c1cb3e1b186975. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/plutigo/pull/320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

