### PR TITLE
perf: index CEK environment lookups

### DIFF
--- a/cek/env.go
+++ b/cek/env.go
@@ -1,11 +1,26 @@
 package cek
 
-import "github.com/blinklabs-io/plutigo/syn"
+import (
+	"math/bits"
+
+	"github.com/blinklabs-io/plutigo/syn"
+)
+
+// envIndexLevels covers every environment depth accepted by the parser and
+// FLAT decoder (both cap nesting at 100,000). Entry n is the ancestor at
+// distance 2^(n+1)-1. Deeper chains built through the exported Env API compose
+// multiple maximum-distance jumps.
+const (
+	envIndexLevels    = 17
+	envMaxIndexedJump = (1 << envIndexLevels) - 1
+)
+
+type envIndex[T syn.Eval] [envIndexLevels]*Env[T]
 
 type Env[T syn.Eval] struct {
 	data  Value[T]
 	next  *Env[T]
-	skip4 *Env[T]
+	index *envIndex[T]
 }
 
 func lookupEnv[T syn.Eval](env *Env[T], idx int) (Value[T], bool) {
@@ -50,107 +65,117 @@ func lookupEnv[T syn.Eval](env *Env[T], idx int) (Value[T], bool) {
 		}
 		return env.data, true
 	case 5:
-		env = advanceEnv4(env)
-		if env == nil {
-			return zero, false
+		if env.index != nil {
+			ancestor := env.index[1]
+			if ancestor != nil {
+				ancestor = ancestor.next
+				if ancestor != nil {
+					return ancestor.data, true
+				}
+			}
 		}
-		return env.data, true
 	case 6:
-		env = advanceEnv4(env)
-		if env == nil {
-			return zero, false
+		if env.index != nil {
+			ancestor := env.index[1]
+			if ancestor != nil {
+				ancestor = ancestor.next
+			}
+			if ancestor != nil {
+				ancestor = ancestor.next
+				if ancestor != nil {
+					return ancestor.data, true
+				}
+			}
 		}
-		env = env.next
-		if env == nil {
-			return zero, false
-		}
-		return env.data, true
 	case 7:
-		env = advanceEnv4(env)
-		if env == nil {
-			return zero, false
+		if env.index != nil {
+			ancestor := env.index[1]
+			for range 3 {
+				if ancestor != nil {
+					ancestor = ancestor.next
+				}
+			}
+			if ancestor != nil {
+				return ancestor.data, true
+			}
 		}
-		env = env.next
-		if env == nil {
-			return zero, false
-		}
-		env = env.next
-		if env == nil {
-			return zero, false
-		}
-		return env.data, true
 	case 8:
-		env = advanceEnv4(env)
-		if env == nil {
-			return zero, false
+		if env.index != nil {
+			if ancestor := env.index[2]; ancestor != nil {
+				return ancestor.data, true
+			}
 		}
-		env = env.next
-		if env == nil {
-			return zero, false
+	}
+	if idx&(idx-1) == 0 {
+		level := bits.TrailingZeros(uint(idx)) - 1
+		if level < envIndexLevels && env.index != nil {
+			if ancestor := env.index[level]; ancestor != nil {
+				return ancestor.data, true
+			}
 		}
-		env = env.next
-		if env == nil {
-			return zero, false
-		}
-		env = env.next
-		if env == nil {
-			return zero, false
-		}
-		return env.data, true
 	}
 
-	current := env
-	remaining := idx - 1
-	for remaining >= 4 {
-		current = advanceEnv4(current)
-		if current == nil {
-			return zero, false
-		}
-		remaining -= 4
+	env = envAncestor(env, idx-1)
+	if env == nil {
+		return zero, false
 	}
-	for remaining > 0 {
-		current = current.next
-		if current == nil {
-			return zero, false
-		}
-		remaining--
-	}
-
-	return current.data, true
+	return env.data, true
 }
 
-func advanceEnv4[T syn.Eval](env *Env[T]) *Env[T] {
-	if env == nil {
-		return nil
-	}
-	if env.skip4 != nil {
-		return env.skip4
-	}
-	for range 4 {
-		env = env.next
-		if env == nil {
-			return nil
+func envAncestor[T syn.Eval](env *Env[T], distance int) *Env[T] {
+	for distance != 0 {
+		level := bits.Len(uint(distance+1)) - 2
+		if level >= envIndexLevels {
+			level = envIndexLevels - 1
 		}
+		jump := min((1<<(level+1))-1, envMaxIndexedJump)
+		var ancestor *Env[T]
+		if env.index != nil {
+			ancestor = env.index[level]
+		}
+		if ancestor == nil {
+			// Keep package-local manually constructed Env values working.
+			// Environments made through Extend or Machine.extendEnv always
+			// have a complete index and take the direct path above.
+			ancestor = env
+			for range jump {
+				ancestor = ancestor.next
+				if ancestor == nil {
+					return nil
+				}
+			}
+		}
+		env = ancestor
+		distance -= jump
 	}
 	return env
 }
 
-func (e *Env[T]) Extend(data Value[T]) *Env[T] {
-	var skip4 *Env[T]
-	if e != nil {
-		skip := e.next
-		if skip != nil {
-			skip = skip.next
-			if skip != nil {
-				skip4 = skip.next
-			}
+func initEnvIndex[T syn.Eval](env, parent *Env[T]) {
+	env.next = parent
+	if env.index == nil {
+		env.index = &envIndex[T]{}
+	}
+	env.index[0] = parent
+	for level := 1; level < envIndexLevels; level++ {
+		previous := env.index[level-1]
+		if previous == nil || previous.index == nil {
+			break
 		}
+		previous = previous.index[level-1]
+		if previous == nil {
+			break
+		}
+		env.index[level] = previous.next
 	}
-	return &Env[T]{
-		data:  data,
-		next:  e,
-		skip4: skip4,
+}
+
+func (e *Env[T]) Extend(data Value[T]) *Env[T] {
+	env := &Env[T]{
+		data: data,
 	}
+	initEnvIndex(env, e)
+	return env
 }
 
 func (e *Env[T]) Lookup(name int) (Value[T], bool) {

--- a/cek/machine.go
+++ b/cek/machine.go
@@ -135,6 +135,8 @@ type Machine[T syn.Eval] struct {
 	envActiveChunk         []Env[T]
 	envActiveChunkLimit    int
 	envChunkPos            int
+	envIndexChunks         [][]envIndex[T]
+	envIndexChunkPos       int
 	budgetTemplate         ExBudget
 	lastRunRemaining       ExBudget
 	hasRun                 bool
@@ -747,6 +749,8 @@ func NewMachine[T syn.Eval](
 		valueArenaChunkSize:   valueColdChunkSize,
 		envChunks:             make([][]Env[T], 0, 8),
 		envChunkPos:           0,
+		envIndexChunks:        make([][]envIndex[T], 0, 8),
+		envIndexChunkPos:      0,
 		budgetTemplate:        DefaultExBudget,
 		lastRunRemaining:      DefaultExBudget,
 		hasRun:                false,
@@ -791,17 +795,15 @@ func (m *Machine[T]) extendEnv(parent *Env[T], data Value[T]) *Env[T] {
 	}
 	env := &chunk[pos&(envChunkSize-1)]
 	m.envChunkPos = pos + 1
+	index := allocArenaSlot(
+		&m.envIndexChunks,
+		&m.envIndexChunkPos,
+		envChunkSize,
+	)
+	*index = envIndex[T]{}
+	env.index = index
 	env.data = data
-	env.next = parent
-	if parent != nil {
-		skip := parent.next
-		if skip != nil {
-			skip = skip.next
-			if skip != nil {
-				env.skip4 = skip.next
-			}
-		}
-	}
+	initEnvIndex(env, parent)
 	return env
 }
 
@@ -812,14 +814,21 @@ func (m *Machine[T]) resetEnvArena() {
 		retainedUsed = maxRetained
 	}
 	clearArenaChunks(m.envChunks, retainedUsed)
+	clearArenaChunks(m.envIndexChunks, retainedUsed)
 	if len(m.envChunks) > envRetainChunkCap {
 		retained := make([][]Env[T], envRetainChunkCap)
 		copy(retained, m.envChunks[:envRetainChunkCap])
 		m.envChunks = retained
 	}
+	if len(m.envIndexChunks) > envRetainChunkCap {
+		retained := make([][]envIndex[T], envRetainChunkCap)
+		copy(retained, m.envIndexChunks[:envRetainChunkCap])
+		m.envIndexChunks = retained
+	}
 	m.envActiveChunk = nil
 	m.envActiveChunkLimit = 0
 	m.envChunkPos = 0
+	m.envIndexChunkPos = 0
 }
 
 // lazyPrepareEnvArena trims chunks beyond envRetainChunkCap and clears the
@@ -827,15 +836,22 @@ func (m *Machine[T]) resetEnvArena() {
 // the previous run's Env/Value graph pinned inside the Machine.
 func (m *Machine[T]) lazyPrepareEnvArena() {
 	lazyPrepareArenaChunks(&m.envChunks, &m.envChunkPos, envRetainChunkCap)
+	lazyPrepareArenaChunks(
+		&m.envIndexChunks,
+		&m.envIndexChunkPos,
+		envRetainChunkCap,
+	)
 	m.envActiveChunk = nil
 	m.envActiveChunkLimit = 0
 }
 
 func (m *Machine[T]) dropEnvArena() {
 	m.envChunks = nil
+	m.envIndexChunks = nil
 	m.envActiveChunk = nil
 	m.envActiveChunkLimit = 0
 	m.envChunkPos = 0
+	m.envIndexChunkPos = 0
 }
 
 func (m *Machine[T]) resetValueArenas() {

--- a/cek/machine_test.go
+++ b/cek/machine_test.go
@@ -36,6 +36,13 @@ func TestNewMachine(t *testing.T) {
 	if m.ExBudget != DefaultExBudget {
 		t.Fatalf("expected default budget, got %+v", m.ExBudget)
 	}
+	if cap(m.envIndexChunks) != cap(m.envChunks) {
+		t.Fatalf(
+			"env index chunk capacity = %d, want env chunk capacity %d",
+			cap(m.envIndexChunks),
+			cap(m.envChunks),
+		)
+	}
 }
 
 func TestRunConstant(t *testing.T) {
@@ -117,6 +124,13 @@ func TestRunResetsEnvArena(t *testing.T) {
 		if m.envChunkPos != 0 {
 			t.Fatalf("envChunkPos after %s Run = %d, want 0", run, m.envChunkPos)
 		}
+		if m.envIndexChunkPos != 0 {
+			t.Fatalf(
+				"envIndexChunkPos after %s Run = %d, want 0",
+				run,
+				m.envIndexChunkPos,
+			)
+		}
 	}
 }
 
@@ -176,8 +190,22 @@ func TestRunClearsRetainedArenaReferencesAfterReturn(t *testing.T) {
 	for ci, chunk := range m.envChunks {
 		for si := range chunk {
 			slot := chunk[si]
-			if slot.data != nil || slot.next != nil {
+			if slot.data != nil || slot.next != nil || slot.index != nil {
 				t.Fatalf("envChunks[%d][%d] retained stale data after Run: %+v", ci, si, slot)
+			}
+		}
+	}
+	for ci, chunk := range m.envIndexChunks {
+		for si := range chunk {
+			for level, ancestor := range chunk[si] {
+				if ancestor != nil {
+					t.Fatalf(
+						"envIndexChunks[%d][%d][%d] retained stale ancestor after Run",
+						ci,
+						si,
+						level,
+					)
+				}
 			}
 		}
 	}
@@ -331,6 +359,9 @@ func TestResetEnvArenaRetainsOnlyTrackedChunkHeaders(t *testing.T) {
 	if len(m.envChunks) < usedChunks {
 		t.Fatalf("expected multiple env chunks, got %d", len(m.envChunks))
 	}
+	if len(m.envIndexChunks) < usedChunks {
+		t.Fatalf("expected multiple env index chunks, got %d", len(m.envIndexChunks))
+	}
 
 	m.resetEnvArena()
 
@@ -340,8 +371,25 @@ func TestResetEnvArenaRetainsOnlyTrackedChunkHeaders(t *testing.T) {
 	if cap(m.envChunks) != envRetainChunkCap {
 		t.Fatalf("cap(envChunks) after reset = %d, want %d", cap(m.envChunks), envRetainChunkCap)
 	}
+	if len(m.envIndexChunks) != envRetainChunkCap {
+		t.Fatalf(
+			"len(envIndexChunks) after reset = %d, want %d",
+			len(m.envIndexChunks),
+			envRetainChunkCap,
+		)
+	}
+	if cap(m.envIndexChunks) != envRetainChunkCap {
+		t.Fatalf(
+			"cap(envIndexChunks) after reset = %d, want %d",
+			cap(m.envIndexChunks),
+			envRetainChunkCap,
+		)
+	}
 	if m.envChunkPos != 0 {
 		t.Fatalf("envChunkPos after reset = %d, want 0", m.envChunkPos)
+	}
+	if m.envIndexChunkPos != 0 {
+		t.Fatalf("envIndexChunkPos after reset = %d, want 0", m.envIndexChunkPos)
 	}
 }
 
@@ -428,6 +476,66 @@ func TestLookupEnvUsesOneIndexedDepth(t *testing.T) {
 				t.Fatalf("lookupEnv(%d) = %d, want %d", tt.idx, got.Inner.Int64(), tt.wantIntValue)
 			}
 		})
+	}
+}
+
+func TestLookupEnvIndexedAtMaximumDepth(t *testing.T) {
+	const depth = 100_000
+
+	machine := NewMachine[syn.DeBruijn](lang.LanguageVersionV3, 0, nil)
+	var env *Env[syn.DeBruijn]
+	for i := 1; i <= depth; i++ {
+		env = machine.extendEnv(env, int64Constant(int64(i)))
+	}
+
+	for _, idx := range []int{1, 2, 3, 7, 31, 257, 4097, depth} {
+		value, ok := lookupEnv(env, idx)
+		if !ok {
+			t.Fatalf("lookupEnv(%d) failed at depth %d", idx, depth)
+		}
+		constant, ok := value.(*Constant)
+		if !ok {
+			t.Fatalf("lookupEnv(%d) returned %T, want *Constant", idx, value)
+		}
+		integer, ok := constant.Constant.(*syn.Integer)
+		if !ok {
+			t.Fatalf(
+				"lookupEnv(%d) constant = %T, want *syn.Integer",
+				idx,
+				constant.Constant,
+			)
+		}
+		want := int64(depth - idx + 1)
+		if got := integer.Inner.Int64(); got != want {
+			t.Fatalf("lookupEnv(%d) = %d, want %d", idx, got, want)
+		}
+	}
+
+	if _, ok := lookupEnv(env, depth+1); ok {
+		t.Fatalf("lookupEnv(%d) succeeded beyond depth %d", depth+1, depth)
+	}
+}
+
+func TestEnvLookupBeyondIndexRange(t *testing.T) {
+	const depth = 2 * (envMaxIndexedJump + 1)
+
+	oldest := int64Constant(1)
+	newer := int64Constant(2)
+	var env *Env[syn.DeBruijn]
+	env = env.Extend(oldest)
+	for range depth - 1 {
+		env = env.Extend(newer)
+	}
+
+	value, ok := env.Lookup(depth)
+	if !ok {
+		t.Fatalf("Lookup(%d) failed for an environment of depth %d", depth, depth)
+	}
+	if value != oldest {
+		t.Fatalf("Lookup(%d) returned %p, want oldest value %p", depth, value, oldest)
+	}
+	if _, ok := env.Lookup(depth + 1); ok {
+		t.Fatalf("Lookup(%d) succeeded beyond environment depth %d", depth+1, depth)
 	}
 }
 

--- a/cek/stack_machine_debruijn.go
+++ b/cek/stack_machine_debruijn.go
@@ -2,6 +2,7 @@
 package cek
 
 import (
+	"math/bits"
 	"unsafe"
 
 	"github.com/blinklabs-io/plutigo/syn"
@@ -86,89 +87,61 @@ func lookupEnvDeBruijn(
 		}
 		return env.data, true
 	case 5:
-		env = advanceEnv4DeBruijn(env)
-		if env == nil {
-			return zero, false
+		if env.index != nil {
+			ancestor := env.index[1]
+			if ancestor != nil {
+				ancestor = ancestor.next
+				if ancestor != nil {
+					return ancestor.data, true
+				}
+			}
 		}
-		return env.data, true
 	case 6:
-		env = advanceEnv4DeBruijn(env)
-		if env == nil {
-			return zero, false
+		if env.index != nil {
+			ancestor := env.index[1]
+			if ancestor != nil {
+				ancestor = ancestor.next
+			}
+			if ancestor != nil {
+				ancestor = ancestor.next
+				if ancestor != nil {
+					return ancestor.data, true
+				}
+			}
 		}
-		env = env.next
-		if env == nil {
-			return zero, false
-		}
-		return env.data, true
 	case 7:
-		env = advanceEnv4DeBruijn(env)
-		if env == nil {
-			return zero, false
+		if env.index != nil {
+			ancestor := env.index[1]
+			for range 3 {
+				if ancestor != nil {
+					ancestor = ancestor.next
+				}
+			}
+			if ancestor != nil {
+				return ancestor.data, true
+			}
 		}
-		env = env.next
-		if env == nil {
-			return zero, false
-		}
-		env = env.next
-		if env == nil {
-			return zero, false
-		}
-		return env.data, true
 	case 8:
-		env = advanceEnv4DeBruijn(env)
-		if env == nil {
-			return zero, false
+		if env.index != nil {
+			if ancestor := env.index[2]; ancestor != nil {
+				return ancestor.data, true
+			}
 		}
-		env = env.next
-		if env == nil {
-			return zero, false
+	}
+	if idx&(idx-1) == 0 {
+		level := bits.TrailingZeros(uint(idx)) - 1
+		if level < envIndexLevels && env.index != nil {
+			if ancestor := env.index[level]; ancestor != nil {
+				return ancestor.data, true
+			}
 		}
-		env = env.next
-		if env == nil {
-			return zero, false
-		}
-		env = env.next
-		if env == nil {
-			return zero, false
-		}
-		return env.data, true
 	}
 
-	current := env
-	remaining := idx - 1
-	for remaining >= 4 {
-		current = advanceEnv4DeBruijn(current)
-		if current == nil {
-			return zero, false
-		}
-		remaining -= 4
-	}
-	for remaining > 0 {
-		current = current.next
-		if current == nil {
-			return zero, false
-		}
-		remaining--
-	}
-
-	return current.data, true
-}
-
-func advanceEnv4DeBruijn(env *Env[syn.DeBruijn]) *Env[syn.DeBruijn] {
+	env = envAncestor(env, idx-1)
 	if env == nil {
-		return nil
+		return zero, false
 	}
-	if env.skip4 != nil {
-		return env.skip4
-	}
-	for range 4 {
-		env = env.next
-		if env == nil {
-			return nil
-		}
-	}
-	return env
+	return env.data, true
 }
 
 func computeKnownImmediateValueNoSlippageDeBruijn(


### PR DESCRIPTION
Closes #269 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up `cek` environment lookups by indexing ancestors, making common de Bruijn accesses O(1) and bounding worst‑case to a few pointer hops. Addresses #269 by removing the deep-env hotspot without changing behavior.

- **Refactors**
  - Added a 17‑level `envIndex` storing ancestors at distances 2^(n+1)-1; removed `skip4` and the advance-by-4 paths.
  - Updated lookups (generic and de Bruijn) to use fast paths for depths 1–8 and power‑of‑two depths; added `envAncestor` fallback that composes indexed jumps for arbitrary depths.
  - Initialized indexes in `Env.Extend` and `Machine.extendEnv`; added `envIndexChunks` arena with reset/drop/clear aligned to env chunks.
  - Expanded tests to cover index arena clearing and capacity parity, lookups up to depth 100,000, and correct behavior beyond the maximum indexed jump.

<sup>Written for commit af9810c48fa949c6bc0185873b0026426d94fb36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/plutigo/pull/349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

