### PR TITLE
perf(syn): thread decode depth as a parameter to drop per-node defer

### DIFF
--- a/syn/flat_decode.go
+++ b/syn/flat_decode.go
@@ -137,7 +137,7 @@ func decodeDeBruijnProgram(
 		return nil, errors.New("version numbers too large")
 	}
 
-	terms, err := decodeTermDeBruijnWithArena(d, arena, consts)
+	terms, err := decodeTermDeBruijnWithArena(d, arena, consts, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -166,11 +166,15 @@ func decodeTermDeBruijnWithArena(
 	d *decoder,
 	arena *termArena[DeBruijn],
 	consts *constantArena,
+	depth int,
 ) (Term[DeBruijn], error) {
-	if err := d.enter(); err != nil {
-		return nil, err
+	// Depth is threaded as a parameter rather than tracked via
+	// d.enter()/defer d.leave(): a per-node defer in this hot recursive
+	// decoder is not open-coded and routes every return through the Go
+	// runtime's panic/defer machinery, which measured ~39% of decode time.
+	if depth >= maxFlatDecodeDepth {
+		return nil, errors.New("term nesting too deep")
 	}
-	defer d.leave()
 
 	tag, err := d.bits4()
 	if err != nil {
@@ -185,23 +189,23 @@ func decodeTermDeBruijnWithArena(
 		}
 		return arena.allocVar(name), nil
 	case DelayTag:
-		t, err := decodeTermDeBruijnWithArena(d, arena, consts)
+		t, err := decodeTermDeBruijnWithArena(d, arena, consts, depth+1)
 		if err != nil {
 			return nil, err
 		}
 		return arena.allocDelay(t), nil
 	case LambdaTag:
-		t, err := decodeTermDeBruijnWithArena(d, arena, consts)
+		t, err := decodeTermDeBruijnWithArena(d, arena, consts, depth+1)
 		if err != nil {
 			return nil, err
 		}
 		return arena.allocLambda(DeBruijn(0), t), nil
 	case ApplyTag:
-		function, err := decodeTermDeBruijnWithArena(d, arena, consts)
+		function, err := decodeTermDeBruijnWithArena(d, arena, consts, depth+1)
 		if err != nil {
 			return nil, err
 		}
-		argument, err := decodeTermDeBruijnWithArena(d, arena, consts)
+		argument, err := decodeTermDeBruijnWithArena(d, arena, consts, depth+1)
 		if err != nil {
 			return nil, err
 		}
@@ -213,7 +217,7 @@ func decodeTermDeBruijnWithArena(
 		}
 		return arena.allocConstant(constant), nil
 	case ForceTag:
-		t, err := decodeTermDeBruijnWithArena(d, arena, consts)
+		t, err := decodeTermDeBruijnWithArena(d, arena, consts, depth+1)
 		if err != nil {
 			return nil, err
 		}
@@ -235,17 +239,17 @@ func decodeTermDeBruijnWithArena(
 		if err != nil {
 			return nil, err
 		}
-		fields, err := decodeTermListDeBruijnWithArena(d, arena, consts)
+		fields, err := decodeTermListDeBruijnWithArena(d, arena, consts, depth+1)
 		if err != nil {
 			return nil, err
 		}
 		return arena.allocConstr(constrTag, fields), nil
 	case CaseTag:
-		constr, err := decodeTermDeBruijnWithArena(d, arena, consts)
+		constr, err := decodeTermDeBruijnWithArena(d, arena, consts, depth+1)
 		if err != nil {
 			return nil, err
 		}
-		branches, err := decodeTermListDeBruijnWithArena(d, arena, consts)
+		branches, err := decodeTermListDeBruijnWithArena(d, arena, consts, depth+1)
 		if err != nil {
 			return nil, err
 		}
@@ -391,6 +395,7 @@ func decodeTermListDeBruijnWithArena(
 	d *decoder,
 	arena *termArena[DeBruijn],
 	consts *constantArena,
+	depth int,
 ) ([]Term[DeBruijn], error) {
 	var result []Term[DeBruijn]
 
@@ -408,7 +413,7 @@ func decodeTermListDeBruijnWithArena(
 		if result == nil {
 			result = arena.allocTermList(4)[:0]
 		}
-		item, err := decodeTermDeBruijnWithArena(d, arena, consts)
+		item, err := decodeTermDeBruijnWithArena(d, arena, consts, depth)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The recursive FLAT decoder enforced the term-nesting limit (added in that per-node defer is not open-coded, so every decode return routes through the runtime panic/defer machinery -- ~39% of decode-only CPU (runtime.(*_panic).nextDefer/start, deferprocStack, popDefer).

Thread the nesting depth as an int parameter through decodeTermDeBruijnWithArena and decodeTermListDeBruijnWithArena and check depth >= maxFlatDecodeDepth at entry. Same limit semantics and error, no per-node defer. This mirrors the approach #322 already used for discharge depth.

Full-corpus BenchmarkFlatFiles (arm64, Go 1.26) recovers 735.75us -> 550.40us (-25.2%), back to v0.1.9-class. amd64 codegen of the decoder hot function: defer/panic CALL sites 28 -> 0. Tests (go test -race ./...), TestConformance, golangci-lint, and nilaway all pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Thread the FLAT decoder’s nesting depth as a parameter to remove per-node defer in the hot recursive path while keeping the same depth limit and error. This eliminates defer/panic overhead and speeds up decoding by ~25% on the full corpus.

- **Refactors**
  - Pass depth through decodeTermDeBruijnWithArena and decodeTermListDeBruijnWithArena; check at entry (depth >= maxFlatDecodeDepth) instead of using d.enter()/defer d.leave().
  - Remove per-node defer; hot path has no defer/panic call sites; behavior and limits unchanged.

<sup>Written for commit 14edc84b32bbcc4ed9b61f204dfb973322a7480a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/plutigo/pull/342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of deeply nested terms during decoding.
  * Added consistent nesting-depth enforcement across recursive decoding paths.
  * Prevented excessive nesting from causing decoder instability by returning a clear error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->