### PR TITLE
perf(cek): shard locks for ed25519 verification cache

### DIFF
--- a/cek/bench_test.go
+++ b/cek/bench_test.go
@@ -1,8 +1,10 @@
 package cek
 
 import (
+	"crypto/ed25519"
 	"fmt"
 	"math/big"
+	"sync/atomic"
 	"testing"
 
 	"github.com/blinklabs-io/plutigo/builtin"
@@ -166,6 +168,42 @@ func BenchmarkBuiltinIntegerOps(b *testing.B) {
 	}
 }
 
+func BenchmarkEd25519VerifyCacheHitParallel(b *testing.B) {
+	keys := buildBenchmarkEd25519VerifyCacheKeys(b, 1024)
+
+	previousCache := ed25519VerifyCache
+	ed25519VerifyCache = newEd25519VerifyCacheStore()
+	b.Cleanup(func() {
+		ed25519VerifyCache = previousCache
+	})
+
+	for i := range keys {
+		ed25519VerifyCache.store(&keys[i], true)
+	}
+
+	var misses uint64
+	var nextWorker uint64
+	mask := len(keys) - 1
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		index := int(atomic.AddUint64(&nextWorker, 1)) * 17
+		for pb.Next() {
+			value, ok := ed25519VerifyCache.get(&keys[index&mask])
+			if !ok || !value {
+				atomic.AddUint64(&misses, 1)
+			}
+			index++
+		}
+	})
+
+	if misses := atomic.LoadUint64(&misses); misses != 0 {
+		b.Fatalf("ed25519VerifyCache misses = %d", misses)
+	}
+}
+
 func buildBenchmarkEnv(depth int) *Env[syn.DeBruijn] {
 	var env *Env[syn.DeBruijn]
 
@@ -179,6 +217,30 @@ func buildBenchmarkEnv(depth int) *Env[syn.DeBruijn] {
 	}
 
 	return env
+}
+
+func buildBenchmarkEd25519VerifyCacheKeys(
+	b *testing.B,
+	count int,
+) []ed25519VerifyCacheKey {
+	b.Helper()
+
+	var seed [ed25519.SeedSize]byte
+	for i := range seed {
+		seed[i] = byte(i + 1)
+	}
+
+	privateKey := ed25519.NewKeyFromSeed(seed[:])
+	publicKey := privateKey.Public().(ed25519.PublicKey)
+	keys := make([]ed25519VerifyCacheKey, count)
+
+	for i := range keys {
+		message := []byte(fmt.Sprintf("cache message %04d", i))
+		signature := ed25519.Sign(privateKey, message)
+		keys[i] = newEd25519VerifyCacheKey(publicKey, message, signature)
+	}
+
+	return keys
 }
 
 func benchmarkIntValue(v int64) *Constant {

--- a/cek/builtins.go
+++ b/cek/builtins.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/ed25519"
 	"crypto/sha3"
+	"encoding/binary"
 	"fmt"
 	"math"
 	"math/big"
@@ -36,6 +37,8 @@ var (
 const (
 	ed25519VerifyCacheLimit  = 4096
 	ed25519VerifyMaxCacheMsg = 64
+	ed25519VerifyCacheShards = 64
+	ed25519VerifyShardLimit  = ed25519VerifyCacheLimit / ed25519VerifyCacheShards
 )
 
 type ed25519VerifyCacheKey struct {
@@ -45,11 +48,73 @@ type ed25519VerifyCacheKey struct {
 	msgLen    uint8
 }
 
-var ed25519VerifyCache = struct {
-	sync.RWMutex
+type ed25519VerifyCacheShard struct {
+	sync.Mutex
 	values map[ed25519VerifyCacheKey]bool
-}{
-	values: make(map[ed25519VerifyCacheKey]bool),
+}
+
+type ed25519VerifyCacheStore struct {
+	shards [ed25519VerifyCacheShards]ed25519VerifyCacheShard
+}
+
+var ed25519VerifyCache = newEd25519VerifyCacheStore()
+
+func newEd25519VerifyCacheStore() *ed25519VerifyCacheStore {
+	cache := &ed25519VerifyCacheStore{}
+	for i := range cache.shards {
+		cache.shards[i].values = make(map[ed25519VerifyCacheKey]bool, ed25519VerifyShardLimit)
+	}
+	return cache
+}
+
+func newEd25519VerifyCacheKey(
+	publicKey []byte,
+	message []byte,
+	signature []byte,
+) ed25519VerifyCacheKey {
+	var key ed25519VerifyCacheKey
+	copy(key.publicKey[:], publicKey)
+	copy(key.signature[:], signature)
+	copy(key.message[:], message)
+	key.msgLen = uint8(len(message))
+	return key
+}
+
+func (c *ed25519VerifyCacheStore) get(key *ed25519VerifyCacheKey) (bool, bool) {
+	shard := c.shard(key)
+	shard.Lock()
+	value, ok := shard.values[*key]
+	shard.Unlock()
+	return value, ok
+}
+
+func (c *ed25519VerifyCacheStore) store(key *ed25519VerifyCacheKey, value bool) {
+	shard := c.shard(key)
+	shard.Lock()
+	if _, ok := shard.values[*key]; !ok && len(shard.values) >= ed25519VerifyShardLimit {
+		// Reset-on-full: clear the shard rather than permanently refusing new
+		// admissions once it reaches capacity. This mirrors the cache-wide
+		// reset-on-full behavior introduced in #327, applied per shard.
+		shard.values = make(map[ed25519VerifyCacheKey]bool, ed25519VerifyShardLimit)
+	}
+	shard.values[*key] = value
+	shard.Unlock()
+}
+
+func (c *ed25519VerifyCacheStore) shard(key *ed25519VerifyCacheKey) *ed25519VerifyCacheShard {
+	hash := binary.LittleEndian.Uint64(key.publicKey[:8])
+	hash ^= bits.RotateLeft64(binary.LittleEndian.Uint64(key.signature[:8]), 21)
+	hash ^= bits.RotateLeft64(
+		binary.LittleEndian.Uint64(key.signature[ed25519.SignatureSize-8:]),
+		42,
+	)
+	if key.msgLen > 0 {
+		lastMsgByte := key.message[int(key.msgLen)-1]
+		hash ^= uint64(key.message[0]) << 8
+		hash ^= uint64(lastMsgByte) << 16
+	}
+	hash ^= uint64(key.msgLen) * 0x9e3779b97f4a7c15
+	return &c.shards[hash&(ed25519VerifyCacheShards-1)]
 }
 
 func absUint64(v int64) uint64 {
@@ -1247,25 +1312,13 @@ func verifyEd25519Signature[T syn.Eval](
 
 	var res bool
 	if len(message) <= ed25519VerifyMaxCacheMsg {
-		var key ed25519VerifyCacheKey
-		copy(key.publicKey[:], publicKey)
-		copy(key.signature[:], signature)
-		copy(key.message[:], message)
-		key.msgLen = uint8(len(message))
-
-		ed25519VerifyCache.RLock()
-		cached, ok := ed25519VerifyCache.values[key]
-		ed25519VerifyCache.RUnlock()
+		key := newEd25519VerifyCacheKey(publicKey, message, signature)
+		cached, ok := ed25519VerifyCache.get(&key)
 		if ok {
 			res = cached
 		} else {
 			res = ed25519.Verify(publicKey, message, signature)
-			ed25519VerifyCache.Lock()
-			if len(ed25519VerifyCache.values) >= ed25519VerifyCacheLimit {
-				ed25519VerifyCache.values = make(map[ed25519VerifyCacheKey]bool)
-			}
-			ed25519VerifyCache.values[key] = res
-			ed25519VerifyCache.Unlock()
+			ed25519VerifyCache.store(&key, res)
 		}
 	} else {
 		res = ed25519.Verify(publicKey, message, signature)

--- a/cek/cache_eviction_test.go
+++ b/cek/cache_eviction_test.go
@@ -11,102 +11,60 @@ import (
 	"github.com/blinklabs-io/plutigo/syn"
 )
 
-// TestEd25519VerifyCacheResetOnFull fills the ed25519 verify cache to its
-// limit, then verifies that one additional unique entry is still admitted
-// (i.e., the cache resets rather than stopping admissions permanently).
+// resetEd25519VerifyCache clears every shard of the ed25519 verify cache,
+// returning it to a known empty state for deterministic tests.
+func resetEd25519VerifyCache() {
+	for i := range ed25519VerifyCache.shards {
+		s := &ed25519VerifyCache.shards[i]
+		s.Lock()
+		s.values = make(map[ed25519VerifyCacheKey]bool, ed25519VerifyShardLimit)
+		s.Unlock()
+	}
+}
+
+// TestEd25519VerifyCacheResetOnFull drives a single cache shard to its limit,
+// then verifies that one additional unique entry mapping to that same shard is
+// still admitted (i.e., a full shard resets rather than refusing admissions
+// permanently). With sharded storage the new entry must be steered to a shard
+// known to be full, otherwise admission would prove nothing about reset-on-full.
 func TestEd25519VerifyCacheResetOnFull(t *testing.T) {
 	// Reset the cache to a known empty state before the test.
-	ed25519VerifyCache.Lock()
-	ed25519VerifyCache.values = make(map[ed25519VerifyCacheKey]bool)
-	ed25519VerifyCache.Unlock()
+	resetEd25519VerifyCache()
 
-	// Generate a fixed key pair for all synthetic entries.
-	pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
-	if err != nil {
-		t.Fatalf("failed to generate ed25519 key: %v", err)
-	}
-
-	// Fill the cache to exactly the limit using distinct messages.
-	// We bypass the builtin machinery and insert directly so the test is fast
-	// and deterministic.
-	for i := 0; i < ed25519VerifyCacheLimit; i++ {
+	// Pick a target shard and synthesize distinct keys that all hash to it, so
+	// we can fill exactly that shard and observe reset-on-full deterministically.
+	target := &ed25519VerifyCache.shards[0]
+	keys := make([]ed25519VerifyCacheKey, 0, ed25519VerifyShardLimit+1)
+	for i := 0; len(keys) < ed25519VerifyShardLimit+1; i++ {
 		var key ed25519VerifyCacheKey
-		copy(key.publicKey[:], pubKey)
-		// Construct a unique message for each entry.
-		msg := [ed25519VerifyMaxCacheMsg]byte{}
-		// Encode i as 4 bytes so all 4096 entries are unique.
-		msg[0] = byte(i >> 24)
-		msg[1] = byte(i >> 16)
-		msg[2] = byte(i >> 8)
-		msg[3] = byte(i)
-		key.message = msg
-		key.msgLen = 4
-		sig := ed25519.Sign(privKey, msg[:4])
-		copy(key.signature[:], sig)
-		ed25519VerifyCache.Lock()
-		if len(ed25519VerifyCache.values) < ed25519VerifyCacheLimit {
-			ed25519VerifyCache.values[key] = true
+		// Vary the bytes the shard hash consumes so keys spread across shards.
+		key.publicKey[0] = byte(i)
+		key.publicKey[1] = byte(i >> 8)
+		key.signature[0] = byte(i >> 16)
+		key.signature[1] = byte(i >> 24)
+		if ed25519VerifyCache.shard(&key) == target {
+			keys = append(keys, key)
 		}
-		ed25519VerifyCache.Unlock()
 	}
 
-	// Verify the cache is now at capacity.
-	ed25519VerifyCache.RLock()
-	cacheSize := len(ed25519VerifyCache.values)
-	ed25519VerifyCache.RUnlock()
-	if cacheSize != ed25519VerifyCacheLimit {
-		t.Fatalf("expected cache size %d, got %d", ed25519VerifyCacheLimit, cacheSize)
+	// Fill the target shard exactly to its limit.
+	for i := 0; i < ed25519VerifyShardLimit; i++ {
+		ed25519VerifyCache.store(&keys[i], true)
 	}
 
-	// Now call verifyEd25519Signature via the builtin with a brand-new key/message.
-	// After the fix, this new entry should be cached (the cache resets on full).
-	newPubKey, newPrivKey, err := ed25519.GenerateKey(rand.Reader)
-	if err != nil {
-		t.Fatalf("failed to generate new ed25519 key: %v", err)
-	}
-	newMsg := []byte("post-full message")
-	newSig := ed25519.Sign(newPrivKey, newMsg)
-
-	m := NewMachine[syn.DeBruijn](lang.LanguageVersionV3, 0, nil)
-	b := &Builtin[syn.DeBruijn]{
-		Func:     builtin.VerifyEd25519Signature,
-		ArgCount: 0,
-		Forces:   0,
-	}
-	b = b.ApplyArg(&Constant{&syn.ByteString{Inner: newPubKey}})
-	b = b.ApplyArg(&Constant{&syn.ByteString{Inner: newMsg}})
-	b = b.ApplyArg(&Constant{&syn.ByteString{Inner: newSig}})
-
-	val, err := m.evalBuiltinApp(b)
-	if err != nil {
-		t.Fatalf("evalBuiltinApp returned error: %v", err)
-	}
-	constVal, ok := val.(*Constant)
-	if !ok {
-		t.Fatalf("expected *Constant, got %T", val)
-	}
-	boolVal, ok := constVal.Constant.(*syn.Bool)
-	if !ok {
-		t.Fatalf("expected *syn.Bool, got %T", constVal.Constant)
-	}
-	if !boolVal.Inner {
-		t.Fatal("expected valid signature to return true")
+	target.Lock()
+	full := len(target.values)
+	target.Unlock()
+	if full != ed25519VerifyShardLimit {
+		t.Fatalf("expected shard at capacity %d, got %d", ed25519VerifyShardLimit, full)
 	}
 
-	// After the fix the new entry must appear in the cache.
-	// Build the key that would have been inserted.
-	var lookupKey ed25519VerifyCacheKey
-	copy(lookupKey.publicKey[:], newPubKey)
-	copy(lookupKey.signature[:], newSig)
-	copy(lookupKey.message[:], newMsg)
-	lookupKey.msgLen = uint8(len(newMsg))
-
-	ed25519VerifyCache.RLock()
-	_, cached := ed25519VerifyCache.values[lookupKey]
-	ed25519VerifyCache.RUnlock()
-
-	if !cached {
-		t.Fatal("new entry was not admitted to cache after cache was full — reset-on-full fix is missing")
+	// Storing a brand-new key for the now-full shard must still be admitted:
+	// reset-on-full clears the shard rather than refusing entries forever.
+	newKey := keys[ed25519VerifyShardLimit]
+	ed25519VerifyCache.store(&newKey, true)
+	if _, cached := ed25519VerifyCache.get(&newKey); !cached {
+		t.Fatal("new entry was not admitted after shard was full — reset-on-full fix is missing")
 	}
 }
 
@@ -114,9 +72,7 @@ func TestEd25519VerifyCacheResetOnFull(t *testing.T) {
 // reads and writes to catch data races.
 func TestEd25519VerifyCacheConcurrentAccess(t *testing.T) {
 	// Reset the cache.
-	ed25519VerifyCache.Lock()
-	ed25519VerifyCache.values = make(map[ed25519VerifyCacheKey]bool)
-	ed25519VerifyCache.Unlock()
+	resetEd25519VerifyCache()
 
 	const goroutines = 16
 	var wg sync.WaitGroup


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Sharded the `ed25519` verification cache in `cek` to reduce lock contention and speed up parallel signature checks. Preserves reset-on-full behavior while capping memory per shard.

- **Refactors**
  - Replaced global cache (`map` + single lock) with a 64‑shard store; each shard has its own lock and a limit of 64 entries (`4096/64`).
  - Added `newEd25519VerifyCacheStore`, `newEd25519VerifyCacheKey`, and `get`/`store` APIs; shard selection uses a cheap hash over key fields.
  - Updated tests to target shard-level reset-on-full and added a parallel benchmark for cache-hit performance.

<sup>Written for commit 4b190d2edca081f50560f53db2b2c273ff39afb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/plutigo/pull/332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

