### PR TITLE
feat: add mainnet script replay runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ plutigo implements the following Cardano Improvement Proposals (CIPs) related to
 ### Testing and Conformance
 All implemented CIPs include comprehensive conformance tests ensuring correct behavior and cost modeling.
 
+Mainnet parity corpora can be executed with `plutigo-replay`; see the
+[replay corpus guide](replay/README.md) for the normalized transaction format
+and reporting workflow.
+
 ## Performance
 
 plutigo is optimized for high-performance Plutus script evaluation:
@@ -130,7 +134,9 @@ plutigo supports all major Plutus protocol versions:
 - Plutus V3 (1.2.0+): Chang+ era - Latest features and optimizations
 - Plutus V4 (1.3.0+): Initial support with placeholder cost models
 
-The library automatically selects appropriate cost models and builtin behavior based on the program version.
+The library selects cost models and builtin behavior from the Plutus ledger
+language supplied to `NewMachine` and the evaluation context. On-chain callers
+must use the ledger language rather than infer it from the UPLC program header.
 
 ## Development
 

--- a/cmd/plutigo-replay/main.go
+++ b/cmd/plutigo-replay/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/blinklabs-io/plutigo/replay"
+)
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func run(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("plutigo-replay", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	var corpusPath string
+	var pretty bool
+	flags.StringVar(&corpusPath, "corpus", "", "path to a replay corpus JSON file")
+	flags.BoolVar(&pretty, "pretty", false, "indent the JSON report")
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+
+	if corpusPath == "" {
+		fmt.Fprintln(stderr, "plutigo-replay: -corpus is required")
+		return 2
+	}
+
+	corpus, err := replay.LoadFile(corpusPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "plutigo-replay: %v\n", err)
+		return 2
+	}
+	report, err := replay.Run(context.Background(), corpus)
+	if err != nil {
+		fmt.Fprintf(stderr, "plutigo-replay: %v\n", err)
+		return 2
+	}
+
+	encoder := json.NewEncoder(stdout)
+	if pretty {
+		encoder.SetIndent("", "  ")
+	}
+	if err := encoder.Encode(report); err != nil {
+		fmt.Fprintf(stderr, "plutigo-replay: encode report: %v\n", err)
+		return 2
+	}
+	if report.Summary.Failed > 0 {
+		return 1
+	}
+	return 0
+}

--- a/cmd/plutigo-replay/main.go
+++ b/cmd/plutigo-replay/main.go
@@ -3,19 +3,37 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/blinklabs-io/plutigo/replay"
 )
 
 func main() {
-	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+	ctx, stop := signal.NotifyContext(
+		context.Background(),
+		os.Interrupt,
+		syscall.SIGTERM,
+	)
+	code := runContext(ctx, os.Args[1:], os.Stdout, os.Stderr)
+	stop()
+	os.Exit(code)
 }
 
 func run(args []string, stdout, stderr io.Writer) int {
+	return runContext(context.Background(), args, stdout, stderr)
+}
+
+func runContext(
+	ctx context.Context,
+	args []string,
+	stdout, stderr io.Writer,
+) int {
 	flags := flag.NewFlagSet("plutigo-replay", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 	var corpusPath string
@@ -23,6 +41,9 @@ func run(args []string, stdout, stderr io.Writer) int {
 	flags.StringVar(&corpusPath, "corpus", "", "path to a replay corpus JSON file")
 	flags.BoolVar(&pretty, "pretty", false, "indent the JSON report")
 	if err := flags.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
 		return 2
 	}
 
@@ -36,7 +57,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "plutigo-replay: %v\n", err)
 		return 2
 	}
-	report, err := replay.Run(context.Background(), corpus)
+	report, err := replay.Run(ctx, corpus)
 	if err != nil {
 		fmt.Fprintf(stderr, "plutigo-replay: %v\n", err)
 		return 2

--- a/cmd/plutigo-replay/main_test.go
+++ b/cmd/plutigo-replay/main_test.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"math/big"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/blinklabs-io/plutigo/data"
@@ -23,6 +25,70 @@ func TestRunRequiresCorpus(t *testing.T) {
 	}
 	if stdout.Len() != 0 {
 		t.Fatalf("run() stdout = %q, want empty", stdout.String())
+	}
+	if got := stderr.String(); !strings.Contains(
+		got,
+		"plutigo-replay: -corpus is required",
+	) {
+		t.Fatalf("run() stderr = %q, want missing corpus error", got)
+	}
+}
+
+func TestRunHelp(t *testing.T) {
+	for _, arg := range []string{"-h", "--help"} {
+		t.Run(arg, func(t *testing.T) {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			if code := run([]string{arg}, &stdout, &stderr); code != 0 {
+				t.Fatalf("run() code = %d, want 0", code)
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf(
+					"run() stdout = %q, want empty",
+					stdout.String(),
+				)
+			}
+			if got := stderr.String(); !strings.Contains(
+				got,
+				"Usage of plutigo-replay:",
+			) {
+				t.Fatalf("run() stderr = %q, want usage", got)
+			}
+		})
+	}
+}
+
+func TestRunCanceledContext(t *testing.T) {
+	corpusPath := writeCorpus(t, replay.Corpus{
+		SchemaVersion: replay.SchemaVersion,
+		Network:       "mainnet",
+		Reference:     commandReference(),
+		Cases:         []replay.Case{commandReplayCase(t)},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if code := runContext(
+		ctx,
+		[]string{"-corpus", corpusPath},
+		&stdout,
+		&stderr,
+	); code != 2 {
+		t.Fatalf("runContext() code = %d, want 2", code)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf(
+			"runContext() stdout = %q, want empty",
+			stdout.String(),
+		)
+	}
+	if got := stderr.String(); !strings.Contains(got, "context canceled") {
+		t.Fatalf(
+			"runContext() stderr = %q, want cancellation error",
+			got,
+		)
 	}
 }
 

--- a/cmd/plutigo-replay/main_test.go
+++ b/cmd/plutigo-replay/main_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/blinklabs-io/plutigo/data"
+	"github.com/blinklabs-io/plutigo/lang"
+	"github.com/blinklabs-io/plutigo/replay"
+	"github.com/blinklabs-io/plutigo/syn"
+)
+
+func TestRunRequiresCorpus(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if code := run(nil, &stdout, &stderr); code != 2 {
+		t.Fatalf("run() code = %d, want 2", code)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("run() stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestRunReportsMatchingCorpus(t *testing.T) {
+	replayCase := commandReplayCase(t)
+	first := replay.RunCase(&replayCase)
+	if !first.Actual.Success {
+		t.Fatalf("replay setup failed: %s", first.Actual.Error)
+	}
+	replayCase.Expected.ExUnits = first.Actual.ExUnits
+
+	corpusPath := writeCorpus(t, replay.Corpus{
+		SchemaVersion: replay.SchemaVersion,
+		Network:       "mainnet",
+		Reference:     commandReference(),
+		Cases:         []replay.Case{replayCase},
+	})
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if code := run(
+		[]string{"-corpus", corpusPath, "-pretty"},
+		&stdout,
+		&stderr,
+	); code != 0 {
+		t.Fatalf(
+			"run() code = %d, want 0; stderr=%s",
+			code,
+			stderr.String(),
+		)
+	}
+
+	var report replay.Report
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("decode report: %v\n%s", err, stdout.String())
+	}
+	if report.Summary.Passed != 1 || report.Summary.Failed != 0 {
+		t.Fatalf("report summary = %+v", report.Summary)
+	}
+}
+
+func TestRunReturnsMismatchExitCode(t *testing.T) {
+	replayCase := commandReplayCase(t)
+	replayCase.Expected.ExUnits = replay.ExUnits{}
+	corpusPath := writeCorpus(t, replay.Corpus{
+		SchemaVersion: replay.SchemaVersion,
+		Network:       "mainnet",
+		Reference:     commandReference(),
+		Cases:         []replay.Case{replayCase},
+	})
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if code := run([]string{"-corpus", corpusPath}, &stdout, &stderr); code != 1 {
+		t.Fatalf(
+			"run() code = %d, want 1; stderr=%s",
+			code,
+			stderr.String(),
+		)
+	}
+}
+
+func commandReference() replay.Reference {
+	return replay.Reference{
+		Implementation: "cardano-node",
+		Version:        "10.14.0.0",
+	}
+}
+
+func commandReplayCase(t *testing.T) replay.Case {
+	t.Helper()
+	program := &syn.Program[syn.DeBruijn]{
+		Version: lang.LanguageVersionV1,
+		Term: &syn.Lambda[syn.DeBruijn]{
+			Body: &syn.Var[syn.DeBruijn]{Name: syn.DeBruijn(1)},
+		},
+	}
+	encodedProgram, err := syn.Encode(program)
+	if err != nil {
+		t.Fatalf("encode program: %v", err)
+	}
+	encodedArg, err := data.Encode(data.NewInteger(big.NewInt(42)))
+	if err != nil {
+		t.Fatalf("encode argument: %v", err)
+	}
+
+	return replay.Case{
+		ID: "tx-command#spend:0",
+		Transaction: replay.TransactionRef{
+			ID:       "tx-command",
+			Redeemer: "spend:0",
+		},
+		Language:         replay.PlutusV1,
+		ProtocolVersion:  replay.ProtocolVersion{Major: 10},
+		FlatProgramHex:   hex.EncodeToString(encodedProgram),
+		ArgumentsCBORHex: []string{hex.EncodeToString(encodedArg)},
+		CostModel:        replay.CostModel{UseDefault: true},
+		BudgetLimit: replay.ExUnits{
+			Steps:  10_000_000_000,
+			Memory: 14_000_000,
+		},
+		Expected: replay.Expected{Success: true},
+	}
+}
+
+func writeCorpus(t *testing.T, corpus replay.Corpus) string {
+	t.Helper()
+	encoded, err := json.Marshal(corpus)
+	if err != nil {
+		t.Fatalf("encode corpus: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "corpus.json")
+	if err := os.WriteFile(path, encoded, 0o600); err != nil {
+		t.Fatalf("write corpus: %v", err)
+	}
+	return path
+}

--- a/replay/README.md
+++ b/replay/README.md
@@ -1,0 +1,98 @@
+# Mainnet replay corpus
+
+`plutigo-replay` executes normalized Plutus validation cases and compares
+plutigo's outcome and execution units with values recorded from cardano-node.
+
+The normalization boundary is deliberate: plutigo is a UPLC evaluator and does
+not reconstruct ledger `ScriptContext` values from full Cardano transactions.
+A transaction-aware collector must resolve inputs and reference scripts, build
+the era-appropriate script arguments, and record cardano-node's reference
+result.
+
+## Corpus format
+
+```json
+{
+  "schema_version": 1,
+  "network": "mainnet",
+  "reference": {
+    "implementation": "cardano-node",
+    "version": "10.14.0.0"
+  },
+  "cases": [
+    {
+      "id": "<transaction-id>#spend:0",
+      "transaction": {
+        "id": "<transaction-id>",
+        "slot": 123456789,
+        "block": "<block-hash>",
+        "redeemer": "spend:0"
+      },
+      "language": "PlutusV2",
+      "protocol_version": {"major": 10, "minor": 0},
+      "flat_program_hex": "<raw-flat-encoded-uplc>",
+      "arguments_cbor_hex": [
+        "<datum-cbor>",
+        "<redeemer-cbor>",
+        "<script-context-cbor>"
+      ],
+      "cost_model": {"use_default": true},
+      "budget_limit": {"steps": 10000000000, "memory": 14000000},
+      "expected": {
+        "success": true,
+        "ex_units": {"steps": 123456, "memory": 789}
+      },
+      "metadata": {
+        "collector": "name and version",
+        "cardano_node": "version used for the reference result"
+      }
+    }
+  ]
+}
+```
+
+`language` is the ledger Plutus language and is intentionally separate from the
+UPLC version encoded in `flat_program_hex`. The program is raw FLAT, without a
+CBOR bytestring envelope. `arguments_cbor_hex` is ordered exactly as the ledger
+applies arguments to the script. `steps` corresponds to plutigo's CPU budget.
+
+For smoke tests only, `"cost_model": {"use_default": true}` selects plutigo's
+built-in model. Mainnet parity corpora should always include the historical
+cost-model parameter array active at the transaction's slot.
+
+## Run
+
+```sh
+go run ./cmd/plutigo-replay -corpus ./mainnet-corpus.json -pretty
+```
+
+The command exits with status 0 when every case matches, 1 for parity
+mismatches, and 2 for an invalid corpus or runner error. Its JSON report
+contains each case's measured latency and aggregate median, p95, and throughput.
+
+## Collection checklist
+
+For each representative V1, V2, and V3 transaction:
+
+1. Record the network, slot, block hash, transaction ID, and redeemer pointer.
+2. Resolve transaction inputs, datums, and reference scripts at that ledger
+   state.
+3. Export the raw FLAT program and the ledger-ordered CBOR `Data` arguments.
+4. Record the active protocol version and complete cost-model parameter array.
+5. Evaluate with cardano-node and record success/failure and exact ExUnits.
+6. Keep collector and cardano-node versions in `metadata` for reproducibility.
+
+With an offline transaction bundle, the reference ExUnits can be produced by:
+
+```sh
+cardano-cli latest transaction calculate-plutus-script-cost offline \
+  --start-time-posix <network-start-time> \
+  --era-history-file <era-history.json> \
+  --utxo-file <resolved-inputs.json> \
+  --protocol-params-file <protocol-parameters.json> \
+  --tx-file <transaction.json> \
+  --out-file <cardano-node-costs.json>
+```
+
+The transaction-aware collector remains responsible for exporting each raw
+script and the exact ledger-ordered `Data` arguments alongside those costs.

--- a/replay/corpus.go
+++ b/replay/corpus.go
@@ -12,7 +12,9 @@ import (
 	"strings"
 
 	"github.com/blinklabs-io/plutigo/cek"
+	"github.com/blinklabs-io/plutigo/data"
 	"github.com/blinklabs-io/plutigo/lang"
+	"github.com/blinklabs-io/plutigo/syn"
 )
 
 const SchemaVersion = 1
@@ -186,12 +188,20 @@ func (c *Case) validate() error {
 	if _, err := c.Language.Version(); err != nil {
 		return err
 	}
-	if _, err := decodeHex("flat program", c.FlatProgramHex); err != nil {
+	flatProgram, err := decodeHex("flat program", c.FlatProgramHex)
+	if err != nil {
 		return err
 	}
+	if _, err := syn.Decode[syn.DeBruijn](flatProgram); err != nil {
+		return fmt.Errorf("decode FLAT program: %w", err)
+	}
 	for i, arg := range c.ArgumentsCBORHex {
-		if _, err := decodeHex(fmt.Sprintf("argument %d CBOR", i), arg); err != nil {
+		argCBOR, err := decodeHex(fmt.Sprintf("argument %d CBOR", i), arg)
+		if err != nil {
 			return err
+		}
+		if _, err := data.Decode(argCBOR); err != nil {
+			return fmt.Errorf("decode argument %d PlutusData: %w", i, err)
 		}
 	}
 	if c.CostModel.UseDefault == (len(c.CostModel.Parameters) > 0) {
@@ -204,6 +214,9 @@ func (c *Case) validate() error {
 	}
 	if c.Expected.ExUnits.Steps < 0 || c.Expected.ExUnits.Memory < 0 {
 		return errors.New("expected execution units cannot be negative")
+	}
+	if c.Expected.Success && c.Expected.ErrorCode != nil {
+		return errors.New("successful expected result cannot include an error code")
 	}
 	if c.Expected.ExUnits.Steps > c.BudgetLimit.Steps ||
 		c.Expected.ExUnits.Memory > c.BudgetLimit.Memory {

--- a/replay/corpus.go
+++ b/replay/corpus.go
@@ -97,6 +97,11 @@ type Expected struct {
 	ErrorCode *cek.ErrorCode `json:"error_code,omitempty"`
 }
 
+type decodedCase struct {
+	program   *syn.Program[syn.DeBruijn]
+	arguments []data.PlutusData
+}
+
 func LoadFile(path string) (*Corpus, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -135,94 +140,127 @@ func Load(r io.Reader) (*Corpus, error) {
 }
 
 func (c *Corpus) Validate() error {
+	_, err := c.validate()
+	return err
+}
+
+func (c *Corpus) validate() ([]decodedCase, error) {
 	if c == nil {
-		return errors.New("replay corpus is required")
+		return nil, errors.New("replay corpus is required")
 	}
 	if c.SchemaVersion != SchemaVersion {
-		return fmt.Errorf(
+		return nil, fmt.Errorf(
 			"unsupported replay corpus schema version %d (want %d)",
 			c.SchemaVersion,
 			SchemaVersion,
 		)
 	}
 	if strings.TrimSpace(c.Network) == "" {
-		return errors.New("replay corpus network is required")
+		return nil, errors.New("replay corpus network is required")
 	}
 	if strings.TrimSpace(c.Reference.Implementation) == "" {
-		return errors.New("replay corpus reference implementation is required")
+		return nil, errors.New(
+			"replay corpus reference implementation is required",
+		)
 	}
 	if strings.TrimSpace(c.Reference.Version) == "" {
-		return errors.New("replay corpus reference version is required")
+		return nil, errors.New("replay corpus reference version is required")
 	}
 	if len(c.Cases) == 0 {
-		return errors.New("replay corpus must contain at least one case")
+		return nil, errors.New("replay corpus must contain at least one case")
 	}
 
 	ids := make(map[string]struct{}, len(c.Cases))
+	decodedCases := make([]decodedCase, 0, len(c.Cases))
 	for i := range c.Cases {
 		replayCase := &c.Cases[i]
-		if err := replayCase.validate(); err != nil {
-			return fmt.Errorf("replay case %d: %w", i, err)
+		decoded, err := replayCase.validate()
+		if err != nil {
+			return nil, fmt.Errorf("replay case %d: %w", i, err)
 		}
 		if _, exists := ids[replayCase.ID]; exists {
-			return fmt.Errorf("replay case %d: duplicate id %q", i, replayCase.ID)
+			return nil, fmt.Errorf(
+				"replay case %d: duplicate id %q",
+				i,
+				replayCase.ID,
+			)
 		}
 		ids[replayCase.ID] = struct{}{}
+		decodedCases = append(decodedCases, decoded)
 	}
-	return nil
+	return decodedCases, nil
 }
 
-func (c *Case) validate() error {
+func (c *Case) validate() (decodedCase, error) {
 	if strings.TrimSpace(c.ID) == "" {
-		return errors.New("id is required")
+		return decodedCase{}, errors.New("id is required")
 	}
 	if strings.TrimSpace(c.Transaction.ID) == "" {
-		return errors.New("transaction id is required")
+		return decodedCase{}, errors.New("transaction id is required")
 	}
 	if strings.TrimSpace(c.Transaction.Redeemer) == "" {
-		return errors.New("transaction redeemer is required")
+		return decodedCase{}, errors.New("transaction redeemer is required")
 	}
 	if c.ProtocolVersion.Major == 0 {
-		return errors.New("protocol major version must be positive")
+		return decodedCase{}, errors.New("protocol major version must be positive")
 	}
 	if _, err := c.Language.Version(); err != nil {
-		return err
+		return decodedCase{}, err
 	}
 	flatProgram, err := decodeHex("flat program", c.FlatProgramHex)
 	if err != nil {
-		return err
+		return decodedCase{}, err
 	}
-	if _, err := syn.Decode[syn.DeBruijn](flatProgram); err != nil {
-		return fmt.Errorf("decode FLAT program: %w", err)
+	program, err := syn.Decode[syn.DeBruijn](flatProgram)
+	if err != nil {
+		return decodedCase{}, fmt.Errorf("decode FLAT program: %w", err)
 	}
+	arguments := make([]data.PlutusData, 0, len(c.ArgumentsCBORHex))
 	for i, arg := range c.ArgumentsCBORHex {
 		argCBOR, err := decodeHex(fmt.Sprintf("argument %d CBOR", i), arg)
 		if err != nil {
-			return err
+			return decodedCase{}, err
 		}
-		if _, err := data.Decode(argCBOR); err != nil {
-			return fmt.Errorf("decode argument %d PlutusData: %w", i, err)
+		decodedArgument, err := data.Decode(argCBOR)
+		if err != nil {
+			return decodedCase{}, fmt.Errorf(
+				"decode argument %d PlutusData: %w",
+				i,
+				err,
+			)
 		}
+		arguments = append(arguments, decodedArgument)
 	}
 	if c.CostModel.UseDefault == (len(c.CostModel.Parameters) > 0) {
-		return errors.New(
+		return decodedCase{}, errors.New(
 			"cost model must select exactly one of use_default or parameters",
 		)
 	}
 	if c.BudgetLimit.Steps <= 0 || c.BudgetLimit.Memory <= 0 {
-		return errors.New("budget limit steps and memory must be positive")
+		return decodedCase{}, errors.New(
+			"budget limit steps and memory must be positive",
+		)
 	}
 	if c.Expected.ExUnits.Steps < 0 || c.Expected.ExUnits.Memory < 0 {
-		return errors.New("expected execution units cannot be negative")
+		return decodedCase{}, errors.New(
+			"expected execution units cannot be negative",
+		)
 	}
 	if c.Expected.Success && c.Expected.ErrorCode != nil {
-		return errors.New("successful expected result cannot include an error code")
+		return decodedCase{}, errors.New(
+			"successful expected result cannot include an error code",
+		)
 	}
 	if c.Expected.ExUnits.Steps > c.BudgetLimit.Steps ||
 		c.Expected.ExUnits.Memory > c.BudgetLimit.Memory {
-		return errors.New("expected execution units exceed the budget limit")
+		return decodedCase{}, errors.New(
+			"expected execution units exceed the budget limit",
+		)
 	}
-	return nil
+	return decodedCase{
+		program:   program,
+		arguments: arguments,
+	}, nil
 }
 
 func decodeHex(name, value string) ([]byte, error) {

--- a/replay/corpus.go
+++ b/replay/corpus.go
@@ -1,0 +1,226 @@
+// Package replay executes normalized Cardano Plutus evaluation cases and
+// compares plutigo results with a reference ledger implementation.
+package replay
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/blinklabs-io/plutigo/cek"
+	"github.com/blinklabs-io/plutigo/lang"
+)
+
+const SchemaVersion = 1
+
+type Corpus struct {
+	SchemaVersion int       `json:"schema_version"`
+	Network       string    `json:"network"`
+	Reference     Reference `json:"reference"`
+	Cases         []Case    `json:"cases"`
+}
+
+type Reference struct {
+	Implementation string `json:"implementation"`
+	Version        string `json:"version"`
+}
+
+type Case struct {
+	ID                 string          `json:"id"`
+	Transaction        TransactionRef  `json:"transaction"`
+	Language           Language        `json:"language"`
+	ProtocolVersion    ProtocolVersion `json:"protocol_version"`
+	FlatProgramHex     string          `json:"flat_program_hex"`
+	ArgumentsCBORHex   []string        `json:"arguments_cbor_hex"`
+	CostModel          CostModel       `json:"cost_model"`
+	BudgetLimit        ExUnits         `json:"budget_limit"`
+	Expected           Expected        `json:"expected"`
+	AdditionalMetadata json.RawMessage `json:"metadata,omitempty"`
+}
+
+type TransactionRef struct {
+	ID       string `json:"id"`
+	Slot     uint64 `json:"slot,omitempty"`
+	Block    string `json:"block,omitempty"`
+	Redeemer string `json:"redeemer"`
+}
+
+type ProtocolVersion struct {
+	Major uint `json:"major"`
+	Minor uint `json:"minor"`
+}
+
+type Language string
+
+const (
+	PlutusV1 Language = "PlutusV1"
+	PlutusV2 Language = "PlutusV2"
+	PlutusV3 Language = "PlutusV3"
+	PlutusV4 Language = "PlutusV4"
+)
+
+func (l Language) Version() (lang.LanguageVersion, error) {
+	switch l {
+	case PlutusV1:
+		return lang.LanguageVersionV1, nil
+	case PlutusV2:
+		return lang.LanguageVersionV2, nil
+	case PlutusV3:
+		return lang.LanguageVersionV3, nil
+	case PlutusV4:
+		return lang.LanguageVersionV4, nil
+	default:
+		return lang.LanguageVersion{}, fmt.Errorf("unsupported Plutus language %q", l)
+	}
+}
+
+type CostModel struct {
+	UseDefault bool    `json:"use_default,omitempty"`
+	Parameters []int64 `json:"parameters,omitempty"`
+}
+
+// ExUnits uses the cardano-node field names: steps are plutigo's CPU units.
+type ExUnits struct {
+	Steps  int64 `json:"steps"`
+	Memory int64 `json:"memory"`
+}
+
+type Expected struct {
+	Success   bool           `json:"success"`
+	ExUnits   ExUnits        `json:"ex_units"`
+	ErrorCode *cek.ErrorCode `json:"error_code,omitempty"`
+}
+
+func LoadFile(path string) (*Corpus, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open replay corpus: %w", err)
+	}
+	defer f.Close()
+
+	corpus, err := Load(f)
+	if err != nil {
+		return nil, fmt.Errorf("load replay corpus %q: %w", path, err)
+	}
+	return corpus, nil
+}
+
+func Load(r io.Reader) (*Corpus, error) {
+	decoder := json.NewDecoder(r)
+	decoder.DisallowUnknownFields()
+
+	var corpus Corpus
+	if err := decoder.Decode(&corpus); err != nil {
+		return nil, fmt.Errorf("decode replay corpus: %w", err)
+	}
+
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return nil, errors.New("decode replay corpus: multiple JSON values")
+		}
+		return nil, fmt.Errorf("decode replay corpus trailing data: %w", err)
+	}
+
+	if err := corpus.Validate(); err != nil {
+		return nil, err
+	}
+	return &corpus, nil
+}
+
+func (c *Corpus) Validate() error {
+	if c == nil {
+		return errors.New("replay corpus is required")
+	}
+	if c.SchemaVersion != SchemaVersion {
+		return fmt.Errorf(
+			"unsupported replay corpus schema version %d (want %d)",
+			c.SchemaVersion,
+			SchemaVersion,
+		)
+	}
+	if strings.TrimSpace(c.Network) == "" {
+		return errors.New("replay corpus network is required")
+	}
+	if strings.TrimSpace(c.Reference.Implementation) == "" {
+		return errors.New("replay corpus reference implementation is required")
+	}
+	if strings.TrimSpace(c.Reference.Version) == "" {
+		return errors.New("replay corpus reference version is required")
+	}
+	if len(c.Cases) == 0 {
+		return errors.New("replay corpus must contain at least one case")
+	}
+
+	ids := make(map[string]struct{}, len(c.Cases))
+	for i := range c.Cases {
+		replayCase := &c.Cases[i]
+		if err := replayCase.validate(); err != nil {
+			return fmt.Errorf("replay case %d: %w", i, err)
+		}
+		if _, exists := ids[replayCase.ID]; exists {
+			return fmt.Errorf("replay case %d: duplicate id %q", i, replayCase.ID)
+		}
+		ids[replayCase.ID] = struct{}{}
+	}
+	return nil
+}
+
+func (c *Case) validate() error {
+	if strings.TrimSpace(c.ID) == "" {
+		return errors.New("id is required")
+	}
+	if strings.TrimSpace(c.Transaction.ID) == "" {
+		return errors.New("transaction id is required")
+	}
+	if strings.TrimSpace(c.Transaction.Redeemer) == "" {
+		return errors.New("transaction redeemer is required")
+	}
+	if c.ProtocolVersion.Major == 0 {
+		return errors.New("protocol major version must be positive")
+	}
+	if _, err := c.Language.Version(); err != nil {
+		return err
+	}
+	if _, err := decodeHex("flat program", c.FlatProgramHex); err != nil {
+		return err
+	}
+	for i, arg := range c.ArgumentsCBORHex {
+		if _, err := decodeHex(fmt.Sprintf("argument %d CBOR", i), arg); err != nil {
+			return err
+		}
+	}
+	if c.CostModel.UseDefault == (len(c.CostModel.Parameters) > 0) {
+		return errors.New(
+			"cost model must select exactly one of use_default or parameters",
+		)
+	}
+	if c.BudgetLimit.Steps <= 0 || c.BudgetLimit.Memory <= 0 {
+		return errors.New("budget limit steps and memory must be positive")
+	}
+	if c.Expected.ExUnits.Steps < 0 || c.Expected.ExUnits.Memory < 0 {
+		return errors.New("expected execution units cannot be negative")
+	}
+	if c.Expected.ExUnits.Steps > c.BudgetLimit.Steps ||
+		c.Expected.ExUnits.Memory > c.BudgetLimit.Memory {
+		return errors.New("expected execution units exceed the budget limit")
+	}
+	return nil
+}
+
+func decodeHex(name, value string) ([]byte, error) {
+	value = strings.TrimSpace(value)
+	value = strings.TrimPrefix(value, "0x")
+	if value == "" {
+		return nil, fmt.Errorf("%s is required", name)
+	}
+	decoded, err := hex.DecodeString(value)
+	if err != nil {
+		return nil, fmt.Errorf("decode %s hex: %w", name, err)
+	}
+	return decoded, nil
+}

--- a/replay/corpus.go
+++ b/replay/corpus.go
@@ -140,55 +140,52 @@ func Load(r io.Reader) (*Corpus, error) {
 }
 
 func (c *Corpus) Validate() error {
-	_, err := c.validate()
-	return err
+	return c.validate()
 }
 
-func (c *Corpus) validate() ([]decodedCase, error) {
+func (c *Corpus) validate() error {
 	if c == nil {
-		return nil, errors.New("replay corpus is required")
+		return errors.New("replay corpus is required")
 	}
 	if c.SchemaVersion != SchemaVersion {
-		return nil, fmt.Errorf(
+		return fmt.Errorf(
 			"unsupported replay corpus schema version %d (want %d)",
 			c.SchemaVersion,
 			SchemaVersion,
 		)
 	}
 	if strings.TrimSpace(c.Network) == "" {
-		return nil, errors.New("replay corpus network is required")
+		return errors.New("replay corpus network is required")
 	}
 	if strings.TrimSpace(c.Reference.Implementation) == "" {
-		return nil, errors.New(
+		return errors.New(
 			"replay corpus reference implementation is required",
 		)
 	}
 	if strings.TrimSpace(c.Reference.Version) == "" {
-		return nil, errors.New("replay corpus reference version is required")
+		return errors.New("replay corpus reference version is required")
 	}
 	if len(c.Cases) == 0 {
-		return nil, errors.New("replay corpus must contain at least one case")
+		return errors.New("replay corpus must contain at least one case")
 	}
 
 	ids := make(map[string]struct{}, len(c.Cases))
-	decodedCases := make([]decodedCase, 0, len(c.Cases))
 	for i := range c.Cases {
 		replayCase := &c.Cases[i]
-		decoded, err := replayCase.validate()
+		_, err := replayCase.validate()
 		if err != nil {
-			return nil, fmt.Errorf("replay case %d: %w", i, err)
+			return fmt.Errorf("replay case %d: %w", i, err)
 		}
 		if _, exists := ids[replayCase.ID]; exists {
-			return nil, fmt.Errorf(
+			return fmt.Errorf(
 				"replay case %d: duplicate id %q",
 				i,
 				replayCase.ID,
 			)
 		}
 		ids[replayCase.ID] = struct{}{}
-		decodedCases = append(decodedCases, decoded)
 	}
-	return decodedCases, nil
+	return nil
 }
 
 func (c *Case) validate() (decodedCase, error) {

--- a/replay/corpus_test.go
+++ b/replay/corpus_test.go
@@ -1,0 +1,74 @@
+package replay
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/plutigo/cek"
+)
+
+func TestCorpusValidateRejectsSuccessfulResultWithErrorCode(t *testing.T) {
+	replayCase := successfulCase(t)
+	errorCode := cek.ErrCodeExplicitError
+	replayCase.Expected.ErrorCode = &errorCode
+
+	corpus := validCorpus(replayCase)
+	err := corpus.Validate()
+	if err == nil || !strings.Contains(
+		err.Error(),
+		"successful expected result cannot include an error code",
+	) {
+		t.Fatalf("Validate() error = %v, want contradictory-result error", err)
+	}
+}
+
+func TestCorpusValidateRejectsMalformedEncodedPayloads(t *testing.T) {
+	tests := []struct {
+		name      string
+		mutate    func(*Case)
+		wantError string
+	}{
+		{
+			name: "FLAT program",
+			mutate: func(replayCase *Case) {
+				replayCase.FlatProgramHex = "00"
+			},
+			wantError: "decode FLAT program",
+		},
+		{
+			name: "PlutusData argument",
+			mutate: func(replayCase *Case) {
+				replayCase.ArgumentsCBORHex = []string{"ff"}
+			},
+			wantError: "decode argument 0 PlutusData",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			replayCase := successfulCase(t)
+			tt.mutate(&replayCase)
+
+			corpus := validCorpus(replayCase)
+			encoded, err := json.Marshal(corpus)
+			if err != nil {
+				t.Fatalf("json.Marshal() failed: %v", err)
+			}
+			_, err = Load(bytes.NewReader(encoded))
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("Load() error = %v, want %q", err, tt.wantError)
+			}
+		})
+	}
+}
+
+func validCorpus(replayCase Case) *Corpus {
+	return &Corpus{
+		SchemaVersion: SchemaVersion,
+		Network:       "mainnet",
+		Reference:     testReference(),
+		Cases:         []Case{replayCase},
+	}
+}

--- a/replay/corpus_test.go
+++ b/replay/corpus_test.go
@@ -64,6 +64,30 @@ func TestCorpusValidateRejectsMalformedEncodedPayloads(t *testing.T) {
 	}
 }
 
+func FuzzLoadEncodedPayloads(f *testing.F) {
+	replayCase := successfulCase(f)
+	f.Add(replayCase.FlatProgramHex, replayCase.ArgumentsCBORHex[0])
+	f.Add("00", "ff")
+	f.Add("not-hex", "0")
+
+	f.Fuzz(func(t *testing.T, flatProgramHex, argumentCBORHex string) {
+		testCase := replayCase
+		testCase.FlatProgramHex = flatProgramHex
+		testCase.ArgumentsCBORHex = []string{argumentCBORHex}
+		encoded, err := json.Marshal(validCorpus(testCase))
+		if err != nil {
+			t.Fatalf("json.Marshal() failed: %v", err)
+		}
+
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				t.Fatalf("Load() panicked: %v", recovered)
+			}
+		}()
+		_, _ = Load(bytes.NewReader(encoded))
+	})
+}
+
 func validCorpus(replayCase Case) *Corpus {
 	return &Corpus{
 		SchemaVersion: SchemaVersion,

--- a/replay/replay_test.go
+++ b/replay/replay_test.go
@@ -94,9 +94,9 @@ func TestRunCaseUsesLedgerLanguageInsteadOfUPLCVersion(t *testing.T) {
 			Con: &syn.Data{Inner: data.NewInteger(big.NewInt(42))},
 		},
 	}
-	replayCase := baseCase(t, term, nil)
-	// baseCase encodes a UPLC 1.0.0 program. serialiseData is nevertheless
-	// valid when the ledger identifies that program as Plutus V2.
+	replayCase := baseCaseWithVersion(t, lang.LanguageVersionV2, term, nil)
+	// The UPLC header identifies this as a V2 program. The ledger language must
+	// still control builtin availability, so the same program is rejected as V1.
 	replayCase.Language = PlutusV2
 	v2Result := RunCase(&replayCase)
 	if !v2Result.Actual.Success {
@@ -227,8 +227,23 @@ func baseCase(
 	arguments []string,
 ) Case {
 	t.Helper()
+	return baseCaseWithVersion(
+		t,
+		lang.LanguageVersionV1,
+		term,
+		arguments,
+	)
+}
+
+func baseCaseWithVersion(
+	t *testing.T,
+	version lang.LanguageVersion,
+	term syn.Term[syn.DeBruijn],
+	arguments []string,
+) Case {
+	t.Helper()
 	program := &syn.Program[syn.DeBruijn]{
-		Version: lang.LanguageVersionV1,
+		Version: version,
 		Term:    term,
 	}
 	encoded, err := syn.Encode(program)

--- a/replay/replay_test.go
+++ b/replay/replay_test.go
@@ -60,6 +60,24 @@ func TestRunCaseMatchesSuccessAndBudget(t *testing.T) {
 	}
 }
 
+func BenchmarkRunCase(b *testing.B) {
+	replayCase := successfulCase(b)
+	first := RunCase(&replayCase)
+	if !first.Actual.Success {
+		b.Fatalf("RunCase() setup failed: %s", first.Actual.Error)
+	}
+	replayCase.Expected.ExUnits = first.Actual.ExUnits
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		result := RunCase(&replayCase)
+		if !result.Passed {
+			b.Fatalf("RunCase() mismatches = %v", result.Mismatches)
+		}
+	}
+}
+
 func TestRunCaseMatchesEvaluationFailure(t *testing.T) {
 	errorCode := cek.ErrCodeExplicitError
 	replayCase := baseCase(t, &syn.Error{}, nil)
@@ -82,6 +100,29 @@ func TestRunCaseMatchesEvaluationFailure(t *testing.T) {
 	result := RunCase(&replayCase)
 	if !result.Passed {
 		t.Fatalf("RunCase() mismatches = %v", result.Mismatches)
+	}
+}
+
+func TestEvaluateRecoversMachinePanic(t *testing.T) {
+	replayCase := baseCase(t, &syn.Error{}, nil)
+	decoded, err := replayCase.validate()
+	if err != nil {
+		t.Fatalf("validate() failed: %v", err)
+	}
+	decoded.program.Term = (*syn.Apply[syn.DeBruijn])(nil)
+
+	actual := evaluate(&replayCase, decoded)
+	if actual.Success {
+		t.Fatal("evaluate() unexpectedly succeeded")
+	}
+	if actual.SetupError {
+		t.Fatalf("evaluate() reported setup error: %s", actual.Error)
+	}
+	if !strings.Contains(actual.Error, "panic during script evaluation") {
+		t.Fatalf("evaluate() error = %q, want recovered panic", actual.Error)
+	}
+	if actual.ExUnits == (ExUnits{}) {
+		t.Fatal("evaluate() did not preserve consumed execution units")
 	}
 }
 
@@ -204,7 +245,7 @@ func testReference() Reference {
 	}
 }
 
-func successfulCase(t *testing.T) Case {
+func successfulCase(t testing.TB) Case {
 	t.Helper()
 	argument, err := data.Encode(data.NewInteger(big.NewInt(42)))
 	if err != nil {
@@ -222,7 +263,7 @@ func successfulCase(t *testing.T) Case {
 }
 
 func baseCase(
-	t *testing.T,
+	t testing.TB,
 	term syn.Term[syn.DeBruijn],
 	arguments []string,
 ) Case {
@@ -236,7 +277,7 @@ func baseCase(
 }
 
 func baseCaseWithVersion(
-	t *testing.T,
+	t testing.TB,
 	version lang.LanguageVersion,
 	term syn.Term[syn.DeBruijn],
 	arguments []string,

--- a/replay/replay_test.go
+++ b/replay/replay_test.go
@@ -1,0 +1,256 @@
+package replay
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/plutigo/builtin"
+	"github.com/blinklabs-io/plutigo/cek"
+	"github.com/blinklabs-io/plutigo/data"
+	"github.com/blinklabs-io/plutigo/lang"
+	"github.com/blinklabs-io/plutigo/syn"
+)
+
+func TestLoadRejectsUnknownFields(t *testing.T) {
+	input := `{
+		"schema_version": 1,
+		"network": "mainnet",
+		"cases": [],
+		"unknown": true
+	}`
+	_, err := Load(strings.NewReader(input))
+	if err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("Load() error = %v, want unknown-field error", err)
+	}
+}
+
+func TestCorpusValidateRejectsDuplicateIDs(t *testing.T) {
+	replayCase := successfulCase(t)
+	corpus := &Corpus{
+		SchemaVersion: SchemaVersion,
+		Network:       "mainnet",
+		Reference:     testReference(),
+		Cases:         []Case{replayCase, replayCase},
+	}
+	err := corpus.Validate()
+	if err == nil || !strings.Contains(err.Error(), "duplicate id") {
+		t.Fatalf("Validate() error = %v, want duplicate-id error", err)
+	}
+}
+
+func TestRunCaseMatchesSuccessAndBudget(t *testing.T) {
+	replayCase := successfulCase(t)
+	first := RunCase(&replayCase)
+	if !first.Actual.Success {
+		t.Fatalf("first RunCase() failed: %s", first.Actual.Error)
+	}
+	if first.Actual.ExUnits == (ExUnits{}) {
+		t.Fatal("first RunCase() consumed zero execution units")
+	}
+
+	replayCase.Expected.ExUnits = first.Actual.ExUnits
+	result := RunCase(&replayCase)
+	if !result.Passed {
+		t.Fatalf("RunCase() mismatches = %v", result.Mismatches)
+	}
+}
+
+func TestRunCaseMatchesEvaluationFailure(t *testing.T) {
+	errorCode := cek.ErrCodeExplicitError
+	replayCase := baseCase(t, &syn.Error{}, nil)
+	replayCase.ID = "tx-error#spend:0"
+	replayCase.Transaction.ID = "tx-error"
+	replayCase.Expected = Expected{
+		Success:   false,
+		ErrorCode: &errorCode,
+	}
+
+	first := RunCase(&replayCase)
+	if first.Actual.Success {
+		t.Fatal("first RunCase() unexpectedly succeeded")
+	}
+	if first.Actual.SetupError {
+		t.Fatalf("first RunCase() setup failed: %s", first.Actual.Error)
+	}
+	replayCase.Expected.ExUnits = first.Actual.ExUnits
+
+	result := RunCase(&replayCase)
+	if !result.Passed {
+		t.Fatalf("RunCase() mismatches = %v", result.Mismatches)
+	}
+}
+
+func TestRunCaseUsesLedgerLanguageInsteadOfUPLCVersion(t *testing.T) {
+	term := &syn.Apply[syn.DeBruijn]{
+		Function: &syn.Builtin{
+			DefaultFunction: builtin.SerialiseData,
+		},
+		Argument: &syn.Constant{
+			Con: &syn.Data{Inner: data.NewInteger(big.NewInt(42))},
+		},
+	}
+	replayCase := baseCase(t, term, nil)
+	// baseCase encodes a UPLC 1.0.0 program. serialiseData is nevertheless
+	// valid when the ledger identifies that program as Plutus V2.
+	replayCase.Language = PlutusV2
+	v2Result := RunCase(&replayCase)
+	if !v2Result.Actual.Success {
+		t.Fatalf("Plutus V2 evaluation failed: %s", v2Result.Actual.Error)
+	}
+
+	replayCase.Language = PlutusV1
+	v1Result := RunCase(&replayCase)
+	if v1Result.Actual.Success {
+		t.Fatal("Plutus V1 evaluation unexpectedly accepted a V2 builtin")
+	}
+	if v1Result.Actual.SetupError {
+		t.Fatalf("Plutus V1 evaluation setup failed: %s", v1Result.Actual.Error)
+	}
+}
+
+func TestRunCaseNeverTreatsSetupFailureAsExpectedScriptFailure(t *testing.T) {
+	replayCase := successfulCase(t)
+	replayCase.FlatProgramHex = "00"
+	replayCase.Expected.Success = false
+	replayCase.Expected.ExUnits = ExUnits{}
+
+	result := RunCase(&replayCase)
+	if result.Passed {
+		t.Fatal("RunCase() passed an invalid FLAT program as an expected failure")
+	}
+	if !result.Actual.SetupError {
+		t.Fatalf("RunCase() actual = %+v, want setup error", result.Actual)
+	}
+}
+
+func TestRunBuildsSummary(t *testing.T) {
+	first := successfulCase(t)
+	firstResult := RunCase(&first)
+	first.Expected.ExUnits = firstResult.Actual.ExUnits
+
+	second := first
+	second.ID = "tx-2#spend:0"
+	second.Transaction.ID = "tx-2"
+
+	corpus := &Corpus{
+		SchemaVersion: SchemaVersion,
+		Network:       "mainnet",
+		Reference:     testReference(),
+		Cases:         []Case{first, second},
+	}
+	report, err := Run(context.Background(), corpus)
+	if err != nil {
+		t.Fatalf("Run() failed: %v", err)
+	}
+	if report.Summary.Total != 2 ||
+		report.Summary.Passed != 2 ||
+		report.Summary.Failed != 0 {
+		t.Fatalf("Run() summary = %+v", report.Summary)
+	}
+	if report.Summary.TotalDurationNS <= 0 ||
+		report.Summary.TransactionsPerSecond <= 0 {
+		t.Fatalf("Run() timing summary = %+v", report.Summary)
+	}
+}
+
+func TestRunHonorsCanceledContext(t *testing.T) {
+	replayCase := successfulCase(t)
+	corpus := &Corpus{
+		SchemaVersion: SchemaVersion,
+		Network:       "mainnet",
+		Reference:     testReference(),
+		Cases:         []Case{replayCase},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := Run(ctx, corpus)
+	if err == nil || !strings.Contains(err.Error(), "context canceled") {
+		t.Fatalf("Run() error = %v, want context cancellation", err)
+	}
+}
+
+func TestLoadRoundTrip(t *testing.T) {
+	replayCase := successfulCase(t)
+	input := Corpus{
+		SchemaVersion: SchemaVersion,
+		Network:       "mainnet",
+		Reference:     testReference(),
+		Cases:         []Case{replayCase},
+	}
+	encoded, err := json.Marshal(input)
+	if err != nil {
+		t.Fatalf("json.Marshal() failed: %v", err)
+	}
+
+	loaded, err := Load(bytes.NewReader(encoded))
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+	if loaded.Cases[0].ID != replayCase.ID {
+		t.Fatalf("Load() case id = %q, want %q", loaded.Cases[0].ID, replayCase.ID)
+	}
+}
+
+func testReference() Reference {
+	return Reference{
+		Implementation: "cardano-node",
+		Version:        "10.14.0.0",
+	}
+}
+
+func successfulCase(t *testing.T) Case {
+	t.Helper()
+	argument, err := data.Encode(data.NewInteger(big.NewInt(42)))
+	if err != nil {
+		t.Fatalf("data.Encode() failed: %v", err)
+	}
+	term := &syn.Lambda[syn.DeBruijn]{
+		ParameterName: syn.DeBruijn(0),
+		Body: &syn.Var[syn.DeBruijn]{
+			Name: syn.DeBruijn(1),
+		},
+	}
+	replayCase := baseCase(t, term, []string{hex.EncodeToString(argument)})
+	replayCase.Expected.Success = true
+	return replayCase
+}
+
+func baseCase(
+	t *testing.T,
+	term syn.Term[syn.DeBruijn],
+	arguments []string,
+) Case {
+	t.Helper()
+	program := &syn.Program[syn.DeBruijn]{
+		Version: lang.LanguageVersionV1,
+		Term:    term,
+	}
+	encoded, err := syn.Encode(program)
+	if err != nil {
+		t.Fatalf("syn.Encode() failed: %v", err)
+	}
+	return Case{
+		ID: "tx-1#spend:0",
+		Transaction: TransactionRef{
+			ID:       "tx-1",
+			Redeemer: "spend:0",
+		},
+		Language:         PlutusV1,
+		ProtocolVersion:  ProtocolVersion{Major: 10},
+		FlatProgramHex:   hex.EncodeToString(encoded),
+		ArgumentsCBORHex: arguments,
+		CostModel: CostModel{
+			UseDefault: true,
+		},
+		BudgetLimit: ExUnits{
+			Steps:  10_000_000_000,
+			Memory: 14_000_000,
+		},
+	}
+}

--- a/replay/runner.go
+++ b/replay/runner.go
@@ -1,0 +1,258 @@
+package replay
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/blinklabs-io/plutigo/cek"
+	"github.com/blinklabs-io/plutigo/data"
+	"github.com/blinklabs-io/plutigo/syn"
+)
+
+type Report struct {
+	SchemaVersion int          `json:"schema_version"`
+	Network       string       `json:"network"`
+	Reference     Reference    `json:"reference"`
+	Cases         []CaseResult `json:"cases"`
+	Summary       Summary      `json:"summary"`
+}
+
+type CaseResult struct {
+	ID          string         `json:"id"`
+	Transaction TransactionRef `json:"transaction"`
+	Passed      bool           `json:"passed"`
+	Actual      Actual         `json:"actual"`
+	DurationNS  int64          `json:"duration_ns"`
+	Mismatches  []string       `json:"mismatches,omitempty"`
+}
+
+type Actual struct {
+	Success    bool           `json:"success"`
+	ExUnits    ExUnits        `json:"ex_units"`
+	SetupError bool           `json:"setup_error,omitempty"`
+	Error      string         `json:"error,omitempty"`
+	ErrorCode  *cek.ErrorCode `json:"error_code,omitempty"`
+}
+
+type Summary struct {
+	Total                 int     `json:"total"`
+	Passed                int     `json:"passed"`
+	Failed                int     `json:"failed"`
+	TotalDurationNS       int64   `json:"total_duration_ns"`
+	MedianDurationNS      int64   `json:"median_duration_ns"`
+	P95DurationNS         int64   `json:"p95_duration_ns"`
+	TransactionsPerSecond float64 `json:"transactions_per_second"`
+}
+
+func Run(ctx context.Context, corpus *Corpus) (*Report, error) {
+	if err := corpus.Validate(); err != nil {
+		return nil, err
+	}
+
+	report := &Report{
+		SchemaVersion: SchemaVersion,
+		Network:       corpus.Network,
+		Reference:     corpus.Reference,
+		Cases:         make([]CaseResult, 0, len(corpus.Cases)),
+	}
+	durations := make([]int64, 0, len(corpus.Cases))
+
+	for i := range corpus.Cases {
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("run replay corpus: %w", err)
+		}
+
+		result := RunCase(&corpus.Cases[i])
+		report.Cases = append(report.Cases, result)
+		durations = append(durations, result.DurationNS)
+		report.Summary.TotalDurationNS += result.DurationNS
+		if result.Passed {
+			report.Summary.Passed++
+		}
+	}
+
+	report.Summary.Total = len(report.Cases)
+	report.Summary.Failed = report.Summary.Total - report.Summary.Passed
+	report.Summary.MedianDurationNS = percentile(durations, 50)
+	report.Summary.P95DurationNS = percentile(durations, 95)
+	if report.Summary.TotalDurationNS > 0 {
+		duration := time.Duration(report.Summary.TotalDurationNS)
+		report.Summary.TransactionsPerSecond = float64(report.Summary.Total) /
+			duration.Seconds()
+	}
+	return report, nil
+}
+
+func RunCase(replayCase *Case) CaseResult {
+	if replayCase == nil {
+		actual := setupFailure(errors.New("replay case is required"))
+		return CaseResult{
+			Actual:     actual,
+			Mismatches: compare(Expected{}, actual),
+		}
+	}
+	result := CaseResult{
+		ID:          replayCase.ID,
+		Transaction: replayCase.Transaction,
+	}
+	start := time.Now()
+	if err := replayCase.validate(); err != nil {
+		result.Actual = setupFailure(err)
+	} else {
+		result.Actual = evaluate(replayCase)
+	}
+	result.DurationNS = time.Since(start).Nanoseconds()
+	result.Mismatches = compare(replayCase.Expected, result.Actual)
+	result.Passed = len(result.Mismatches) == 0
+	return result
+}
+
+func evaluate(replayCase *Case) Actual {
+	flatProgram, err := decodeHex("flat program", replayCase.FlatProgramHex)
+	if err != nil {
+		return setupFailure(err)
+	}
+	program, err := syn.Decode[syn.DeBruijn](flatProgram)
+	if err != nil {
+		return setupFailure(fmt.Errorf("decode FLAT program: %w", err))
+	}
+	languageVersion, err := replayCase.Language.Version()
+	if err != nil {
+		return setupFailure(err)
+	}
+
+	term := program.Term
+	for i, encodedArg := range replayCase.ArgumentsCBORHex {
+		argCBOR, err := decodeHex(fmt.Sprintf("argument %d CBOR", i), encodedArg)
+		if err != nil {
+			return setupFailure(err)
+		}
+		arg, err := data.Decode(argCBOR)
+		if err != nil {
+			return setupFailure(fmt.Errorf("decode argument %d PlutusData: %w", i, err))
+		}
+		term = &syn.Apply[syn.DeBruijn]{
+			Function: term,
+			Argument: &syn.Constant{
+				Con: &syn.Data{Inner: arg},
+			},
+		}
+	}
+
+	protoVersion := cek.ProtoVersion{
+		Major: replayCase.ProtocolVersion.Major,
+		Minor: replayCase.ProtocolVersion.Minor,
+	}
+	var evalContext *cek.EvalContext
+	if replayCase.CostModel.UseDefault {
+		evalContext = cek.NewDefaultEvalContext(languageVersion, protoVersion)
+	} else {
+		evalContext, err = cek.NewEvalContext(
+			languageVersion,
+			protoVersion,
+			replayCase.CostModel.Parameters,
+		)
+		if err != nil {
+			return setupFailure(fmt.Errorf("build evaluation context: %w", err))
+		}
+	}
+
+	initialBudget := cek.ExBudget{
+		Cpu: replayCase.BudgetLimit.Steps,
+		Mem: replayCase.BudgetLimit.Memory,
+	}
+	machine := cek.NewMachine[syn.DeBruijn](
+		languageVersion,
+		0,
+		evalContext,
+	)
+	machine.ExBudget = initialBudget
+	_, evalErr := machine.Run(term)
+	consumed := initialBudget.Sub(&machine.ExBudget)
+
+	actual := Actual{
+		Success: evalErr == nil,
+		ExUnits: ExUnits{
+			Steps:  consumed.Cpu,
+			Memory: consumed.Mem,
+		},
+	}
+	if evalErr != nil {
+		actual.Error = evalErr.Error()
+		if code, ok := cek.GetErrorCode(evalErr); ok {
+			actual.ErrorCode = &code
+		}
+	}
+	return actual
+}
+
+func setupFailure(err error) Actual {
+	return Actual{
+		Success:    false,
+		SetupError: true,
+		Error:      "replay setup: " + err.Error(),
+	}
+}
+
+func compare(expected Expected, actual Actual) []string {
+	var mismatches []string
+	if actual.SetupError {
+		mismatches = append(mismatches, actual.Error)
+	}
+	if actual.Success != expected.Success {
+		mismatches = append(
+			mismatches,
+			fmt.Sprintf(
+				"success: got %t, want %t",
+				actual.Success,
+				expected.Success,
+			),
+		)
+	}
+	if actual.ExUnits != expected.ExUnits {
+		mismatches = append(
+			mismatches,
+			fmt.Sprintf(
+				"ex_units: got steps=%d memory=%d, want steps=%d memory=%d",
+				actual.ExUnits.Steps,
+				actual.ExUnits.Memory,
+				expected.ExUnits.Steps,
+				expected.ExUnits.Memory,
+			),
+		)
+	}
+	if expected.ErrorCode != nil {
+		if actual.ErrorCode == nil {
+			mismatches = append(
+				mismatches,
+				fmt.Sprintf("error_code: got none, want %d", *expected.ErrorCode),
+			)
+		} else if *actual.ErrorCode != *expected.ErrorCode {
+			mismatches = append(
+				mismatches,
+				fmt.Sprintf(
+					"error_code: got %d, want %d",
+					*actual.ErrorCode,
+					*expected.ErrorCode,
+				),
+			)
+		}
+	}
+	return mismatches
+}
+
+func percentile(values []int64, percentage int) int64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sorted := slices.Clone(values)
+	slices.Sort(sorted)
+	index := ((len(sorted) * percentage) + 99) / 100
+	if index == 0 {
+		return sorted[0]
+	}
+	return sorted[index-1]
+}

--- a/replay/runner.go
+++ b/replay/runner.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/plutigo/cek"
-	"github.com/blinklabs-io/plutigo/data"
 	"github.com/blinklabs-io/plutigo/syn"
 )
 
@@ -48,7 +47,8 @@ type Summary struct {
 }
 
 func Run(ctx context.Context, corpus *Corpus) (*Report, error) {
-	if err := corpus.Validate(); err != nil {
+	decodedCases, err := corpus.validate()
+	if err != nil {
 		return nil, err
 	}
 
@@ -65,7 +65,7 @@ func Run(ctx context.Context, corpus *Corpus) (*Report, error) {
 			return nil, fmt.Errorf("run replay corpus: %w", err)
 		}
 
-		result := RunCase(&corpus.Cases[i])
+		result := runDecodedCase(&corpus.Cases[i], decodedCases[i])
 		report.Cases = append(report.Cases, result)
 		durations = append(durations, result.DurationNS)
 		report.Summary.TotalDurationNS += result.DurationNS
@@ -94,50 +94,44 @@ func RunCase(replayCase *Case) CaseResult {
 			Mismatches: compare(Expected{}, actual),
 		}
 	}
+	decoded, err := replayCase.validate()
+	if err != nil {
+		actual := setupFailure(err)
+		return CaseResult{
+			ID:          replayCase.ID,
+			Transaction: replayCase.Transaction,
+			Actual:      actual,
+			Mismatches:  compare(replayCase.Expected, actual),
+		}
+	}
+	return runDecodedCase(replayCase, decoded)
+}
+
+func runDecodedCase(replayCase *Case, decoded decodedCase) CaseResult {
 	result := CaseResult{
 		ID:          replayCase.ID,
 		Transaction: replayCase.Transaction,
 	}
 	start := time.Now()
-	if err := replayCase.validate(); err != nil {
-		result.Actual = setupFailure(err)
-	} else {
-		result.Actual = evaluate(replayCase)
-	}
+	result.Actual = evaluate(replayCase, decoded)
 	result.DurationNS = time.Since(start).Nanoseconds()
 	result.Mismatches = compare(replayCase.Expected, result.Actual)
 	result.Passed = len(result.Mismatches) == 0
 	return result
 }
 
-func evaluate(replayCase *Case) Actual {
-	flatProgram, err := decodeHex("flat program", replayCase.FlatProgramHex)
-	if err != nil {
-		return setupFailure(err)
-	}
-	program, err := syn.Decode[syn.DeBruijn](flatProgram)
-	if err != nil {
-		return setupFailure(fmt.Errorf("decode FLAT program: %w", err))
-	}
+func evaluate(replayCase *Case, decoded decodedCase) Actual {
 	languageVersion, err := replayCase.Language.Version()
 	if err != nil {
 		return setupFailure(err)
 	}
 
-	term := program.Term
-	for i, encodedArg := range replayCase.ArgumentsCBORHex {
-		argCBOR, err := decodeHex(fmt.Sprintf("argument %d CBOR", i), encodedArg)
-		if err != nil {
-			return setupFailure(err)
-		}
-		arg, err := data.Decode(argCBOR)
-		if err != nil {
-			return setupFailure(fmt.Errorf("decode argument %d PlutusData: %w", i, err))
-		}
+	term := decoded.program.Term
+	for _, argument := range decoded.arguments {
 		term = &syn.Apply[syn.DeBruijn]{
 			Function: term,
 			Argument: &syn.Constant{
-				Con: &syn.Data{Inner: arg},
+				Con: &syn.Data{Inner: argument},
 			},
 		}
 	}
@@ -170,7 +164,7 @@ func evaluate(replayCase *Case) Actual {
 		evalContext,
 	)
 	machine.ExBudget = initialBudget
-	_, evalErr := machine.Run(term)
+	evalErr := runMachine(machine, term)
 	consumed := initialBudget.Sub(&machine.ExBudget)
 
 	actual := Actual{
@@ -187,6 +181,19 @@ func evaluate(replayCase *Case) Actual {
 		}
 	}
 	return actual
+}
+
+func runMachine(
+	machine *cek.Machine[syn.DeBruijn],
+	term syn.Term[syn.DeBruijn],
+) (err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("panic during script evaluation: %v", recovered)
+		}
+	}()
+	_, err = machine.Run(term)
+	return err
 }
 
 func setupFailure(err error) Actual {

--- a/replay/runner.go
+++ b/replay/runner.go
@@ -47,8 +47,7 @@ type Summary struct {
 }
 
 func Run(ctx context.Context, corpus *Corpus) (*Report, error) {
-	decodedCases, err := corpus.validate()
-	if err != nil {
+	if err := corpus.validate(); err != nil {
 		return nil, err
 	}
 
@@ -65,7 +64,12 @@ func Run(ctx context.Context, corpus *Corpus) (*Report, error) {
 			return nil, fmt.Errorf("run replay corpus: %w", err)
 		}
 
-		result := runDecodedCase(&corpus.Cases[i], decodedCases[i])
+		replayCase := &corpus.Cases[i]
+		decoded, err := replayCase.validate()
+		if err != nil {
+			return nil, fmt.Errorf("replay case %d: %w", i, err)
+		}
+		result := runDecodedCase(replayCase, decoded)
 		report.Cases = append(report.Cases, result)
 		durations = append(durations, result.DurationNS)
 		report.Summary.TotalDurationNS += result.DurationNS


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `plutigo-replay`, a CLI to replay normalized mainnet Plutus validation cases and check parity with `cardano-node`. Ships a v1 corpus, a runner that compares pass/fail and ExUnits, and a JSON report with per-case timing and aggregate metrics.

- **New Features**
  - CLI `plutigo-replay`: run with `-corpus` (optional `-pretty`), writes JSON to stdout. Exit codes: 0 (all match), 1 (mismatches), 2 (invalid corpus/error). Supports `-h/--help` and signal-aware cancellation.
  - Corpus schema v1: ledger `language`, raw FLAT program hex, ordered `arguments_cbor_hex`, protocol version, cost model (`use_default` or parameter array), budget limit, expected success/ExUnits/optional `error_code`, optional metadata and tx refs.
  - Runner and docs: evaluates with the ledger language and protocol version, applies args in order, matches success/ExUnits/optional error code; reports per-case duration plus median, p95, and TPS. Adds `replay/README.md` and updates root `README` to clarify language/cost-model selection.

- **Bug Fixes**
  - Strict corpus parsing: rejects unknown fields and trailing JSON; enforces unique case IDs, positive budgets, non-negative expected units, expected ≤ budget; validates exclusive cost-model selection.
  - Robust execution: recovers evaluation panics while preserving consumed units; never treats setup failures as expected script failures; clearer errors; help exits 0; canceled contexts return code 2.

<sup>Written for commit cee85b5db852740b094cb8a37a7efc8340a7e5f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/plutigo/pull/350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `plutigo-replay` for running normalized Plutus replay corpora and generating JSON reports.
  * Added corpus validation for transaction metadata, programs, arguments, cost models, budgets, and expected results.
  * Reports include per-case outcomes, execution units, failures, timing statistics, and summary metrics.
  * Added configurable formatting and meaningful exit codes for success, mismatches, and errors.

* **Documentation**
  * Added replay corpus schema, workflow, reporting, and collection guidance.
  * Clarified ledger language and cost-model selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->