### PR TITLE
refactor(builtin): use untyped constants for builtin count

### DIFF
--- a/builtin/default_function.go
+++ b/builtin/default_function.go
@@ -673,14 +673,14 @@ func (f DefaultFunction) String() string {
 	return defaultFunctionToString[f]
 }
 
-// Smallest DefaultFunction
-const MinDefaultFunction byte = 0
+// MinDefaultFunction is the smallest DefaultFunction tag value
+const MinDefaultFunction = 0
 
-// Smallest DefaultFunction
-const MaxDefaultFunction byte = 103
+// MaxDefaultFunction is the largest DefaultFunction tag value
+const MaxDefaultFunction = 103
 
-// Total Builtin Count
-const TotalBuiltinCount byte = MaxDefaultFunction + 1
+// TotalBuiltinCount is the total number of builtin functions
+const TotalBuiltinCount = MaxDefaultFunction + 1
 
 func FromByte(tag byte) (DefaultFunction, error) {
 	// only need to check if greater than because


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched `MinDefaultFunction`, `MaxDefaultFunction`, and `TotalBuiltinCount` to untyped constants to remove `byte` narrowing and make constant arithmetic more flexible. No behavior changes.

- **Refactors**
  - Replaced `byte`-typed constants with untyped constants in `builtin/default_function.go`.
  - Clarified constant doc comments.

<sup>Written for commit 27afa65258fbcee0fe92515fad2869aa5f8a78f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/plutigo/pull/335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

