### PR TITLE
fix(syn): reject trailing bytes and validate version before term decode

### DIFF
--- a/syn/flat_decode.go
+++ b/syn/flat_decode.go
@@ -84,14 +84,14 @@ func Decode[T Binder](bytes []byte) (*Program[T], error) {
 		return nil, err
 	}
 
-	terms, err := decodeTermWithArena[T](d, arena)
-	if err != nil {
-		return nil, err
-	}
-
 	if major > math.MaxUint32 || minor > math.MaxUint32 ||
 		patch > math.MaxUint32 {
 		return nil, errors.New("version numbers too large")
+	}
+
+	terms, err := decodeTermWithArena[T](d, arena)
+	if err != nil {
+		return nil, err
 	}
 
 	version := lang.LanguageVersion{uint32(major), uint32(minor), uint32(patch)}
@@ -102,6 +102,10 @@ func Decode[T Binder](bytes []byte) (*Program[T], error) {
 	}
 
 	if err := d.filler(); err != nil {
+		return nil, err
+	}
+
+	if err := d.ensureFullyConsumed(); err != nil {
 		return nil, err
 	}
 
@@ -128,14 +132,14 @@ func decodeDeBruijnProgram(
 		return nil, err
 	}
 
-	terms, err := decodeTermDeBruijnWithArena(d, arena, consts)
-	if err != nil {
-		return nil, err
-	}
-
 	if major > math.MaxUint32 || minor > math.MaxUint32 ||
 		patch > math.MaxUint32 {
 		return nil, errors.New("version numbers too large")
+	}
+
+	terms, err := decodeTermDeBruijnWithArena(d, arena, consts)
+	if err != nil {
+		return nil, err
 	}
 
 	program := &Program[DeBruijn]{
@@ -144,6 +148,10 @@ func decodeDeBruijnProgram(
 	}
 
 	if err := d.filler(); err != nil {
+		return nil, err
+	}
+
+	if err := d.ensureFullyConsumed(); err != nil {
 		return nil, err
 	}
 
@@ -1358,6 +1366,22 @@ func (d *decoder) filler() error {
 		}
 	}
 
+	return nil
+}
+
+// ensureFullyConsumed verifies the decoder consumed the entire input buffer.
+// A valid flat-encoded program ends with a byte-aligned filler, so after the
+// final filler the decoder must sit exactly at the end of the buffer with no
+// partially consumed byte. Any leftover bytes (or stray bits from a filler
+// whose terminating 1-bit was not byte-aligned) are trailing garbage and the
+// input is rejected.
+func (d *decoder) ensureFullyConsumed() error {
+	if d.usedBits != 0 || d.pos != len(d.buffer) {
+		return fmt.Errorf(
+			"trailing bytes after program: %d byte(s) not consumed",
+			len(d.buffer)-d.pos,
+		)
+	}
 	return nil
 }
 

--- a/syn/flat_decode_limits_test.go
+++ b/syn/flat_decode_limits_test.go
@@ -2,6 +2,7 @@ package syn
 
 import (
 	"bytes"
+	"math/bits"
 	"strings"
 	"testing"
 
@@ -56,6 +57,106 @@ func TestDecodeTermDepthLimit(t *testing.T) {
 				t.Fatalf("expected error containing %q, got: %v", tt.wantErrText, err)
 			}
 		})
+	}
+}
+
+// TestDecodeRejectsTrailingBytes verifies the flat decoder consumes the whole
+// input: a valid program followed by trailing garbage bytes must be rejected,
+// while the exact same bytes without the garbage decode fine. Both the generic
+// decode path and the fast DeBruijn path must agree.
+func TestDecodeRejectsTrailingBytes(t *testing.T) {
+	// A binder-free program so the same encoding is valid for every binder
+	// type (DeBruijn and NamedDeBruijn binders encode differently).
+	encoded, err := Encode(&Program[DeBruijn]{
+		Version: lang.LanguageVersionV1,
+		Term:    &Error{},
+	})
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		trailing []byte
+		wantErr  bool
+	}{
+		{"no trailing bytes decodes", nil, false},
+		{"trailing zero byte rejected", []byte{0x00}, true},
+		{"trailing 0xFF byte rejected", []byte{0xFF}, true},
+		{"multiple trailing bytes rejected", []byte{0x00, 0xFF, 0x00}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := make([]byte, 0, len(encoded)+len(tt.trailing))
+			input = append(input, encoded...)
+			input = append(input, tt.trailing...)
+
+			_, fastErr := DecodeDeBruijn(input)
+			_, genericFastErr := Decode[DeBruijn](input)
+			_, genericErr := Decode[NamedDeBruijn](input)
+
+			for path, err := range map[string]error{
+				"DecodeDeBruijn":        fastErr,
+				"Decode[DeBruijn]":      genericFastErr,
+				"Decode[NamedDeBruijn]": genericErr,
+			} {
+				if !tt.wantErr {
+					if err != nil {
+						t.Errorf("%s: decode should succeed, got: %v", path, err)
+					}
+					continue
+				}
+				if err == nil {
+					t.Errorf("%s: expected trailing-bytes error, got nil", path)
+					continue
+				}
+				if !strings.Contains(err.Error(), "trailing bytes") {
+					t.Errorf(
+						"%s: expected error containing %q, got: %v",
+						path, "trailing bytes", err,
+					)
+				}
+			}
+		})
+	}
+}
+
+// TestDecodeVersionOverflowFailsFast verifies that an oversized version varint
+// is rejected immediately after the version words are read, before any attempt
+// to decode the term. The input deliberately has no term bytes: a decoder that
+// validates the version only after the term decode reports "end of buffer"
+// instead of the version error.
+func TestDecodeVersionOverflowFailsFast(t *testing.T) {
+	// major = 2^32 (exceeds MaxUint32), minor = 1, patch = 1, then nothing.
+	input := []byte{0x80, 0x80, 0x80, 0x80, 0x10, 0x01, 0x01}
+
+	wantErrText := "version numbers too large"
+	if bits.UintSize == 32 {
+		// On 32-bit targets the varint itself overflows the machine word, so
+		// word() rejects it even earlier.
+		wantErrText = "overflows machine word"
+	}
+
+	_, fastErr := DecodeDeBruijn(input)
+	_, genericFastErr := Decode[DeBruijn](input)
+	_, genericErr := Decode[NamedDeBruijn](input)
+
+	for path, err := range map[string]error{
+		"DecodeDeBruijn":        fastErr,
+		"Decode[DeBruijn]":      genericFastErr,
+		"Decode[NamedDeBruijn]": genericErr,
+	} {
+		if err == nil {
+			t.Errorf("%s: expected error, got nil", path)
+			continue
+		}
+		if !strings.Contains(err.Error(), wantErrText) {
+			t.Errorf(
+				"%s: expected error containing %q, got: %v",
+				path, wantErrText, err,
+			)
+		}
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reject trailing bytes in the flat decoder and validate the version before decoding the term. This prevents accepting garbage after a valid program and fails fast on oversized versions in both decode paths.

- **Bug Fixes**
  - Enforce full input consumption with `ensureFullyConsumed`; reject leftover bytes or partial bits.
  - Check version size before term decoding in both generic and DeBruijn paths; fail early on overflow.
  - Add tests covering trailing-bytes rejection and fast-fail version overflow for `DecodeDeBruijn`, `Decode[DeBruijn]`, and `Decode[NamedDeBruijn]`.

<sup>Written for commit 0e2d41377b039ec31f9494fe80ee4523ce3808bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/plutigo/pull/325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

