### PR TITLE
perf(data): single-pass JSON decoding for PlutusData

### DIFF
--- a/data/json.go
+++ b/data/json.go
@@ -6,8 +6,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math/big"
 	"sort"
+	"strconv"
 )
 
 // JSON (de)serialization for PlutusData types.
@@ -279,22 +281,238 @@ func (st *jsonDecodeState) enterNode() error {
 	return nil
 }
 
-// unmarshalPlutusDataJSON unmarshals JSON into the appropriate PlutusData type
-// by inspecting which key is present in the JSON object. It decodes directly
-// from the already-extracted raw messages to avoid double-parsing.
+// jsonValueKind identifies the syntactic kind of a parsed JSON value.
+type jsonValueKind uint8
+
+const (
+	jsonKindNull jsonValueKind = iota
+	jsonKindBool
+	jsonKindNumber
+	jsonKindString
+	jsonKindArray
+	jsonKindObject
+)
+
+// jsonEntry is a single key/value member of a JSON object. Object members
+// are kept in order of appearance, including duplicate keys, so the decoder
+// can reproduce encoding/json's last-occurrence-wins map semantics as well
+// as the Map pair node accounting for repeated "k"/"v" keys.
+type jsonEntry struct {
+	key string
+	val jsonValue
+}
+
+// jsonValue is a JSON value parsed in a single pass over the input. start
+// and end are byte offsets of the raw value within the original input, so
+// scalar leaves can be handed to encoding/json verbatim without rescanning
+// any enclosing structure.
+type jsonValue struct {
+	kind    jsonValueKind
+	start   int
+	end     int
+	items   []jsonValue // kind == jsonKindArray
+	entries []jsonEntry // kind == jsonKindObject
+}
+
+// unmarshalPlutusDataJSON unmarshals JSON into the appropriate PlutusData
+// type by inspecting which key is present in the JSON object. The input is
+// scanned exactly once into a lightweight syntax tree and PlutusData values
+// are built from that tree, so decoding does O(size) work instead of
+// re-parsing the remaining subtree at every nesting level.
 func unmarshalPlutusDataJSON(data json.RawMessage) (PlutusData, error) {
-	return unmarshalPlutusDataJSONState(data, &jsonDecodeState{})
+	root, err := parsePlutusDataJSONTree(data)
+	if err != nil {
+		return nil, fmt.Errorf("PlutusData JSON must be an object: %w", err)
+	}
+	return decodePlutusDataJSONValue(data, root, &jsonDecodeState{}, false)
 }
 
-func unmarshalPlutusDataJSONState(
-	data json.RawMessage,
-	st *jsonDecodeState,
-) (PlutusData, error) {
-	return unmarshalPlutusDataJSONStateCounted(data, st, false)
+// parsePlutusDataJSONTree parses data into a jsonValue tree in a single
+// pass, rejecting malformed JSON and trailing non-whitespace data exactly
+// like json.Unmarshal does.
+func parsePlutusDataJSONTree(data []byte) (jsonValue, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	root, err := parsePlutusDataJSONValue(dec, data)
+	if err != nil {
+		return jsonValue{}, normalizeJSONStreamError(err)
+	}
+	if err := checkJSONTrailingData(data, dec.InputOffset()); err != nil {
+		return jsonValue{}, err
+	}
+	return root, nil
 }
 
-func unmarshalPlutusDataJSONStateCounted(
-	data json.RawMessage,
+func parsePlutusDataJSONValue(
+	dec *json.Decoder,
+	data []byte,
+) (jsonValue, error) {
+	start := jsonValueStart(data, dec.InputOffset())
+	tok, err := dec.Token()
+	if err != nil {
+		return jsonValue{}, err
+	}
+	switch t := tok.(type) {
+	case json.Delim:
+		switch t {
+		case '[':
+			var items []jsonValue
+			for dec.More() {
+				item, err := parsePlutusDataJSONValue(dec, data)
+				if err != nil {
+					return jsonValue{}, err
+				}
+				items = append(items, item)
+			}
+			// Consume the closing ']'.
+			if _, err := dec.Token(); err != nil {
+				return jsonValue{}, err
+			}
+			return jsonValue{
+				kind:  jsonKindArray,
+				start: start,
+				end:   int(dec.InputOffset()),
+				items: items,
+			}, nil
+		case '{':
+			var entries []jsonEntry
+			for dec.More() {
+				keyTok, err := dec.Token()
+				if err != nil {
+					return jsonValue{}, err
+				}
+				key, ok := keyTok.(string)
+				if !ok {
+					// Object keys are always strings in well-formed JSON.
+					return jsonValue{}, fmt.Errorf(
+						"unexpected JSON object key token %v",
+						keyTok,
+					)
+				}
+				val, err := parsePlutusDataJSONValue(dec, data)
+				if err != nil {
+					return jsonValue{}, err
+				}
+				entries = append(entries, jsonEntry{
+					key: internJSONKey(key),
+					val: val,
+				})
+			}
+			// Consume the closing '}'.
+			if _, err := dec.Token(); err != nil {
+				return jsonValue{}, err
+			}
+			return jsonValue{
+				kind:    jsonKindObject,
+				start:   start,
+				end:     int(dec.InputOffset()),
+				entries: entries,
+			}, nil
+		default:
+			// Unreachable: closing delimiters are consumed above.
+			return jsonValue{}, fmt.Errorf("unexpected JSON delimiter %v", t)
+		}
+	case nil:
+		return jsonValue{kind: jsonKindNull, start: start, end: int(dec.InputOffset())}, nil
+	case bool:
+		return jsonValue{kind: jsonKindBool, start: start, end: int(dec.InputOffset())}, nil
+	case json.Number:
+		return jsonValue{kind: jsonKindNumber, start: start, end: int(dec.InputOffset())}, nil
+	case string:
+		return jsonValue{kind: jsonKindString, start: start, end: int(dec.InputOffset())}, nil
+	default:
+		// Unreachable: the cases above cover every token type.
+		return jsonValue{}, fmt.Errorf("unexpected JSON token %v", tok)
+	}
+}
+
+// jsonValueStart returns the offset of the first byte of the next JSON
+// value at or after from, skipping insignificant whitespace and the ':' or
+// ',' separators that json.Decoder consumes silently between tokens.
+func jsonValueStart(data []byte, from int64) int {
+	i := int(from)
+	for i < len(data) {
+		switch data[i] {
+		case ' ', '\t', '\r', '\n', ',', ':':
+			i++
+		default:
+			return i
+		}
+	}
+	return i
+}
+
+// internJSONKey returns a static copy of well-known object keys so large
+// documents do not retain one allocation per repeated key.
+func internJSONKey(key string) string {
+	switch key {
+	case "int":
+		return "int"
+	case "bytes":
+		return "bytes"
+	case "list":
+		return "list"
+	case "map":
+		return "map"
+	case "constructor":
+		return "constructor"
+	case "fields":
+		return "fields"
+	case "k":
+		return "k"
+	case "v":
+		return "v"
+	default:
+		return key
+	}
+}
+
+// normalizeJSONStreamError maps json.Decoder end-of-input errors to the
+// message json.Unmarshal reports for truncated documents.
+func normalizeJSONStreamError(err error) error {
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return errors.New("unexpected end of JSON input")
+	}
+	return err
+}
+
+// checkJSONTrailingData rejects non-whitespace bytes after the top-level
+// value, matching json.Unmarshal's behavior and error message.
+func checkJSONTrailingData(data []byte, from int64) error {
+	for i := int(from); i < len(data); i++ {
+		switch data[i] {
+		case ' ', '\t', '\r', '\n':
+		default:
+			return fmt.Errorf(
+				"invalid character %s after top-level value",
+				jsonQuoteChar(data[i]),
+			)
+		}
+	}
+	return nil
+}
+
+// jsonQuoteChar formats c as a quoted character literal the same way
+// encoding/json does in its syntax errors.
+func jsonQuoteChar(c byte) string {
+	if c == '\'' {
+		return `'\''`
+	}
+	if c == '"' {
+		return `'"'`
+	}
+	s := strconv.Quote(string(rune(c)))
+	return "'" + s[1:len(s)-1] + "'"
+}
+
+// jsonRawSpan returns the raw bytes of v within data.
+func jsonRawSpan(data []byte, v jsonValue) json.RawMessage {
+	return json.RawMessage(data[v.start:v.end])
+}
+
+func decodePlutusDataJSONValue(
+	data []byte,
+	v jsonValue,
 	st *jsonDecodeState,
 	counted bool,
 ) (PlutusData, error) {
@@ -313,10 +531,31 @@ func unmarshalPlutusDataJSONStateCounted(
 		}
 	}
 
-	var keys map[string]json.RawMessage
-	if err := json.Unmarshal(data, &keys); err != nil {
+	var keys map[string]jsonValue
+	switch v.kind {
+	case jsonKindObject:
+		keys = make(map[string]jsonValue, len(v.entries))
+		for _, e := range v.entries {
+			// Duplicate keys: the last occurrence wins, matching
+			// encoding/json's map unmarshaling behavior.
+			keys[e.key] = e.val
+		}
+	case jsonKindNull:
+		// json.Unmarshal leaves the destination map nil for a JSON null,
+		// which then reads as an object with no keys.
+	default:
+		// Reproduce json.Unmarshal's type error for non-object values by
+		// running it on the raw value. This is reached at most once per
+		// decode, so it cannot re-introduce quadratic scanning.
+		var m map[string]json.RawMessage
+		err := json.Unmarshal(jsonRawSpan(data, v), &m)
+		if err == nil {
+			// Unreachable: every non-object, non-null kind fails above.
+			err = errors.New("value is not a JSON object")
+		}
 		return nil, fmt.Errorf("PlutusData JSON must be an object: %w", err)
 	}
+
 	// Reject objects with multiple discriminator keys (e.g. both "int" and "bytes").
 	var found []string
 	for _, dk := range discriminatorKeys {
@@ -333,7 +572,7 @@ func unmarshalPlutusDataJSONStateCounted(
 	switch {
 	case hasKey(keys, "int"):
 		var n *big.Int
-		if err := json.Unmarshal(keys["int"], &n); err != nil {
+		if err := json.Unmarshal(jsonRawSpan(data, keys["int"]), &n); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal Integer value: %w", err)
 		}
 		if n == nil {
@@ -342,7 +581,7 @@ func unmarshalPlutusDataJSONStateCounted(
 		return &Integer{Inner: n}, nil
 	case hasKey(keys, "bytes"):
 		var s string
-		if err := json.Unmarshal(keys["bytes"], &s); err != nil {
+		if err := json.Unmarshal(jsonRawSpan(data, keys["bytes"]), &s); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal ByteString value: %w", err)
 		}
 		decoded, err := hex.DecodeString(s)
@@ -351,38 +590,38 @@ func unmarshalPlutusDataJSONStateCounted(
 		}
 		return &ByteString{Inner: decoded}, nil
 	case hasKey(keys, "list"):
-		itemsRaw := keys["list"]
-		if string(itemsRaw) == "null" {
+		itemsVal := keys["list"]
+		if itemsVal.kind == jsonKindNull {
 			return nil, errors.New("null \"list\" value in List JSON")
 		}
-		items, err := decodePlutusDataJSONArray(itemsRaw, st, "List item")
+		items, err := decodePlutusDataJSONArray(data, itemsVal, st, "List item")
 		if err != nil {
 			return nil, fmt.Errorf("failed to unmarshal List value: %w", err)
 		}
 		return &List{Items: items}, nil
 	case hasKey(keys, "map"):
-		pairsRaw := keys["map"]
-		if string(pairsRaw) == "null" {
+		pairsVal := keys["map"]
+		if pairsVal.kind == jsonKindNull {
 			return nil, errors.New("null \"map\" value in Map JSON")
 		}
-		pairs, err := decodePlutusDataJSONMap(pairsRaw, st)
+		pairs, err := decodePlutusDataJSONMap(data, pairsVal, st)
 		if err != nil {
 			return nil, fmt.Errorf("failed to unmarshal Map value: %w", err)
 		}
 		return &Map{Pairs: pairs}, nil
 	case hasKey(keys, "constructor"):
 		var tag uint
-		if err := json.Unmarshal(keys["constructor"], &tag); err != nil {
+		if err := json.Unmarshal(jsonRawSpan(data, keys["constructor"]), &tag); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal Constr constructor tag: %w", err)
 		}
-		fieldsRaw, ok := keys["fields"]
+		fieldsVal, ok := keys["fields"]
 		if !ok {
 			return nil, errors.New("missing \"fields\" key in Constr JSON")
 		}
-		if string(fieldsRaw) == "null" {
+		if fieldsVal.kind == jsonKindNull {
 			return nil, errors.New("null \"fields\" value in Constr JSON")
 		}
-		fields, err := decodePlutusDataJSONArray(fieldsRaw, st, "Constr field")
+		fields, err := decodePlutusDataJSONArray(data, fieldsVal, st, "Constr field")
 		if err != nil {
 			return nil, fmt.Errorf("failed to unmarshal Constr fields: %w", err)
 		}
@@ -393,160 +632,106 @@ func unmarshalPlutusDataJSONStateCounted(
 }
 
 func decodePlutusDataJSONArray(
-	data json.RawMessage,
+	data []byte,
+	v jsonValue,
 	st *jsonDecodeState,
 	itemLabel string,
 ) ([]PlutusData, error) {
-	dec := json.NewDecoder(bytes.NewReader(data))
-	if err := readJSONArrayStart(dec); err != nil {
-		return nil, err
+	if v.kind != jsonKindArray {
+		return nil, errors.New("value must be an array")
 	}
 
-	items := make([]PlutusData, 0)
-	for i := 0; dec.More(); i++ {
+	items := make([]PlutusData, 0, len(v.items))
+	for i, item := range v.items {
 		if err := st.enterNode(); err != nil {
 			return nil, err
 		}
-		var item json.RawMessage
-		if err := dec.Decode(&item); err != nil {
-			return nil, fmt.Errorf("failed to decode %s %d: %w", itemLabel, i, err)
-		}
-		pd, err := unmarshalPlutusDataJSONStateCounted(item, st, true)
+		pd, err := decodePlutusDataJSONValue(data, item, st, true)
 		if err != nil {
 			return nil, fmt.Errorf("failed to unmarshal %s %d: %w", itemLabel, i, err)
 		}
 		items = append(items, pd)
 	}
-
-	if err := readJSONArrayEnd(dec); err != nil {
-		return nil, err
-	}
 	return items, nil
 }
 
 func decodePlutusDataJSONMap(
-	data json.RawMessage,
+	data []byte,
+	v jsonValue,
 	st *jsonDecodeState,
 ) ([][2]PlutusData, error) {
-	dec := json.NewDecoder(bytes.NewReader(data))
-	if err := readJSONArrayStart(dec); err != nil {
-		return nil, err
+	if v.kind != jsonKindArray {
+		return nil, errors.New("value must be an array")
 	}
 
-	pairs := make([][2]PlutusData, 0)
-	for i := 0; dec.More(); i++ {
-		pair, err := decodePlutusDataJSONMapPair(dec, st, i)
+	pairs := make([][2]PlutusData, 0, len(v.items))
+	for i, pairVal := range v.items {
+		pair, err := decodePlutusDataJSONMapPair(data, pairVal, st, i)
 		if err != nil {
 			return nil, err
 		}
 		pairs = append(pairs, pair)
 	}
-
-	if err := readJSONArrayEnd(dec); err != nil {
-		return nil, err
-	}
 	return pairs, nil
 }
 
 func decodePlutusDataJSONMapPair(
-	dec *json.Decoder,
+	data []byte,
+	v jsonValue,
 	st *jsonDecodeState,
 	index int,
 ) ([2]PlutusData, error) {
 	var pair [2]PlutusData
-	tok, err := dec.Token()
-	if err != nil {
-		return pair, fmt.Errorf("failed to read Map pair %d: %w", index, err)
-	}
-	if delim, ok := tok.(json.Delim); !ok || delim != '{' {
+	if v.kind != jsonKindObject {
 		return pair, fmt.Errorf("Map pair %d must be an object", index)
 	}
 
-	var kRaw, vRaw json.RawMessage
-	for dec.More() {
-		keyTok, err := dec.Token()
-		if err != nil {
-			return pair, fmt.Errorf("failed to read Map pair %d key: %w", index, err)
-		}
-		key, ok := keyTok.(string)
-		if !ok {
-			return pair, fmt.Errorf("Map pair %d key must be a string", index)
-		}
-		switch key {
+	var kVal, vVal jsonValue
+	var kSeen, vSeen bool
+	for _, e := range v.entries {
+		switch e.key {
 		case "k":
+			// Each occurrence counts as a node, and the last one wins,
+			// mirroring the previous streaming decoder.
 			if err := st.enterNode(); err != nil {
 				return pair, err
 			}
-			if err := dec.Decode(&kRaw); err != nil {
-				return pair, fmt.Errorf("failed to decode Map key %d: %w", index, err)
-			}
+			kVal, kSeen = e.val, true
 		case "v":
 			if err := st.enterNode(); err != nil {
 				return pair, err
 			}
-			if err := dec.Decode(&vRaw); err != nil {
-				return pair, fmt.Errorf("failed to decode Map value %d: %w", index, err)
-			}
+			vVal, vSeen = e.val, true
 		default:
-			return pair, fmt.Errorf("unexpected Map pair %d field %q", index, key)
+			return pair, fmt.Errorf("unexpected Map pair %d field %q", index, e.key)
 		}
 	}
-
-	tok, err = dec.Token()
-	if err != nil {
-		return pair, fmt.Errorf("failed to close Map pair %d: %w", index, err)
-	}
-	if delim, ok := tok.(json.Delim); !ok || delim != '}' {
-		return pair, fmt.Errorf("Map pair %d must end with an object delimiter", index)
-	}
-	if kRaw == nil {
+	if !kSeen {
 		return pair, fmt.Errorf("missing \"k\" key in Map pair %d", index)
 	}
-	if vRaw == nil {
+	if !vSeen {
 		return pair, fmt.Errorf("missing \"v\" key in Map pair %d", index)
 	}
 
-	k, err := unmarshalPlutusDataJSONStateCounted(kRaw, st, true)
+	k, err := decodePlutusDataJSONValue(data, kVal, st, true)
 	if err != nil {
 		return pair, fmt.Errorf("failed to unmarshal Map key %d: %w", index, err)
 	}
-	v, err := unmarshalPlutusDataJSONStateCounted(vRaw, st, true)
+	val, err := decodePlutusDataJSONValue(data, vVal, st, true)
 	if err != nil {
 		return pair, fmt.Errorf("failed to unmarshal Map value %d: %w", index, err)
 	}
 	pair[0] = k
-	pair[1] = v
+	pair[1] = val
 	return pair, nil
 }
 
-func readJSONArrayStart(dec *json.Decoder) error {
-	tok, err := dec.Token()
-	if err != nil {
-		return err
-	}
-	if delim, ok := tok.(json.Delim); !ok || delim != '[' {
-		return errors.New("value must be an array")
-	}
-	return nil
-}
-
-func readJSONArrayEnd(dec *json.Decoder) error {
-	tok, err := dec.Token()
-	if err != nil {
-		return err
-	}
-	if delim, ok := tok.(json.Delim); !ok || delim != ']' {
-		return errors.New("array value has invalid terminator")
-	}
-	return nil
-}
-
-func hasKey(m map[string]json.RawMessage, key string) bool {
+func hasKey(m map[string]jsonValue, key string) bool {
 	_, ok := m[key]
 	return ok
 }
 
-func keysOf(m map[string]json.RawMessage) []string {
+func keysOf(m map[string]jsonValue) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)

--- a/data/json_bench_test.go
+++ b/data/json_bench_test.go
@@ -1,0 +1,63 @@
+package data
+
+import (
+	"strings"
+	"testing"
+)
+
+// deepNestedJSONWithSiblings builds a document of `depth` nested Lists where
+// every level also carries a sizable ByteString sibling. A decoder that
+// re-parses the remaining subtree at each nesting level does
+// O(depth * size) work on this shape.
+func deepNestedJSONWithSiblings(depth, siblingHexLen int) string {
+	sibling := `{"bytes":"` + strings.Repeat("ab", siblingHexLen/2) + `"}`
+	var sb strings.Builder
+	for i := 0; i < depth; i++ {
+		sb.WriteString(`{"list":[`)
+		sb.WriteString(sibling)
+		sb.WriteString(`,`)
+	}
+	sb.WriteString(`{"int":0}`)
+	for i := 0; i < depth; i++ {
+		sb.WriteString(`]}`)
+	}
+	return sb.String()
+}
+
+// wideFlatJSON builds a single List with many small Integer items.
+func wideFlatJSON(items int) string {
+	var sb strings.Builder
+	sb.WriteString(`{"list":[`)
+	for i := 0; i < items; i++ {
+		if i > 0 {
+			sb.WriteByte(',')
+		}
+		sb.WriteString(`{"int":1}`)
+	}
+	sb.WriteString(`]}`)
+	return sb.String()
+}
+
+func BenchmarkDecodeJSONDeepNested(b *testing.B) {
+	input := []byte(deepNestedJSONWithSiblings(240, 4096))
+	b.SetBytes(int64(len(input)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := DecodeJSON(input); err != nil {
+			b.Fatalf("DecodeJSON error: %v", err)
+		}
+	}
+}
+
+func BenchmarkDecodeJSONWideFlat(b *testing.B) {
+	input := []byte(wideFlatJSON(10_000))
+	b.SetBytes(int64(len(input)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := DecodeJSON(input); err != nil {
+			b.Fatalf("DecodeJSON error: %v", err)
+		}
+	}
+}

--- a/data/json_parity_test.go
+++ b/data/json_parity_test.go
@@ -1,0 +1,456 @@
+package data
+
+import (
+	"math/big"
+	"strings"
+	"testing"
+)
+
+// These tests characterize the exact observable behavior of the PlutusData
+// JSON decoder so the decoding implementation can be changed without
+// changing semantics. They intentionally pin corner cases such as duplicate
+// keys, ignored unknown keys, exact error messages, and limit boundaries.
+
+func bigFromString(t *testing.T, s string) *big.Int {
+	t.Helper()
+	n, ok := new(big.Int).SetString(s, 10)
+	if !ok {
+		t.Fatalf("invalid big.Int literal %q", s)
+	}
+	return n
+}
+
+func TestDecodeJSONParityAccepted(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+		want PlutusData
+	}{
+		{
+			name: "duplicate int key keeps last occurrence",
+			json: `{"int":1,"int":2}`,
+			want: NewInteger(big.NewInt(2)),
+		},
+		{
+			name: "duplicate list key keeps last occurrence",
+			json: `{"list":[{"int":1}],"list":[{"int":2}]}`,
+			want: NewList(NewInteger(big.NewInt(2))),
+		},
+		{
+			name: "duplicate list key ignores invalid first occurrence",
+			json: `{"list":[{"bogus":1}],"list":[{"int":2}]}`,
+			want: NewList(NewInteger(big.NewInt(2))),
+		},
+		{
+			name: "duplicate bytes key keeps last occurrence",
+			json: `{"bytes":"ff","bytes":"abcd"}`,
+			want: NewByteString([]byte{0xab, 0xcd}),
+		},
+		{
+			name: "duplicate constructor key keeps last occurrence",
+			json: `{"constructor":1,"constructor":2,"fields":[]}`,
+			want: NewConstr(2),
+		},
+		{
+			name: "duplicate fields key keeps last occurrence",
+			json: `{"constructor":0,"fields":[{"int":1}],"fields":[{"int":2}]}`,
+			want: NewConstr(0, NewInteger(big.NewInt(2))),
+		},
+		{
+			name: "unknown sibling key is ignored",
+			json: `{"int":1,"extra":"x"}`,
+			want: NewInteger(big.NewInt(1)),
+		},
+		{
+			name: "unknown sibling key with nested junk is ignored",
+			json: `{"int":1,"extra":{"deep":[1,2,{"a":null},true]}}`,
+			want: NewInteger(big.NewInt(1)),
+		},
+		{
+			name: "unknown sibling key on constr is ignored",
+			json: `{"constructor":0,"fields":[],"junk":3}`,
+			want: NewConstr(0),
+		},
+		{
+			name: "fields without constructor is ignored when int present",
+			json: `{"int":7,"fields":[{"bogus":true}]}`,
+			want: NewInteger(big.NewInt(7)),
+		},
+		{
+			name: "null bytes value decodes to empty bytestring",
+			json: `{"bytes":null}`,
+			want: NewByteString(nil),
+		},
+		{
+			name: "null constructor tag decodes as zero",
+			json: `{"constructor":null,"fields":[]}`,
+			want: NewConstr(0),
+		},
+		{
+			name: "uppercase hex accepted",
+			json: `{"bytes":"AbCd"}`,
+			want: NewByteString([]byte{0xab, 0xcd}),
+		},
+		{
+			name: "escaped hex string accepted",
+			json: `{"bytes":"ab"}`,
+			want: NewByteString([]byte{0xab}),
+		},
+		{
+			name: "escaped discriminator key recognized",
+			json: `{"int":42}`,
+			want: NewInteger(big.NewInt(42)),
+		},
+		{
+			name: "big integer fidelity positive",
+			json: `{"int":123456789012345678901234567890}`,
+			want: NewInteger(bigFromString(t, "123456789012345678901234567890")),
+		},
+		{
+			name: "big integer fidelity negative",
+			json: `{"int":-987654321098765432109876543210}`,
+			want: NewInteger(bigFromString(t, "-987654321098765432109876543210")),
+		},
+		{
+			name: "surrounding whitespace tolerated",
+			json: "  \n\t{ \"int\" : 42 }\r\n ",
+			want: NewInteger(big.NewInt(42)),
+		},
+		{
+			name: "map pair duplicate k keeps last occurrence",
+			json: `{"map":[{"k":{"int":1},"k":{"int":2},"v":{"int":3}}]}`,
+			want: NewMap([][2]PlutusData{
+				{NewInteger(big.NewInt(2)), NewInteger(big.NewInt(3))},
+			}),
+		},
+		{
+			name: "map pair duplicate k ignores invalid first occurrence",
+			json: `{"map":[{"k":{"bogus":1},"k":{"int":2},"v":{"int":3}}]}`,
+			want: NewMap([][2]PlutusData{
+				{NewInteger(big.NewInt(2)), NewInteger(big.NewInt(3))},
+			}),
+		},
+		{
+			name: "map pair duplicate k after v keeps last occurrence",
+			json: `{"map":[{"k":{"int":1},"v":{"int":2},"k":{"int":9}}]}`,
+			want: NewMap([][2]PlutusData{
+				{NewInteger(big.NewInt(9)), NewInteger(big.NewInt(2))},
+			}),
+		},
+		{
+			name: "map pair v before k accepted",
+			json: `{"map":[{"v":{"int":2},"k":{"int":1}}]}`,
+			want: NewMap([][2]PlutusData{
+				{NewInteger(big.NewInt(1)), NewInteger(big.NewInt(2))},
+			}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := DecodeJSON([]byte(tt.json))
+			if err != nil {
+				t.Fatalf("DecodeJSON(%s) error: %v", tt.json, err)
+			}
+			if !tt.want.Equal(got) {
+				t.Errorf("DecodeJSON(%s):\n  got:  %v\n  want: %v", tt.json, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDecodeJSONParityErrorMessages(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+		want string
+	}{
+		{
+			name: "top-level number",
+			json: `42`,
+			want: `PlutusData JSON must be an object: json: cannot unmarshal number into Go value of type map[string]json.RawMessage`,
+		},
+		{
+			name: "top-level string",
+			json: `"x"`,
+			want: `PlutusData JSON must be an object: json: cannot unmarshal string into Go value of type map[string]json.RawMessage`,
+		},
+		{
+			name: "top-level array",
+			json: `[1]`,
+			want: `PlutusData JSON must be an object: json: cannot unmarshal array into Go value of type map[string]json.RawMessage`,
+		},
+		{
+			name: "top-level bool",
+			json: `true`,
+			want: `PlutusData JSON must be an object: json: cannot unmarshal bool into Go value of type map[string]json.RawMessage`,
+		},
+		{
+			name: "top-level null",
+			json: `null`,
+			want: `unrecognized PlutusData JSON keys: []`,
+		},
+		{
+			name: "empty input",
+			json: ``,
+			want: `PlutusData JSON must be an object: unexpected end of JSON input`,
+		},
+		{
+			name: "truncated object",
+			json: `{"int":`,
+			want: `PlutusData JSON must be an object: unexpected end of JSON input`,
+		},
+		{
+			name: "truncated after value",
+			json: `{"int":1,`,
+			want: `PlutusData JSON must be an object: unexpected end of JSON input`,
+		},
+		{
+			name: "trailing garbage",
+			json: `{"int":1}x`,
+			want: `PlutusData JSON must be an object: invalid character 'x' after top-level value`,
+		},
+		{
+			name: "trailing second document",
+			json: `{"int":1}{"int":2}`,
+			want: `PlutusData JSON must be an object: invalid character '{' after top-level value`,
+		},
+		{
+			name: "unknown key listed",
+			json: `{"unknown":1}`,
+			want: `unrecognized PlutusData JSON keys: [unknown]`,
+		},
+		{
+			name: "unknown keys sorted",
+			json: `{"b":1,"a":2}`,
+			want: `unrecognized PlutusData JSON keys: [a b]`,
+		},
+		{
+			name: "fields without constructor",
+			json: `{"fields":[]}`,
+			want: `unrecognized PlutusData JSON keys: [fields]`,
+		},
+		{
+			name: "ambiguous int and bytes",
+			json: `{"int":1,"bytes":"ab"}`,
+			want: `ambiguous PlutusData JSON: multiple discriminator keys [int bytes]`,
+		},
+		{
+			name: "ambiguity beats invalid scalar values",
+			json: `{"int":"garbage","bytes":"zz"}`,
+			want: `ambiguous PlutusData JSON: multiple discriminator keys [int bytes]`,
+		},
+		{
+			name: "ambiguity beats invalid list content",
+			json: `{"list":[{"bogus":1}],"int":1}`,
+			want: `ambiguous PlutusData JSON: multiple discriminator keys [int list]`,
+		},
+		{
+			name: "ambiguous constructor and int",
+			json: `{"constructor":0,"fields":[],"int":1}`,
+			want: `ambiguous PlutusData JSON: multiple discriminator keys [int constructor]`,
+		},
+		{
+			name: "list value not an array",
+			json: `{"list":42}`,
+			want: `failed to unmarshal List value: value must be an array`,
+		},
+		{
+			name: "list value is an object",
+			json: `{"list":{"a":1}}`,
+			want: `failed to unmarshal List value: value must be an array`,
+		},
+		{
+			name: "map value not an array",
+			json: `{"map":"x"}`,
+			want: `failed to unmarshal Map value: value must be an array`,
+		},
+		{
+			name: "fields value not an array",
+			json: `{"constructor":0,"fields":42}`,
+			want: `failed to unmarshal Constr fields: value must be an array`,
+		},
+		{
+			name: "invalid list item wrapped with index",
+			json: `{"list":[{"int":1},{"bad":1}]}`,
+			want: `failed to unmarshal List value: failed to unmarshal List item 1: unrecognized PlutusData JSON keys: [bad]`,
+		},
+		{
+			name: "invalid constr field wrapped with index",
+			json: `{"constructor":0,"fields":[{"bad":1}]}`,
+			want: `failed to unmarshal Constr fields: failed to unmarshal Constr field 0: unrecognized PlutusData JSON keys: [bad]`,
+		},
+		{
+			name: "invalid map key wrapped",
+			json: `{"map":[{"k":{"bad":1},"v":{"int":1}}]}`,
+			want: `failed to unmarshal Map value: failed to unmarshal Map key 0: unrecognized PlutusData JSON keys: [bad]`,
+		},
+		{
+			name: "invalid map value wrapped",
+			json: `{"map":[{"k":{"int":1},"v":{"bad":1}}]}`,
+			want: `failed to unmarshal Map value: failed to unmarshal Map value 0: unrecognized PlutusData JSON keys: [bad]`,
+		},
+		{
+			name: "map key error reported before map value error",
+			json: `{"map":[{"v":{"bad":1},"k":{"bad2":1}}]}`,
+			want: `failed to unmarshal Map value: failed to unmarshal Map key 0: unrecognized PlutusData JSON keys: [bad2]`,
+		},
+		{
+			name: "map pair not an object",
+			json: `{"map":[42]}`,
+			want: `failed to unmarshal Map value: Map pair 0 must be an object`,
+		},
+		{
+			name: "map pair null",
+			json: `{"map":[null]}`,
+			want: `failed to unmarshal Map value: Map pair 0 must be an object`,
+		},
+		{
+			name: "map pair unknown field",
+			json: `{"map":[{"k":{"int":1},"v":{"int":2},"x":3}]}`,
+			want: `failed to unmarshal Map value: unexpected Map pair 0 field "x"`,
+		},
+		{
+			name: "map pair missing k",
+			json: `{"map":[{"v":{"int":1}}]}`,
+			want: `failed to unmarshal Map value: missing "k" key in Map pair 0`,
+		},
+		{
+			name: "map pair missing v",
+			json: `{"map":[{"k":{"int":1}}]}`,
+			want: `failed to unmarshal Map value: missing "v" key in Map pair 0`,
+		},
+		{
+			name: "constr tag error beats fields content error",
+			json: `{"constructor":"x","fields":[{"bad":1}]}`,
+			want: `failed to unmarshal Constr constructor tag: json: cannot unmarshal string into Go value of type uint`,
+		},
+		{
+			name: "constr tag error when fields come first",
+			json: `{"fields":[{"bad":1}],"constructor":"x"}`,
+			want: `failed to unmarshal Constr constructor tag: json: cannot unmarshal string into Go value of type uint`,
+		},
+		{
+			name: "negative constructor tag",
+			json: `{"constructor":-1,"fields":[]}`,
+			want: `failed to unmarshal Constr constructor tag: json: cannot unmarshal number -1 into Go value of type uint`,
+		},
+		{
+			name: "fractional constructor tag",
+			json: `{"constructor":1.5,"fields":[]}`,
+			want: `failed to unmarshal Constr constructor tag: json: cannot unmarshal number 1.5 into Go value of type uint`,
+		},
+		{
+			name: "overflowing constructor tag",
+			json: `{"constructor":18446744073709551616,"fields":[]}`,
+			want: `failed to unmarshal Constr constructor tag: json: cannot unmarshal number 18446744073709551616 into Go value of type uint`,
+		},
+		{
+			name: "null int value",
+			json: `{"int":null}`,
+			want: `null "int" value in Integer JSON`,
+		},
+		{
+			name: "null list value",
+			json: `{"list":null}`,
+			want: `null "list" value in List JSON`,
+		},
+		{
+			name: "null map value",
+			json: `{"map":null}`,
+			want: `null "map" value in Map JSON`,
+		},
+		{
+			name: "null fields value",
+			json: `{"constructor":0,"fields":null}`,
+			want: `null "fields" value in Constr JSON`,
+		},
+		{
+			name: "missing fields key",
+			json: `{"constructor":0}`,
+			want: `missing "fields" key in Constr JSON`,
+		},
+		{
+			name: "bytes value not a string",
+			json: `{"bytes":5}`,
+			want: `failed to unmarshal ByteString value: json: cannot unmarshal number into Go value of type string`,
+		},
+		{
+			name: "odd-length hex",
+			json: `{"bytes":"abc"}`,
+			want: `invalid hex in ByteString JSON: encoding/hex: odd length hex string`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := DecodeJSON([]byte(tt.json))
+			if err == nil {
+				t.Fatalf("DecodeJSON(%s): expected error, got nil", tt.json)
+			}
+			if err.Error() != tt.want {
+				t.Errorf("DecodeJSON(%s):\n  got:  %s\n  want: %s", tt.json, err, tt.want)
+			}
+		})
+	}
+}
+
+// TestDecodeJSONParityErrorsRejected covers inputs whose error text comes
+// from the Go runtime in version-dependent form; only rejection is pinned.
+func TestDecodeJSONParityErrorsRejected(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+	}{
+		{"string int value", `{"int":"42"}`},
+		{"float int value", `{"int":1.5}`},
+		{"exponent int value", `{"int":1e3}`},
+		{"bool int value", `{"int":true}`},
+		{"object int value", `{"int":{"a":1}}`},
+		{"string constructor tag", `{"constructor":"0","fields":[]}`},
+		{"number with trailing junk", `{"int":12,}`},
+		{"unterminated string", `{"bytes":"ab`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := DecodeJSON([]byte(tt.json)); err == nil {
+				t.Errorf("DecodeJSON(%s): expected error, got nil", tt.json)
+			}
+		})
+	}
+}
+
+func TestDecodeJSONParityDepthBoundary(t *testing.T) {
+	// nestedListJSON(d) produces d nested Lists plus one Integer, so the
+	// deepest PlutusData node sits at depth d+1.
+	t.Run("exactly at limit decodes", func(t *testing.T) {
+		input := nestedListJSON(MaxDecodeNestingDepth - 1)
+		if _, err := DecodeJSON([]byte(input)); err != nil {
+			t.Fatalf("expected success at depth limit, got: %v", err)
+		}
+	})
+	t.Run("one past limit rejected", func(t *testing.T) {
+		input := nestedListJSON(MaxDecodeNestingDepth)
+		_, err := DecodeJSON([]byte(input))
+		if err == nil {
+			t.Fatal("expected depth error, got nil")
+		}
+		want := "PlutusData JSON nesting exceeds max depth 256"
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error containing %q, got: %v", want, err)
+		}
+	})
+}
+
+func TestDecodeJSONParityBigIntRoundTrip(t *testing.T) {
+	in := `{"int":123456789012345678901234567890}`
+	pd, err := DecodeJSON([]byte(in))
+	if err != nil {
+		t.Fatalf("DecodeJSON error: %v", err)
+	}
+	out, err := EncodeJSON(pd)
+	if err != nil {
+		t.Fatalf("EncodeJSON error: %v", err)
+	}
+	if string(out) != in {
+		t.Errorf("round-trip:\n  got:  %s\n  want: %s", out, in)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch PlutusData JSON decoding to a single-pass parser that builds a lightweight syntax tree and decodes from raw spans. This removes depth-proportional rescans, improves performance, and preserves existing semantics and error messages.

- **Refactors**
  - Added a single-pass `jsonValue` tree built with `encoding/json.Decoder`; scalars reuse raw spans to avoid re-parsing.
  - Kept `encoding/json` semantics: last-key-wins for duplicates, strict trailing-data checks, and normalized EOF errors.
  - Preserved Map pair behavior, including repeated "k"/"v" with last occurrence winning, and depth accounting via `enterNode`.
  - Replaced recursive re-unmarshal with span-based helpers (`decodePlutusDataJSONValue`, `decodePlutusDataJSONArray`, `decodePlutusDataJSONMap`) and interned common keys to cut allocations.
  - Added parity tests to lock exact behavior and error text, plus benchmarks for deep-nesting and wide lists.

<sup>Written for commit 846b204321923c931058fb93f7ba46c6c26604df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/plutigo/pull/329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

