### PR TITLE
fix(cek): return typed BuiltinError from builtin argument validation

### DIFF
--- a/cek/builtins.go
+++ b/cek/builtins.go
@@ -1224,17 +1224,25 @@ func verifyEd25519Signature[T syn.Eval](
 	}
 
 	if len(publicKey) != ed25519.PublicKeySize { // 32 bytes
-		return nil, fmt.Errorf(
-			"invalid public key length: got %d, expected 32",
-			len(publicKey),
-		)
+		return nil, &BuiltinError{
+			Code:    ErrCodeInvalidArgument,
+			Builtin: "verifyEd25519Signature",
+			Message: fmt.Sprintf(
+				"invalid public key length: got %d, expected 32",
+				len(publicKey),
+			),
+		}
 	}
 
 	if len(signature) != ed25519.SignatureSize { // 64 bytes
-		return nil, fmt.Errorf(
-			"invalid signature length: got %d, expected 64",
-			len(signature),
-		)
+		return nil, &BuiltinError{
+			Code:    ErrCodeInvalidArgument,
+			Builtin: "verifyEd25519Signature",
+			Message: fmt.Sprintf(
+				"invalid signature length: got %d, expected 64",
+				len(signature),
+			),
+		}
 	}
 
 	var res bool
@@ -1466,7 +1474,11 @@ func verifySchnorrSecp256K1Signature[T syn.Eval](
 
 	key, err := schnorr.ParsePubKey(publicKey)
 	if err != nil {
-		return nil, err
+		return nil, &BuiltinError{
+			Code:    ErrCodeInvalidArgument,
+			Builtin: "verifySchnorrSecp256k1Signature",
+			Message: fmt.Sprintf("invalid public key: %v", err),
+		}
 	}
 
 	r := new(btcec.FieldVal)
@@ -2971,7 +2983,11 @@ func integerToByteString[T syn.Eval](
 
 	// Check for negative input
 	if input.Sign() < 0 {
-		return nil, fmt.Errorf("integerToByteString: negative input %v", input)
+		return nil, &BuiltinError{
+			Code:    ErrCodeInvalidArgument,
+			Builtin: "integerToByteString",
+			Message: fmt.Sprintf("negative input %v", input),
+		}
 	}
 
 	// Convert size to int64
@@ -2986,10 +3002,11 @@ func integerToByteString[T syn.Eval](
 	sizeInt64 := size.Int64()
 
 	if sizeInt64 < 0 {
-		return nil, fmt.Errorf(
-			"integerToByteString: negative size %v",
-			sizeInt64,
-		)
+		return nil, &BuiltinError{
+			Code:    ErrCodeInvalidArgument,
+			Builtin: "integerToByteString",
+			Message: fmt.Sprintf("negative size %v", sizeInt64),
+		}
 	}
 
 	sizeUnwrapped := int(sizeInt64)
@@ -3025,10 +3042,14 @@ func integerToByteString[T syn.Eval](
 		(input.BitLen()-1) >= 8*IntegerToByteStringMaximumOutputLength {
 		required := (input.BitLen() + 7) / 8
 
-		return nil, fmt.Errorf(
-			"integerToByteString: input requires %d bytes, exceeds max %d",
-			required, IntegerToByteStringMaximumOutputLength,
-		)
+		return nil, &BuiltinError{
+			Code:    ErrCodeOverflow,
+			Builtin: "integerToByteString",
+			Message: fmt.Sprintf(
+				"input requires %d bytes, exceeds max %d",
+				required, IntegerToByteStringMaximumOutputLength,
+			),
+		}
 	}
 
 	// Handle zero input
@@ -3045,10 +3066,14 @@ func integerToByteString[T syn.Eval](
 
 	// Check if bytes exceed specified size
 	if sizeInt64 != 0 && len(bytes) > sizeUnwrapped {
-		return nil, fmt.Errorf(
-			"integerToByteString: size %d too small, need %d",
-			sizeUnwrapped, len(bytes),
-		)
+		return nil, &BuiltinError{
+			Code:    ErrCodeInvalidArgument,
+			Builtin: "integerToByteString",
+			Message: fmt.Sprintf(
+				"size %d too small, need %d",
+				sizeUnwrapped, len(bytes),
+			),
+		}
 	}
 
 	// Handle padding
@@ -3483,10 +3508,14 @@ func writeBits[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 		// Unwrap integer from list element
 		bitIndex, ok := index.(*syn.Integer)
 		if !ok {
-			return nil, fmt.Errorf(
-				"writeBits: expected integer in indices list, got %T",
-				index,
-			)
+			return nil, &BuiltinError{
+				Code:    ErrCodeInvalidArgument,
+				Builtin: "writeBits",
+				Message: fmt.Sprintf(
+					"expected integer in indices list, got %T",
+					index,
+				),
+			}
 		}
 
 		// Validate bit index
@@ -3583,10 +3612,11 @@ func replicateByte[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 
 	// Validate byte
 	if !byteVal.IsInt64() || byteVal.Int64() < 0 || byteVal.Int64() > 255 {
-		return nil, fmt.Errorf(
-			"replicateByte: byte value %v out of bounds (0-255)",
-			byteVal,
-		)
+		return nil, &BuiltinError{
+			Code:    ErrCodeInvalidArgument,
+			Builtin: "replicateByte",
+			Message: fmt.Sprintf("byte value %v out of bounds (0-255)", byteVal),
+		}
 	}
 	byteUint := byte(byteVal.Int64())
 
@@ -3949,7 +3979,11 @@ func expModInteger[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 
 	case bb.Sign() == 0:
 		// 0^negative is undefined
-		return nil, fmt.Errorf("expModInteger: 0^%s is undefined", e.String())
+		return nil, &BuiltinError{
+			Code:    ErrCodeInvalidArgument,
+			Builtin: "expModInteger",
+			Message: fmt.Sprintf("0^%s is undefined", e.String()),
+		}
 
 	default:
 		// Negative exponent: need to compute modular inverse
@@ -3961,12 +3995,16 @@ func expModInteger[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 		gcd := new(big.Int)
 		gcd.GCD(nil, nil, reducedBase, mm)
 		if gcd.Cmp(big.NewInt(1)) != 0 {
-			return nil, fmt.Errorf(
-				"expModInteger: %s is not invertible modulo %s (gcd = %s)",
-				bb.String(),
-				mm.String(),
-				gcd.String(),
-			)
+			return nil, &BuiltinError{
+				Code:    ErrCodeInvalidArgument,
+				Builtin: "expModInteger",
+				Message: fmt.Sprintf(
+					"%s is not invertible modulo %s (gcd = %s)",
+					bb.String(),
+					mm.String(),
+					gcd.String(),
+				),
+			}
 		}
 
 		// Compute modular inverse using extended Euclidean algorithm

--- a/cek/builtins_test.go
+++ b/cek/builtins_test.go
@@ -2460,6 +2460,280 @@ func TestConsByteStringBuiltin(t *testing.T) {
 	}
 }
 
+// TestTypedErrorsBuiltinValidation tests that each builtin error path that was
+// previously returning bare fmt.Errorf values now returns a typed *BuiltinError.
+func TestTypedErrorsBuiltinValidation(t *testing.T) {
+	// verifyEd25519Signature: invalid public key length (line ~1227)
+	t.Run("verifyEd25519Signature/invalid_pubkey_length", func(t *testing.T) {
+		m := newTestMachine()
+		b := newTestBuiltin(builtin.VerifyEd25519Signature)
+
+		// Use a 10-byte public key (not 32)
+		shortKey := make([]byte, 10)
+		msg := []byte("hello")
+		sig := make([]byte, ed25519.SignatureSize)
+
+		b = b.ApplyArg(&Constant{&syn.ByteString{Inner: shortKey}})
+		b = b.ApplyArg(&Constant{&syn.ByteString{Inner: msg}})
+		b = b.ApplyArg(&Constant{&syn.ByteString{Inner: sig}})
+
+		_, err := evalBuiltinWithError(t, m, b)
+		if err == nil {
+			t.Fatal("expected error for invalid public key length, got nil")
+		}
+		var builtinErr *BuiltinError
+		if !errors.As(err, &builtinErr) {
+			t.Fatalf("expected *BuiltinError, got %T: %v", err, err)
+		}
+		if builtinErr.Code != ErrCodeInvalidArgument {
+			t.Fatalf("expected ErrCodeInvalidArgument, got %v", builtinErr.Code)
+		}
+	})
+
+	// verifyEd25519Signature: invalid signature length (line ~1234)
+	t.Run("verifyEd25519Signature/invalid_signature_length", func(t *testing.T) {
+		m := newTestMachine()
+		b := newTestBuiltin(builtin.VerifyEd25519Signature)
+
+		validKey := make([]byte, ed25519.PublicKeySize)
+		msg := []byte("hello")
+		shortSig := make([]byte, 10) // not 64
+
+		b = b.ApplyArg(&Constant{&syn.ByteString{Inner: validKey}})
+		b = b.ApplyArg(&Constant{&syn.ByteString{Inner: msg}})
+		b = b.ApplyArg(&Constant{&syn.ByteString{Inner: shortSig}})
+
+		_, err := evalBuiltinWithError(t, m, b)
+		if err == nil {
+			t.Fatal("expected error for invalid signature length, got nil")
+		}
+		var builtinErr *BuiltinError
+		if !errors.As(err, &builtinErr) {
+			t.Fatalf("expected *BuiltinError, got %T: %v", err, err)
+		}
+		if builtinErr.Code != ErrCodeInvalidArgument {
+			t.Fatalf("expected ErrCodeInvalidArgument, got %v", builtinErr.Code)
+		}
+	})
+
+	// verifySchnorrSecp256k1Signature: schnorr.ParsePubKey returns raw error (line ~1469)
+	t.Run("verifySchnorrSecp256k1Signature/invalid_pubkey", func(t *testing.T) {
+		m := newTestMachine()
+		b := newTestBuiltin(builtin.VerifySchnorrSecp256k1Signature)
+
+		// 32-byte key that is invalid (all zeros is not a valid Schnorr pubkey)
+		invalidKey := make([]byte, 32)
+		msg := []byte("hello")
+		sig := make([]byte, 64)
+
+		b = b.ApplyArg(&Constant{&syn.ByteString{Inner: invalidKey}})
+		b = b.ApplyArg(&Constant{&syn.ByteString{Inner: msg}})
+		b = b.ApplyArg(&Constant{&syn.ByteString{Inner: sig}})
+
+		_, err := evalBuiltinWithError(t, m, b)
+		if err == nil {
+			t.Fatal("expected error for invalid Schnorr public key, got nil")
+		}
+		var builtinErr *BuiltinError
+		if !errors.As(err, &builtinErr) {
+			t.Fatalf("expected *BuiltinError, got %T: %v", err, err)
+		}
+		if builtinErr.Code != ErrCodeInvalidArgument {
+			t.Fatalf("expected ErrCodeInvalidArgument, got %v", builtinErr.Code)
+		}
+	})
+
+	// integerToByteString: negative input (line ~2974)
+	t.Run("integerToByteString/negative_input", func(t *testing.T) {
+		m := newTestMachine()
+		b := newTestBuiltin(builtin.IntegerToByteString)
+
+		b = b.ApplyArg(&Constant{&syn.Bool{Inner: true}})
+		b = b.ApplyArg(&Constant{&syn.Integer{Inner: big.NewInt(4)}})
+		b = b.ApplyArg(&Constant{&syn.Integer{Inner: big.NewInt(-1)}})
+
+		_, err := evalBuiltinWithError(t, m, b)
+		if err == nil {
+			t.Fatal("expected error for negative input, got nil")
+		}
+		var builtinErr *BuiltinError
+		if !errors.As(err, &builtinErr) {
+			t.Fatalf("expected *BuiltinError, got %T: %v", err, err)
+		}
+		if builtinErr.Code != ErrCodeInvalidArgument {
+			t.Fatalf("expected ErrCodeInvalidArgument, got %v", builtinErr.Code)
+		}
+	})
+
+	// integerToByteString: negative size (line ~2989)
+	t.Run("integerToByteString/negative_size", func(t *testing.T) {
+		m := newTestMachine()
+		b := newTestBuiltin(builtin.IntegerToByteString)
+
+		b = b.ApplyArg(&Constant{&syn.Bool{Inner: true}})
+		b = b.ApplyArg(&Constant{&syn.Integer{Inner: big.NewInt(-1)}})
+		b = b.ApplyArg(&Constant{&syn.Integer{Inner: big.NewInt(5)}})
+
+		_, err := evalBuiltinWithError(t, m, b)
+		if err == nil {
+			t.Fatal("expected error for negative size, got nil")
+		}
+		var builtinErr *BuiltinError
+		if !errors.As(err, &builtinErr) {
+			t.Fatalf("expected *BuiltinError, got %T: %v", err, err)
+		}
+		if builtinErr.Code != ErrCodeInvalidArgument {
+			t.Fatalf("expected ErrCodeInvalidArgument, got %v", builtinErr.Code)
+		}
+	})
+
+	// integerToByteString: zero size with large input (line ~3028)
+	t.Run("integerToByteString/zero_size_large_input", func(t *testing.T) {
+		m := newTestMachine()
+		b := newTestBuiltin(builtin.IntegerToByteString)
+
+		// Build a number that requires more than max bytes
+		// IntegerToByteStringMaximumOutputLength is 8192 bytes = 65536 bits
+		// So we need a number with more than 65536 bits
+		large := new(big.Int).Lsh(big.NewInt(1), 8*IntegerToByteStringMaximumOutputLength)
+
+		b = b.ApplyArg(&Constant{&syn.Bool{Inner: true}})
+		b = b.ApplyArg(&Constant{&syn.Integer{Inner: big.NewInt(0)}}) // size=0 means auto
+		b = b.ApplyArg(&Constant{&syn.Integer{Inner: large}})
+
+		_, err := evalBuiltinWithError(t, m, b)
+		if err == nil {
+			t.Fatal("expected error for zero-size with too-large input, got nil")
+		}
+		var builtinErr *BuiltinError
+		if !errors.As(err, &builtinErr) {
+			t.Fatalf("expected *BuiltinError, got %T: %v", err, err)
+		}
+		if builtinErr.Code != ErrCodeOverflow {
+			t.Fatalf("expected ErrCodeOverflow, got %v", builtinErr.Code)
+		}
+	})
+
+	// integerToByteString: size too small for input (line ~3048)
+	t.Run("integerToByteString/size_too_small", func(t *testing.T) {
+		m := newTestMachine()
+		b := newTestBuiltin(builtin.IntegerToByteString)
+
+		b = b.ApplyArg(&Constant{&syn.Bool{Inner: true}})
+		b = b.ApplyArg(&Constant{&syn.Integer{Inner: big.NewInt(1)}}) // size=1
+		b = b.ApplyArg(&Constant{&syn.Integer{Inner: big.NewInt(0xABCD)}}) // needs 2 bytes
+
+		_, err := evalBuiltinWithError(t, m, b)
+		if err == nil {
+			t.Fatal("expected error for size too small, got nil")
+		}
+		var builtinErr *BuiltinError
+		if !errors.As(err, &builtinErr) {
+			t.Fatalf("expected *BuiltinError, got %T: %v", err, err)
+		}
+		if builtinErr.Code != ErrCodeInvalidArgument {
+			t.Fatalf("expected ErrCodeInvalidArgument, got %v", builtinErr.Code)
+		}
+	})
+
+	// writeBits: non-integer in indices list (line ~3486)
+	t.Run("writeBits/non_integer_in_list", func(t *testing.T) {
+		m := newTestMachine()
+		b := newTestBuiltin(builtin.WriteBits)
+
+		bs := []byte{0xFF}
+		// Create a list containing a non-integer element (a ByteString instead)
+		indices := &syn.ProtoList{
+			LTyp: &syn.TInteger{},
+			List: []syn.IConstant{
+				&syn.ByteString{Inner: []byte{0x01}}, // wrong type!
+			},
+		}
+
+		b = b.ApplyArg(&Constant{&syn.ByteString{Inner: bs}})
+		b = b.ApplyArg(&Constant{indices})
+		b = b.ApplyArg(&Constant{&syn.Bool{Inner: true}})
+
+		_, err := evalBuiltinWithError(t, m, b)
+		if err == nil {
+			t.Fatal("expected error for non-integer in list, got nil")
+		}
+		var builtinErr *BuiltinError
+		if !errors.As(err, &builtinErr) {
+			t.Fatalf("expected *BuiltinError, got %T: %v", err, err)
+		}
+		if builtinErr.Code != ErrCodeInvalidArgument {
+			t.Fatalf("expected ErrCodeInvalidArgument, got %v", builtinErr.Code)
+		}
+	})
+
+	// replicateByte: byte value out of range (line ~3586)
+	t.Run("replicateByte/byte_out_of_range", func(t *testing.T) {
+		m := newTestMachine()
+		b := newTestBuiltin(builtin.ReplicateByte)
+
+		b = b.ApplyArg(&Constant{&syn.Integer{Inner: big.NewInt(4)}})  // size=4
+		b = b.ApplyArg(&Constant{&syn.Integer{Inner: big.NewInt(256)}}) // byte=256, out of range
+
+		_, err := evalBuiltinWithError(t, m, b)
+		if err == nil {
+			t.Fatal("expected error for byte value out of range, got nil")
+		}
+		var builtinErr *BuiltinError
+		if !errors.As(err, &builtinErr) {
+			t.Fatalf("expected *BuiltinError, got %T: %v", err, err)
+		}
+		if builtinErr.Code != ErrCodeInvalidArgument {
+			t.Fatalf("expected ErrCodeInvalidArgument, got %v", builtinErr.Code)
+		}
+	})
+
+	// expModInteger: 0^negative is undefined (line ~3952)
+	t.Run("expModInteger/zero_to_negative_exponent", func(t *testing.T) {
+		m := newTestMachine()
+		b := newTestBuiltin(builtin.ExpModInteger)
+
+		b = b.ApplyArg(&Constant{&syn.Integer{Inner: big.NewInt(0)}})  // base=0
+		b = b.ApplyArg(&Constant{&syn.Integer{Inner: big.NewInt(-1)}}) // exponent=-1
+		b = b.ApplyArg(&Constant{&syn.Integer{Inner: big.NewInt(5)}})  // modulus=5
+
+		_, err := evalBuiltinWithError(t, m, b)
+		if err == nil {
+			t.Fatal("expected error for 0^(-1), got nil")
+		}
+		var builtinErr *BuiltinError
+		if !errors.As(err, &builtinErr) {
+			t.Fatalf("expected *BuiltinError, got %T: %v", err, err)
+		}
+		if builtinErr.Code != ErrCodeInvalidArgument {
+			t.Fatalf("expected ErrCodeInvalidArgument, got %v", builtinErr.Code)
+		}
+	})
+
+	// expModInteger: base not invertible modulo m (line ~3964)
+	t.Run("expModInteger/not_invertible", func(t *testing.T) {
+		m := newTestMachine()
+		b := newTestBuiltin(builtin.ExpModInteger)
+
+		// 2^(-1) mod 4 is undefined because gcd(2,4) = 2 != 1
+		b = b.ApplyArg(&Constant{&syn.Integer{Inner: big.NewInt(2)}})  // base=2
+		b = b.ApplyArg(&Constant{&syn.Integer{Inner: big.NewInt(-1)}}) // exponent=-1
+		b = b.ApplyArg(&Constant{&syn.Integer{Inner: big.NewInt(4)}})  // modulus=4
+
+		_, err := evalBuiltinWithError(t, m, b)
+		if err == nil {
+			t.Fatal("expected error for non-invertible base, got nil")
+		}
+		var builtinErr *BuiltinError
+		if !errors.As(err, &builtinErr) {
+			t.Fatalf("expected *BuiltinError, got %T: %v", err, err)
+		}
+		if builtinErr.Code != ErrCodeInvalidArgument {
+			t.Fatalf("expected ErrCodeInvalidArgument, got %v", builtinErr.Code)
+		}
+	})
+}
+
 func TestSliceByteStringBuiltin(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized builtin argument validation in `cek` to return typed BuiltinError with error codes instead of raw fmt.Errorf. This makes errors consistent and machine-readable, and adds tests to lock in behavior.

- **Bug Fixes**
  - Return BuiltinError from: verifyEd25519Signature, verifySchnorrSecp256k1Signature, integerToByteString, writeBits, replicateByte, expModInteger.
  - Use ErrCodeInvalidArgument and ErrCodeOverflow consistently.
  - Added focused tests that assert typed errors for each updated path.

<sup>Written for commit a0f7fa631dfa2110036ecf74368a39d04936cc61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/plutigo/pull/324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

