### PR TITLE
fix(syn): bound application width in parser to depth limit

### DIFF
--- a/syn/parser.go
+++ b/syn/parser.go
@@ -1378,8 +1378,25 @@ func (p *Parser) parseApply() (Term[Name], error) {
 	}
 
 	var terms []Term[Name]
+	applicationDepth := 0
+	defer func() {
+		for range applicationDepth {
+			p.leave()
+		}
+	}()
 
 	for p.curToken.Type != lex.TokenRBracket {
+		// Each argument produces one Apply node in the left-nested chain,
+		// contributing depth 1 to the resulting AST. We therefore charge one
+		// depth unit per argument (held until the application is fully parsed)
+		// so the accumulated application width counts against the same budget
+		// as recursive term nesting — preventing downstream passes from
+		// overflowing the stack on very wide applications.
+		if err := p.enter(); err != nil {
+			return nil, err
+		}
+		applicationDepth++
+
 		term, err := p.ParseTerm()
 		if err != nil {
 			return nil, err

--- a/syn/parser_limits_test.go
+++ b/syn/parser_limits_test.go
@@ -1,6 +1,7 @@
 package syn
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -58,4 +59,52 @@ func TestParseDepthLimit(t *testing.T) {
 			t.Fatalf("expected a depth error, got: %v", err)
 		}
 	})
+}
+
+// TestParseApplyWidth verifies that a single application with more arguments
+// than maxParseDepth is rejected with a depth-limit error. Each argument in
+// [f a1 a2 ... aN] produces one Apply node in a left-nested chain of depth N,
+// so very wide applications defeat the recursive-descent depth guard on
+// downstream passes (NameToDeBruijn, flat encoding, pretty printing) just as
+// deeply nested terms do.
+func TestParseApplyWidth(t *testing.T) {
+	// Build argument strings: each argument is a simple variable "x".
+	makeApply := func(n int) string {
+		args := make([]string, n+1)
+		args[0] = "(builtin addInteger)" // function head
+		for i := 1; i <= n; i++ {
+			args[i] = fmt.Sprintf("x%d", i)
+		}
+		return "(program 1.0.0 [ " + strings.Join(args, " ") + " ])"
+	}
+
+	t.Run("healthy width parses", func(t *testing.T) {
+		// 100 args is well within maxParseDepth (100_000); must succeed.
+		if _, err := Parse(makeApply(100)); err != nil {
+			t.Fatalf("100-argument application should parse, got: %v", err)
+		}
+	})
+
+	t.Run("excessive width is rejected", func(t *testing.T) {
+		// maxParseDepth+1 args must be rejected with a "too deep" error.
+		src := makeApply(maxParseDepth + 1)
+		_, err := Parse(src)
+		if err == nil {
+			t.Fatal("expected depth-limit error for wide application, got nil")
+		}
+		if !strings.Contains(err.Error(), "too deep") {
+			t.Fatalf("expected a depth error, got: %v", err)
+		}
+	})
+}
+
+func TestParseApplyReleasesWidthOnArgumentError(t *testing.T) {
+	p := NewParser("[(builtin addInteger) (con integer x)]")
+	_, err := p.ParseTerm()
+	if err == nil {
+		t.Fatal("expected argument parse error, got nil")
+	}
+	if p.depth != 0 {
+		t.Fatalf("parser depth leaked after argument parse error: got %d, want 0", p.depth)
+	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bound application width to the parser depth limit so very wide applications are rejected with a depth error, preventing stack overflows in downstream passes.

- **Bug Fixes**
  - Charge one depth unit per argument in `parseApply()` (via `enter()`), and release them after the application with a deferred `leave()`, so width counts toward the same depth budget.
  - Added tests: healthy width (100 args) parses; width > `maxParseDepth` fails with "too deep".
  - Added test to ensure depth is released on argument parse errors (no depth leak).

<sup>Written for commit 2df57597408e8b18d9d22693cbc7863513d3fa2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/plutigo/pull/326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

