### PR TITLE
docs: correct Parse example generics and clarify V4 cost model status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ The CEK machine that executes UPLC programs.
 
 **Standard evaluation flow:**
 ```go
-program, _ := syn.Parse[syn.Name](input)
+program, _ := syn.Parse(input)
 dbProgram, _ := syn.NameToDeBruijn(program)
 machine := cek.NewMachine[syn.DeBruijn](dbProgram.Version, 0, nil)
 result, _ := machine.Run(dbProgram.Term)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -401,7 +401,7 @@ import (
 )
 
 // Parse UPLC text
-program, err := syn.Parse[syn.Name](uplcText)
+program, err := syn.Parse(uplcText)
 if err != nil {
     return err
 }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ for a full node. The other stuff like Typed Plutus Core and Plutus IR is for Pli
 
 - Complete Plutus Support: Implements Untyped Plutus Core (UPLC) evaluation
 - Multi-Version Support: Compatible with Plutus V1, V2, V3, and initial Plutus V4 support
-- Cost Model Integration: Automatic cost model selection based on Plutus version (Plutus V4 cost models are placeholders)
+- Cost Model Integration: Automatic cost model selection based on Plutus version (the Plutus V4 cost model is provisional; only `multiIndexArray` still uses a placeholder cost)
 - High Performance: Optimized CEK machine implementation in pure Go
 - Cryptographic Operations: Full BLS12-381 support using gnark-crypto
 - Comprehensive Testing: 49.9% test coverage with fuzz testing and property-based testing


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update docs to match the current API: examples now call `syn.Parse(input)` without generics, and the README clarifies the Plutus V4 cost model status. This removes confusion and reflects that the V4 model is provisional, with only `multiIndexArray` still using a placeholder cost.

<sup>Written for commit ea95c4082e2fd5ff797979d9863d5c8afa626808. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/plutigo/pull/334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code examples for syntax parsing in AGENTS and DEVELOPMENT guides
  * Clarified Plutus V4 cost model status and builtin cost specifications in README

<!-- end of auto-generated comment: release notes by coderabbit.ai -->