### PR TITLE
fix(syn): panic on unhandled term type

### DIFF
--- a/syn/builder.go
+++ b/syn/builder.go
@@ -50,9 +50,7 @@ func (b *termInterner) intern(currentTerm Term[Name]) {
 	case *Error:
 		// No names to intern
 	default:
-		// Debug: print the type
-		println("intern: unhandled type", fmt.Sprintf("%T", currentTerm))
-		return
+		panic(fmt.Sprintf("intern: unhandled type %T", currentTerm))
 	}
 }
 

--- a/syn/builder_test.go
+++ b/syn/builder_test.go
@@ -487,3 +487,19 @@ func TestIfThenElse(t *testing.T) {
 		t.Error("Expected IfThenElse builtin")
 	}
 }
+
+// unknownTestTerm implements Term[Name] but is not a variant the
+// interner knows about.
+type unknownTestTerm struct{}
+
+func (unknownTestTerm) isTerm() {}
+
+func TestInternPanicsOnUnknownTermType(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected Intern to panic on unknown term type")
+		}
+	}()
+
+	Intern(unknownTestTerm{})
+}

--- a/syn/doc.go
+++ b/syn/doc.go
@@ -33,7 +33,7 @@
 // # Basic Usage
 //
 //	// Parse UPLC text
-//	program, err := syn.Parse[syn.Name](input)
+//	program, err := syn.Parse(input)
 //	if err != nil {
 //	    // Handle parse error
 //	}

--- a/syn/pretty.go
+++ b/syn/pretty.go
@@ -36,6 +36,13 @@ func NewPrettyPrinter(indentSize int) *PrettyPrinter {
 	}
 }
 
+// Reset clears the accumulated output and indentation state so the
+// printer can be reused
+func (pp *PrettyPrinter) Reset() {
+	pp.builder.Reset()
+	pp.indent = 0
+}
+
 // write writes a string to the builder
 func (pp *PrettyPrinter) write(s string) {
 	pp.builder.WriteString(s)

--- a/syn/pretty_test.go
+++ b/syn/pretty_test.go
@@ -39,3 +39,19 @@ func TestPrettyTermComplex(t *testing.T) {
 		t.Errorf("PrettyTerm output does not contain 'lam': %s", result)
 	}
 }
+
+func TestPrettyPrinterReset(t *testing.T) {
+	pp := NewPrettyPrinter(2)
+	pp.write("hello")
+	pp.increaseIndent()
+
+	pp.Reset()
+
+	if got := pp.builder.String(); got != "" {
+		t.Errorf("expected empty builder after Reset, got %q", got)
+	}
+
+	if pp.indent != 0 {
+		t.Errorf("expected indent 0 after Reset, got %d", pp.indent)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fail fast on unknown `Term` types in the `syn` interner to avoid silent errors. Adds `PrettyPrinter.Reset()` for reuse and updates the Parse example.

- **Bug Fixes**
  - Interner now panics on unhandled term types instead of printing and returning; test ensures `Intern` panics on unknown `Term`.
  - Docs: example updated to use `syn.Parse(input)` to match the current API.

- **New Features**
  - Added `PrettyPrinter.Reset()` to clear the builder and reset indentation; test included.

<sup>Written for commit 3ea133b35bd96a0ef217df512efab9dc5e3b59a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/plutigo/pull/333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

