### PR TITLE
fix(syn): decode string escapes as Unicode code points

### DIFF
--- a/syn/lex/lexer.go
+++ b/syn/lex/lexer.go
@@ -1,7 +1,6 @@
 package lex
 
 import (
-	"encoding/hex"
 	"fmt"
 	"math/big"
 	"strconv"
@@ -107,6 +106,12 @@ func (l *Lexer) readNumber() (string, error) {
 	return string(l.input[start:l.pos]), nil
 }
 
+func isHexDigit(ch rune) bool {
+	return (ch >= '0' && ch <= '9') ||
+		(ch >= 'a' && ch <= 'f') ||
+		(ch >= 'A' && ch <= 'F')
+}
+
 func (l *Lexer) readString() (string, error) {
 	var sb strings.Builder
 	leftoverChar := false
@@ -134,14 +139,11 @@ func (l *Lexer) readString() (string, error) {
 				var unicodeHex string
 				for {
 					l.readChar()
-					unicodeHex += string(l.ch)
-					tmpHex := fmt.Sprintf("%04s", unicodeHex)
-					if _, err := hex.DecodeString(tmpHex); err != nil {
-						// Strip off last hex character
-						unicodeHex = unicodeHex[:len(unicodeHex)-1]
+					if !isHexDigit(l.ch) {
 						leftoverChar = true
 						break
 					}
+					unicodeHex += string(l.ch)
 					if len(unicodeHex) >= 4 {
 						break
 					}
@@ -152,16 +154,22 @@ func (l *Lexer) readString() (string, error) {
 						unicodeHex,
 					)
 				}
-				// Pad hex string for parsing
-				tmpHex := fmt.Sprintf("%04s", unicodeHex)
-				r, err := hex.DecodeString(tmpHex)
+				// The hex digits denote a Unicode code point, not raw
+				// bytes, so the result must be UTF-8 encoded
+				codepoint, err := strconv.ParseUint(unicodeHex, 16, 32)
 				if err != nil {
 					return "", fmt.Errorf(
 						"invalid unicode escape sequence: \\u%s",
 						unicodeHex,
 					)
 				}
-				sb.Write(r)
+				if codepoint > unicode.MaxRune {
+					return "", fmt.Errorf(
+						"invalid unicode escape sequence: \\u%s",
+						unicodeHex,
+					)
+				}
+				sb.WriteRune(rune(codepoint))
 				continue
 			}
 			// Hex escape
@@ -169,14 +177,11 @@ func (l *Lexer) readString() (string, error) {
 				var hexStr string
 				for {
 					l.readChar()
-					hexStr += string(l.ch)
-					tmpHex := fmt.Sprintf("%04s", hexStr)
-					if _, err := hex.DecodeString(tmpHex); err != nil {
-						// Strip off last hex character
-						hexStr = hexStr[:len(hexStr)-1]
+					if !isHexDigit(l.ch) {
 						leftoverChar = true
 						break
 					}
+					hexStr += string(l.ch)
 					if len(hexStr) >= 4 {
 						break
 					}
@@ -187,18 +192,22 @@ func (l *Lexer) readString() (string, error) {
 						hexStr,
 					)
 				}
-				// Pad hex string for parsing
-				tmpHex := fmt.Sprintf("%04s", hexStr)
-				// Strip out any leading zero bytes
-				tmpHex = strings.TrimPrefix(tmpHex, "00")
-				r, err := hex.DecodeString(tmpHex)
+				// The hex digits denote a Unicode code point, not raw
+				// bytes, so the result must be UTF-8 encoded
+				codepoint, err := strconv.ParseUint(hexStr, 16, 32)
 				if err != nil {
 					return "", fmt.Errorf(
 						"invalid hex escape sequence: \\x%s",
 						hexStr,
 					)
 				}
-				sb.Write(r)
+				if codepoint > unicode.MaxRune {
+					return "", fmt.Errorf(
+						"invalid hex escape sequence: \\x%s",
+						hexStr,
+					)
+				}
+				sb.WriteRune(rune(codepoint))
 				continue
 			}
 			// Octal escape

--- a/syn/lex/lexer_test.go
+++ b/syn/lex/lexer_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestUnknownNamedEscapeMessageContainsFullName(t *testing.T) {
@@ -150,6 +151,101 @@ func TestLexerStrings(t *testing.T) {
 				)
 			}
 		}
+	}
+}
+
+func TestLexerStringNumericEscapes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		// \u escapes denote Unicode code points, not raw bytes
+		{"unicode ascii 4 digits", `"\u0041"`, "A"},
+		{"unicode ascii 2 digits", `"\u41"`, "A"},
+		{"unicode latin1", `"\u00e9"`, "é"},
+		{"unicode bmp", `"\u20ac"`, "€"},
+		{"unicode nul", `"\u0000"`, "\x00"},
+		// \x escapes denote Unicode code points, not raw bytes.
+		// Leading zeros are insignificant digits of the same number, so
+		// \x0041 is the single character A, not a NUL byte followed by A.
+		{"hex ascii", `"\x41"`, "A"},
+		{"hex ascii leading zeros", `"\x0041"`, "A"},
+		{"hex latin1", `"\xe9"`, "é"},
+		{"hex bmp", `"\x20AC"`, "€"},
+		{"hex nul", `"\x00"`, "\x00"},
+		// Digit collection stops at 4 hex digits; the rest is literal text
+		{"unicode greedy 4 digit cap", `"\u0041BC"`, "ABC"},
+		// Digit collection stops at the first non-hex character
+		{"unicode stops at non-hex", `"\ue9z"`, "éz"},
+		{"hex stops at non-hex", `"\x41!"`, "A!"},
+		// Escapes embedded in surrounding text
+		{"unicode in text", `"caf\u00e9"`, "café"},
+		{"hex in text", `"caf\xe9"`, "café"},
+		// Surrogate code points cannot be encoded in UTF-8; they become
+		// U+FFFD, matching Data.Text's replacement behavior
+		{"unicode surrogate", `"\ud800"`, "�"},
+		// Decimal and octal escapes already used code point semantics
+		{"decimal", `"\233"`, "é"},
+		{"octal", `"\o351"`, "é"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lexer := NewLexer(tt.input)
+			token := lexer.NextToken()
+
+			if token.Type != TokenString {
+				t.Fatalf(
+					"expected TokenString, got %v (literal %q)",
+					token.Type,
+					token.Literal,
+				)
+			}
+			if token.Literal != tt.expected {
+				t.Errorf(
+					"input %s: expected literal %q, got %q",
+					tt.input,
+					tt.expected,
+					token.Literal,
+				)
+			}
+			if !utf8.ValidString(token.Literal) {
+				t.Errorf(
+					"input %s: literal %q is not valid UTF-8",
+					tt.input,
+					token.Literal,
+				)
+			}
+		})
+	}
+}
+
+func TestLexerStringNumericEscapeErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"unicode no digits", `"\uzz"`},
+		{"unicode one digit", `"\u9"`},
+		{"hex no digits", `"\xzz"`},
+		{"hex one digit", `"\x9"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lexer := NewLexer(tt.input)
+			token := lexer.NextToken()
+
+			if token.Type != TokenError {
+				t.Fatalf(
+					"input %s: expected TokenError, got %v (literal %q)",
+					tt.input,
+					token.Type,
+					token.Literal,
+				)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix string escape decoding in `syn/lex` so `\u` and `\x` escapes are interpreted as Unicode code points and emitted as UTF-8 runes, not raw bytes. This makes strings like `"\xe9"` decode to "é" and ensures valid UTF-8 output.

- **Bug Fixes**
  - `\u` and `\x` parse up to 4 hex digits, stop at the first non-hex, and error on 0–1 digits.
  - Interpret digits as code points via `strconv.ParseUint` and write with `sb.WriteRune`; removed `encoding/hex`. Added `isHexDigit` and kept leftover-char handling.

- **Tests**
  - Covered ASCII/Latin-1/BMP/NUL, greedy/stopping behavior, surrogate replacement, and unchanged decimal/octal semantics.
  - Added error cases for missing/short digits and asserted all outputs are valid UTF-8.

<sup>Written for commit 03c0627e6fef8bb7ee52192281f3e3144a10f275. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/plutigo/pull/323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

