### PR TITLE
perf(cek): dataListValue/dataMapValue fast paths for dropList

### DIFF
--- a/cek/bench_test.go
+++ b/cek/bench_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/plutigo/builtin"
+	"github.com/blinklabs-io/plutigo/data"
 	"github.com/blinklabs-io/plutigo/lang"
 	"github.com/blinklabs-io/plutigo/syn"
 )
@@ -298,5 +299,49 @@ func buildDischargeValue(depth int) Value[syn.DeBruijn] {
 				},
 			},
 		},
+	}
+}
+
+// BenchmarkDropListDataBacked measures dropList over a data-backed list
+// value (as produced by unListData), the case optimized by the
+// dataListValue/dataMapValue fast paths.
+func BenchmarkDropListDataBacked(b *testing.B) {
+	for _, size := range []int{16, 128, 1024} {
+		items := make([]data.PlutusData, size)
+		for i := range items {
+			items[i] = data.NewInteger(big.NewInt(int64(i)))
+		}
+
+		machine := NewMachine[syn.DeBruijn](
+			lang.LanguageVersionV3,
+			0,
+			NewDefaultEvalContext(
+				lang.LanguageVersionV3,
+				ProtoVersion{Major: 11},
+			),
+		)
+		builtinValue := &Builtin[syn.DeBruijn]{Func: builtin.DropList}
+		builtinValue = builtinValue.ApplyArg(
+			benchmarkIntValue(int64(size / 2)),
+		)
+		builtinValue = builtinValue.ApplyArg(
+			&dataListValue[syn.DeBruijn]{items: items},
+		)
+
+		b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {
+			b.ReportAllocs()
+
+			for b.Loop() {
+				machine.ExBudget = ExBudget{
+					Cpu: 1 << 62,
+					Mem: 1 << 62,
+				}
+				result, err := machine.evalBuiltinApp(builtinValue)
+				if err != nil {
+					b.Fatalf("evalBuiltinApp failed: %v", err)
+				}
+				benchmarkValueSink = result
+			}
+		})
 	}
 }

--- a/cek/builtins.go
+++ b/cek/builtins.go
@@ -3997,26 +3997,25 @@ func expModInteger[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 // Note: caseList and caseData (IDs 88, 89) were removed from Plutus.
 // ============================================================================
 
-func dropList[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
-	b.Args.Extract(&m.argHolder, b.ArgCount)
-	// Args: (con integer n) (con (list t) xs)
-	nVal, err := unwrapInteger[T](m.argHolder[0])
-	if err != nil {
-		return nil, err
-	}
-
-	lst, err := unwrapList[T](nil, m.argHolder[1])
-	if err != nil {
-		return nil, err
-	}
-
+// dropListStart charges the dropList budget for a list with the given
+// length and ExMem size, then computes the start index after dropping n
+// elements. The costing is shared by the materialized (ProtoList) path and
+// the data-backed fast paths so that both charge byte-for-byte identical
+// budgets.
+func dropListStart[T syn.Eval](
+	m *Machine[T],
+	b *Builtin[T],
+	nVal *big.Int,
+	listLen int,
+	listMem func() ExMem,
+) (int, error) {
 	// Spend budget (base)
 	if err := m.CostTwo(
 		&b.Func,
-		func() ExMem { return listExMem(lst.List)() },
+		listMem,
 		bigIntExMem(nVal),
 	); err != nil {
-		return nil, err
+		return 0, err
 	}
 
 	// Capture original magnitude for costing before clamping negatives to zero
@@ -4044,32 +4043,79 @@ func dropList[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 		if origAbsN.BitLen() > dropListHugeBitLenThresh {
 			budgetCpu := math.MaxInt64 - dropListBaseCpuApprox
 			if err := m.spendBudget(ExBudget{Cpu: budgetCpu, Mem: 0}); err != nil {
-				return nil, err
+				return 0, err
 			}
 		} else if extra.BitLen() > 63 {
 			if err := m.spendBudget(ExBudget{Cpu: math.MaxInt64 / 2, Mem: 0}); err != nil {
-				return nil, err
+				return 0, err
 			}
 		} else {
 			if err := m.spendBudget(ExBudget{Cpu: extra.Int64(), Mem: 0}); err != nil {
-				return nil, err
+				return 0, err
 			}
 		}
 	}
 
 	// Convert n to int if possible, otherwise drop everything
-	start := len(lst.List)
+	start := listLen
 	if nVal.IsInt64() {
 		nVal64 := nVal.Int64()
 		if nVal64 > int64(math.MaxInt) {
-			return nil, &BuiltinError{
+			return 0, &BuiltinError{
 				Code:    ErrCodeOverflow,
 				Builtin: "dropList",
 				Message: "n too large",
 			}
 		}
 		ni := int(nVal64)
-		start = min(ni, len(lst.List))
+		start = min(ni, listLen)
+	}
+
+	return start, nil
+}
+
+func dropList[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
+	b.Args.Extract(&m.argHolder, b.ArgCount)
+	// Args: (con integer n) (con (list t) xs)
+	nVal, err := unwrapInteger[T](m.argHolder[0])
+	if err != nil {
+		return nil, err
+	}
+
+	// Fast paths: data-backed lists/maps are re-sliced without materializing
+	// the whole list into a ProtoList. valueExMem (toExMem) of these values
+	// is defined to equal listExMem of their materialized equivalent, so the
+	// charged budget is identical to the materialized path (the same
+	// mechanism headList/tailList/nullList rely on).
+	switch v := m.argHolder[1].(type) {
+	case *dataListValue[T]:
+		start, err := dropListStart(m, b, nVal, len(v.items), valueExMem[T](v))
+		if err != nil {
+			return nil, err
+		}
+		return m.allocDataListValue(v.items[start:]), nil
+	case *dataMapValue[T]:
+		start, err := dropListStart(m, b, nVal, len(v.items), valueExMem[T](v))
+		if err != nil {
+			return nil, err
+		}
+		return m.allocDataMapValue(v.items[start:]), nil
+	}
+
+	lst, err := unwrapList[T](nil, m.argHolder[1])
+	if err != nil {
+		return nil, err
+	}
+
+	start, err := dropListStart(
+		m,
+		b,
+		nVal,
+		len(lst.List),
+		func() ExMem { return listExMem(lst.List)() },
+	)
+	if err != nil {
+		return nil, err
 	}
 
 	// Build resulting list

--- a/cek/builtins_test.go
+++ b/cek/builtins_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"math"
 	"math/big"
+	"reflect"
 	"testing"
 
 	"github.com/blinklabs-io/plutigo/builtin"
@@ -4653,5 +4654,450 @@ func TestSliceByteStringClamping(t *testing.T) {
 				t.Fatalf("expected %x, got %x", tt.expected, bs.Inner)
 			}
 		})
+	}
+}
+
+// ----------------------------------------------------------------------------
+// dropList characterization tests
+//
+// dropList must charge the exact same budget regardless of whether its list
+// argument is a materialized *syn.ProtoList constant or one of the
+// data-backed representations (*dataListValue / *dataMapValue) produced by
+// unListData / unMapData / unConstrData. dataListValue.toExMem and
+// dataMapValue.toExMem are defined to be equal to listExMem of the
+// materialized equivalent, which is what makes data-backed fast paths
+// consensus-safe (the same mechanism headList/tailList/nullList rely on).
+//
+// The exact budget numbers pinned below were captured from the
+// implementation that always materialized via unwrapList, BEFORE any
+// data-backed fast path existed. They must not change without a
+// corresponding cost-model change.
+// ----------------------------------------------------------------------------
+
+// newPV11TestMachine returns a machine where dropList is available
+// (dropList requires protocol version >= 11).
+func newPV11TestMachine() *Machine[syn.DeBruijn] {
+	ctx := NewDefaultEvalContext(
+		lang.LanguageVersionV3,
+		ProtoVersion{Major: 11},
+	)
+	return NewMachine[syn.DeBruijn](lang.LanguageVersionV3, 0, ctx)
+}
+
+func dropListCharItems() []data.PlutusData {
+	return []data.PlutusData{
+		data.NewInteger(big.NewInt(1)),
+		data.NewByteString(bytes.Repeat([]byte{0xab}, 24)),
+		data.NewList(
+			data.NewInteger(big.NewInt(2)),
+			data.NewInteger(big.NewInt(3)),
+		),
+		data.NewConstr(0, data.NewInteger(big.NewInt(5))),
+		data.NewInteger(new(big.Int).Lsh(big.NewInt(1), 100)),
+	}
+}
+
+func dropListCharPairs() [][2]data.PlutusData {
+	return [][2]data.PlutusData{
+		{
+			data.NewByteString([]byte("key-one")),
+			data.NewInteger(big.NewInt(42)),
+		},
+		{
+			data.NewInteger(big.NewInt(7)),
+			data.NewList(data.NewByteString([]byte{0x01, 0x02})),
+		},
+		{
+			data.NewByteString([]byte("k3")),
+			data.NewConstr(1, data.NewInteger(big.NewInt(9))),
+		},
+	}
+}
+
+// dropListTestBudget is the initial budget used by the dropList
+// characterization tests unless a case overrides it.
+var dropListTestBudget = ExBudget{Cpu: math.MaxInt64, Mem: math.MaxInt64}
+
+// evalDropListConsumed evaluates dropList with the given argument values on a
+// fresh machine and returns the result, the exact consumed budget, and any
+// evaluation error.
+func evalDropListConsumed(
+	t *testing.T,
+	initial ExBudget,
+	nArg Value[syn.DeBruijn],
+	listArg Value[syn.DeBruijn],
+) (Value[syn.DeBruijn], ExBudget, error) {
+	t.Helper()
+	m := newPV11TestMachine()
+	m.ExBudget = initial
+	b := newTestBuiltin(builtin.DropList)
+	b = b.ApplyArg(nArg)
+	b = b.ApplyArg(listArg)
+	val, err := m.evalBuiltinApp(b)
+	consumed := initial.Sub(&m.ExBudget)
+	return val, consumed, err
+}
+
+func materializeForTest(
+	t *testing.T,
+	val Value[syn.DeBruijn],
+) syn.IConstant {
+	t.Helper()
+	c, ok, err := materializeConstantValue[syn.DeBruijn](val)
+	if err != nil {
+		t.Fatalf("materializeConstantValue failed: %v", err)
+	}
+	if !ok || c == nil {
+		t.Fatalf("could not materialize %T", val)
+	}
+	return c
+}
+
+// runDropListCharacterization runs dropList over the data-backed
+// representation and the materialized ProtoList equivalent, asserting that
+// both charge byte-for-byte identical budgets (pinned to wantBudget) and
+// produce identical results / errors.
+func runDropListCharacterization(
+	t *testing.T,
+	initial ExBudget,
+	n *big.Int,
+	fastArg Value[syn.DeBruijn],
+	slowArg Value[syn.DeBruijn],
+	wantBudget ExBudget,
+	wantBudgetErr bool,
+) {
+	t.Helper()
+
+	fastN := &Constant{&syn.Integer{Inner: new(big.Int).Set(n)}}
+	slowN := &Constant{&syn.Integer{Inner: new(big.Int).Set(n)}}
+
+	fastVal, fastBudget, fastErr := evalDropListConsumed(t, initial, fastN, fastArg)
+	slowVal, slowBudget, slowErr := evalDropListConsumed(t, initial, slowN, slowArg)
+
+	if fastBudget != slowBudget {
+		t.Fatalf(
+			"budget mismatch between representations: data-backed=%+v materialized=%+v",
+			fastBudget,
+			slowBudget,
+		)
+	}
+	if fastBudget != wantBudget {
+		t.Fatalf(
+			"budget characterization changed: got %+v, want %+v",
+			fastBudget,
+			wantBudget,
+		)
+	}
+
+	if wantBudgetErr {
+		var fastBudgetErr, slowBudgetErr *BudgetError
+		if !errors.As(fastErr, &fastBudgetErr) {
+			t.Fatalf("expected BudgetError for data-backed arg, got %v", fastErr)
+		}
+		if !errors.As(slowErr, &slowBudgetErr) {
+			t.Fatalf("expected BudgetError for materialized arg, got %v", slowErr)
+		}
+		return
+	}
+
+	if fastErr != nil {
+		t.Fatalf("unexpected error for data-backed arg: %v", fastErr)
+	}
+	if slowErr != nil {
+		t.Fatalf("unexpected error for materialized arg: %v", slowErr)
+	}
+
+	fastConst := materializeForTest(t, fastVal)
+	slowConst := materializeForTest(t, slowVal)
+	if !reflect.DeepEqual(fastConst, slowConst) {
+		t.Fatalf(
+			"result mismatch: data-backed=%v materialized=%v",
+			fastConst,
+			slowConst,
+		)
+	}
+}
+
+func TestDropListDataListBudgetCharacterization(t *testing.T) {
+	items := dropListCharItems()
+
+	tests := []struct {
+		name          string
+		initial       ExBudget
+		n             *big.Int
+		wantBudget    ExBudget
+		wantBudgetErr bool
+	}{
+		{
+			"zero",
+			dropListTestBudget,
+			big.NewInt(0),
+			ExBudget{Mem: 4, Cpu: 116711},
+			false,
+		},
+		{
+			"negative",
+			dropListTestBudget,
+			big.NewInt(-3),
+			ExBudget{Mem: 4, Cpu: 122582},
+			false,
+		},
+		{
+			"drop two",
+			dropListTestBudget,
+			big.NewInt(2),
+			ExBudget{Mem: 4, Cpu: 120625},
+			false,
+		},
+		{
+			"exact length",
+			dropListTestBudget,
+			big.NewInt(int64(len(items))),
+			ExBudget{Mem: 4, Cpu: 126496},
+			false,
+		},
+		{
+			"beyond length",
+			dropListTestBudget,
+			big.NewInt(9),
+			ExBudget{Mem: 4, Cpu: 134324},
+			false,
+		},
+		{
+			"large int64",
+			dropListTestBudget,
+			new(big.Int).Lsh(big.NewInt(1), 39),
+			ExBudget{Mem: 4, Cpu: 1075872127895527},
+			false,
+		},
+		{
+			// |n| >= 2^40 charges just enough CPU so that base + extra
+			// approximates MaxInt64; with a MaxInt64 starting budget the
+			// spend still succeeds and everything is dropped.
+			"huge non-int64",
+			dropListTestBudget,
+			new(big.Int).Lsh(big.NewInt(1), 70),
+			ExBudget{Mem: 4, Cpu: 9223372036854679707},
+			false,
+		},
+		{
+			// With a small starting budget the huge-n CPU spend fails after
+			// the base cost was charged: a BudgetError with only the base
+			// cost consumed.
+			"huge non-int64 out of budget",
+			ExBudget{Mem: 1_000_000, Cpu: 1_000_000},
+			new(big.Int).Lsh(big.NewInt(1), 70),
+			ExBudget{Mem: 4, Cpu: 116711},
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runDropListCharacterization(
+				t,
+				tt.initial,
+				tt.n,
+				&dataListValue[syn.DeBruijn]{items: items},
+				&Constant{materializeDataListConstant(items)},
+				tt.wantBudget,
+				tt.wantBudgetErr,
+			)
+		})
+	}
+}
+
+func TestDropListDataMapBudgetCharacterization(t *testing.T) {
+	pairs := dropListCharPairs()
+
+	tests := []struct {
+		name          string
+		initial       ExBudget
+		n             *big.Int
+		wantBudget    ExBudget
+		wantBudgetErr bool
+	}{
+		{
+			"zero",
+			dropListTestBudget,
+			big.NewInt(0),
+			ExBudget{Mem: 4, Cpu: 116711},
+			false,
+		},
+		{
+			"negative",
+			dropListTestBudget,
+			big.NewInt(-2),
+			ExBudget{Mem: 4, Cpu: 120625},
+			false,
+		},
+		{
+			"drop one",
+			dropListTestBudget,
+			big.NewInt(1),
+			ExBudget{Mem: 4, Cpu: 118668},
+			false,
+		},
+		{
+			"exact length",
+			dropListTestBudget,
+			big.NewInt(int64(len(pairs))),
+			ExBudget{Mem: 4, Cpu: 122582},
+			false,
+		},
+		{
+			"beyond length",
+			dropListTestBudget,
+			big.NewInt(7),
+			ExBudget{Mem: 4, Cpu: 130410},
+			false,
+		},
+		{
+			"huge non-int64",
+			dropListTestBudget,
+			new(big.Int).Lsh(big.NewInt(1), 70),
+			ExBudget{Mem: 4, Cpu: 9223372036854679707},
+			false,
+		},
+		{
+			"huge non-int64 out of budget",
+			ExBudget{Mem: 1_000_000, Cpu: 1_000_000},
+			new(big.Int).Lsh(big.NewInt(1), 70),
+			ExBudget{Mem: 4, Cpu: 116711},
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runDropListCharacterization(
+				t,
+				tt.initial,
+				tt.n,
+				&dataMapValue[syn.DeBruijn]{items: pairs},
+				&Constant{materializeDataMapConstant(pairs)},
+				tt.wantBudget,
+				tt.wantBudgetErr,
+			)
+		})
+	}
+}
+
+// TestDropListTypeErrorCharacterization pins error behavior for wrong
+// argument types: a TypeError with zero budget consumed, identically for
+// data-backed and materialized list arguments.
+func TestDropListTypeErrorCharacterization(t *testing.T) {
+	items := dropListCharItems()
+
+	t.Run("non-integer count", func(t *testing.T) {
+		badN := &Constant{&syn.String{Inner: "nope"}}
+		listArgs := []Value[syn.DeBruijn]{
+			&dataListValue[syn.DeBruijn]{items: items},
+			&dataMapValue[syn.DeBruijn]{items: dropListCharPairs()},
+			&Constant{materializeDataListConstant(items)},
+		}
+		for _, listArg := range listArgs {
+			_, consumed, err := evalDropListConsumed(
+				t,
+				dropListTestBudget,
+				badN,
+				listArg,
+			)
+			var typeErr *TypeError
+			if !errors.As(err, &typeErr) {
+				t.Fatalf("expected TypeError for %T, got %v", listArg, err)
+			}
+			if consumed != (ExBudget{}) {
+				t.Fatalf(
+					"expected zero budget consumed for %T, got %+v",
+					listArg,
+					consumed,
+				)
+			}
+		}
+	})
+
+	t.Run("non-list argument", func(t *testing.T) {
+		nArg := &Constant{&syn.Integer{Inner: big.NewInt(1)}}
+		badLists := []Value[syn.DeBruijn]{
+			&Constant{&syn.Integer{Inner: big.NewInt(2)}},
+			&dataValue[syn.DeBruijn]{item: data.NewInteger(big.NewInt(3))},
+		}
+		for _, badList := range badLists {
+			_, consumed, err := evalDropListConsumed(
+				t,
+				dropListTestBudget,
+				nArg,
+				badList,
+			)
+			var typeErr *TypeError
+			if !errors.As(err, &typeErr) {
+				t.Fatalf("expected TypeError for %T, got %v", badList, err)
+			}
+			if consumed != (ExBudget{}) {
+				t.Fatalf(
+					"expected zero budget consumed for %T, got %+v",
+					badList,
+					consumed,
+				)
+			}
+		}
+	})
+}
+
+// TestDropListUnListDataEndToEnd pins the result and total consumed budget
+// of a full program where a data-backed list (from unListData) flows into
+// dropList through normal machine evaluation.
+func TestDropListUnListDataEndToEnd(t *testing.T) {
+	src := `(program 1.1.0
+ [
+  [ (force (builtin dropList)) (con integer 2) ]
+   [ (builtin unListData) (con data (List [I 11, I 22, I 33, I 44])) ]
+  ]
+)`
+
+	program, err := syn.Parse(src)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	dProgram, err := syn.NameToDeBruijn(program)
+	if err != nil {
+		t.Fatalf("NameToDeBruijn failed: %v", err)
+	}
+
+	machine := newPV11TestMachine()
+	initial := ExBudget{Cpu: math.MaxInt64, Mem: math.MaxInt64}
+	machine.ExBudget = initial
+
+	result, err := machine.Run(dProgram.Term)
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+
+	expectedSrc := `(program 1.1.0 (con (list data) [I 33, I 44]))`
+	expected, err := syn.Parse(expectedSrc)
+	if err != nil {
+		t.Fatalf("Parse of expected failed: %v", err)
+	}
+	dExpected, err := syn.NameToDeBruijn(expected)
+	if err != nil {
+		t.Fatalf("NameToDeBruijn of expected failed: %v", err)
+	}
+
+	prettyResult := syn.PrettyTerm[syn.DeBruijn](result)
+	prettyExpected := syn.PrettyTerm[syn.DeBruijn](dExpected.Term)
+	if prettyResult != prettyExpected {
+		t.Fatalf("result mismatch\ngot:\n%s\nwant:\n%s", prettyResult, prettyExpected)
+	}
+
+	// Budget pinned from the pre-fast-path implementation; must never change.
+	consumed := initial.Sub(&machine.ExBudget)
+	wantConsumed := ExBudget{Mem: 936, Cpu: 274658}
+	if consumed != wantConsumed {
+		t.Fatalf(
+			"consumed budget characterization changed: got %+v, want %+v",
+			consumed,
+			wantConsumed,
+		)
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Optimize `dropList` by adding fast paths for data-backed lists/maps that re-slice without materializing, while preserving identical cost and results. Adds characterization tests and a benchmark to pin behavior and performance.

- **Refactors**
  - Introduced `dropListStart` to share costing and clamping logic across all paths.
  - Added fast paths for `dataListValue` and `dataMapValue` using `valueExMem` for byte-for-byte identical budgeting to materialized lists.
  - Added budget characterization tests (including error cases) and an end-to-end `unListData` case to pin results and consumed budget.
  - Added `BenchmarkDropListDataBacked` for sizes 16/128/1024.

<sup>Written for commit 83711f8b73cd72f1521fc2ffad55444e35aa8125. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/plutigo/pull/328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

