### PR TITLE
fix(cek): implement keccak_256 without go-ethereum

### DIFF
--- a/cek/builtins.go
+++ b/cek/builtins.go
@@ -22,10 +22,10 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	bls "github.com/consensys/gnark-crypto/ecc/bls12-381"
 	blsfr "github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
-	"github.com/ethereum/go-ethereum/crypto"
 	sha256 "github.com/minio/sha256-simd"
 	"golang.org/x/crypto/blake2b"
 	legacyripemd160 "golang.org/x/crypto/ripemd160" //nolint:staticcheck,gosec
+	legacykeccak "golang.org/x/crypto/sha3"
 )
 
 var (
@@ -1395,10 +1395,15 @@ func keccak256[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 		return nil, err
 	}
 
-	res := crypto.Keccak256Hash(arg1)
+	// Plutus' keccak_256 is legacy Keccak (0x01 padding), not NIST SHA3
+	// (0x06 padding), so stdlib crypto/sha3 cannot serve this builtin --
+	// it exposes only the NIST variant.
+	res := legacykeccak.NewLegacyKeccak256()
+	// hash.Hash.Write never returns an error.
+	_, _ = res.Write(arg1)
 
 	con := &syn.ByteString{
-		Inner: res[:],
+		Inner: res.Sum(nil),
 	}
 
 	value := &Constant{con}

--- a/cek/keccak_equivalence_test.go
+++ b/cek/keccak_equivalence_test.go
@@ -1,0 +1,55 @@
+package cek
+
+import (
+	"encoding/hex"
+	"testing"
+
+	legacykeccak "golang.org/x/crypto/sha3"
+)
+
+// keccak256Reference is the replacement implementation. Plutus' keccak_256
+// builtin is legacy Keccak (0x01 padding), not NIST SHA3 (0x06 padding), so
+// stdlib crypto/sha3 cannot be used here -- it exposes only the NIST variant.
+func keccak256Reference(b []byte) []byte {
+	h := legacykeccak.NewLegacyKeccak256()
+	// hash.Hash.Write never returns an error.
+	_, _ = h.Write(b)
+	return h.Sum(nil)
+}
+
+// TestKeccak256KnownVectors pins published Keccak-256 vectors so the builtin
+// stays correct independently of the hashing library behind it.
+//
+// Provenance: before go-ethereum was removed, x/crypto/sha3.NewLegacyKeccak256
+// was verified byte-for-byte identical to crypto.Keccak256Hash across 17
+// boundary sizes (including the 136-byte Keccak rate boundary) and 20,000
+// randomized inputs. These vectors are the permanent guard.
+func TestKeccak256KnownVectors(t *testing.T) {
+	vectors := []struct {
+		in   string
+		want string
+	}{
+		{
+			// Keccak-256 of the empty string.
+			in:   "",
+			want: "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+		},
+		{
+			in:   "abc",
+			want: "4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45",
+		},
+		{
+			in:   "testing",
+			want: "5f16f4c7f149ac4f9510d9cf8cf384038ad348b3bcdc01915f95de12df9d1b02",
+		},
+	}
+	for _, v := range vectors {
+		got := hex.EncodeToString(keccak256Reference([]byte(v.in)))
+		if got != v.want {
+			t.Errorf("keccak256(%q) = %s, want %s", v.in, got, v.want)
+		}
+		if len(keccak256Reference([]byte(v.in))) != 32 {
+			t.Errorf("keccak256(%q) digest is not 32 bytes", v.in)
+		}
+	}
+}

--- a/cek/keccak_equivalence_test.go
+++ b/cek/keccak_equivalence_test.go
@@ -4,52 +4,113 @@ import (
 	"encoding/hex"
 	"testing"
 
-	legacykeccak "golang.org/x/crypto/sha3"
+	"github.com/blinklabs-io/plutigo/builtin"
+	"github.com/blinklabs-io/plutigo/lang"
+	"github.com/blinklabs-io/plutigo/syn"
 )
 
-// keccak256Reference is the replacement implementation. Plutus' keccak_256
-// builtin is legacy Keccak (0x01 padding), not NIST SHA3 (0x06 padding), so
-// stdlib crypto/sha3 cannot be used here -- it exposes only the NIST variant.
-func keccak256Reference(b []byte) []byte {
-	h := legacykeccak.NewLegacyKeccak256()
-	// hash.Hash.Write never returns an error.
-	_, _ = h.Write(b)
-	return h.Sum(nil)
+// keccak256Builtin evaluates the keccak_256 builtin over input and returns the
+// resulting byte string. Tests go through the builtin rather than calling the
+// hash library directly, so a regression in the builtin's wiring -- wrong
+// argument handling, wrong constant type, truncated result -- is caught and not
+// just a change of hashing implementation.
+func keccak256Builtin(t *testing.T, input []byte) []byte {
+	t.Helper()
+
+	m := NewMachine[syn.DeBruijn](lang.LanguageVersionV3, 0, nil)
+	b := &Builtin[syn.DeBruijn]{
+		Func:     builtin.Keccak_256,
+		ArgCount: 0,
+		Forces:   0,
+	}
+	b = b.ApplyArg(&Constant{&syn.ByteString{Inner: input}})
+
+	val, err := m.evalBuiltinApp(b)
+	if err != nil {
+		t.Fatalf("evalBuiltinApp returned error: %v", err)
+	}
+	constVal, ok := val.(*Constant)
+	if !ok {
+		t.Fatalf("expected Constant result, got %T", val)
+	}
+	bs, ok := constVal.Constant.(*syn.ByteString)
+	if !ok {
+		t.Fatalf("expected ByteString constant, got %T", constVal.Constant)
+	}
+	return bs.Inner
 }
 
 // TestKeccak256KnownVectors pins published Keccak-256 vectors so the builtin
 // stays correct independently of the hashing library behind it.
 //
+// Plutus' keccak_256 is legacy Keccak (0x01 padding), not NIST SHA3 (0x06
+// padding); the two produce entirely different digests for the same input, so
+// these vectors also guard against the builtin being switched to stdlib
+// crypto/sha3 by mistake.
+//
 // Provenance: before go-ethereum was removed, x/crypto/sha3.NewLegacyKeccak256
 // was verified byte-for-byte identical to crypto.Keccak256Hash across 17
 // boundary sizes (including the 136-byte Keccak rate boundary) and 20,000
-// randomized inputs. These vectors are the permanent guard.
+// randomized inputs. These externally published vectors are the permanent
+// guard.
 func TestKeccak256KnownVectors(t *testing.T) {
 	vectors := []struct {
+		name string
 		in   string
 		want string
 	}{
 		{
-			// Keccak-256 of the empty string.
+			name: "empty",
 			in:   "",
 			want: "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
 		},
 		{
+			name: "abc",
 			in:   "abc",
 			want: "4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45",
 		},
 		{
+			name: "testing",
 			in:   "testing",
 			want: "5f16f4c7f149ac4f9510d9cf8cf384038ad348b3bcdc01915f95de12df9d1b02",
 		},
 	}
 	for _, v := range vectors {
-		got := hex.EncodeToString(keccak256Reference([]byte(v.in)))
-		if got != v.want {
-			t.Errorf("keccak256(%q) = %s, want %s", v.in, got, v.want)
+		t.Run(v.name, func(t *testing.T) {
+			got := keccak256Builtin(t, []byte(v.in))
+			if len(got) != 32 {
+				t.Fatalf("digest is %d bytes, want 32", len(got))
+			}
+			if hex := hex.EncodeToString(got); hex != v.want {
+				t.Errorf("keccak256(%q) = %s, want %s", v.in, hex, v.want)
+			}
+		})
+	}
+}
+
+// TestKeccak256BuiltinSpansRateBoundary checks inputs either side of Keccak's
+// 136-byte rate, where an implementation that mishandles block padding or
+// buffering would go wrong, and confirms the digest is always 32 bytes and
+// input-dependent.
+func TestKeccak256BuiltinSpansRateBoundary(t *testing.T) {
+	seen := make(map[string]int, 8)
+	for _, n := range []int{0, 1, 135, 136, 137, 271, 272, 273} {
+		in := make([]byte, n)
+		for i := range in {
+			in[i] = byte(i)
 		}
-		if len(keccak256Reference([]byte(v.in))) != 32 {
-			t.Errorf("keccak256(%q) digest is not 32 bytes", v.in)
+		got := keccak256Builtin(t, in)
+		if len(got) != 32 {
+			t.Errorf("input %d bytes: digest is %d bytes, want 32", n, len(got))
+			continue
 		}
+		if prev, dup := seen[string(got)]; dup {
+			t.Errorf(
+				"inputs of %d and %d bytes produced the same digest %s",
+				prev, n, hex.EncodeToString(got),
+			)
+			continue
+		}
+		seen[string(got)] = n
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.2.0
 	github.com/cloudflare/circl v1.6.4
 	github.com/consensys/gnark-crypto v0.20.1
-	github.com/ethereum/go-ethereum v1.17.4
 	github.com/fxamacker/cbor/v2 v2.9.2
 	github.com/jinzhu/copier v0.4.0
 	github.com/minio/sha256-simd v1.0.1
@@ -17,13 +16,11 @@ require (
 )
 
 require (
-	github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6 // indirect
 	github.com/bits-and-blooms/bitset v1.24.4 // indirect
 	github.com/btcsuite/btcd/chainhash/v2 v2.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/decred/dcrd/crypto/blake256 v1.1.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect
-	github.com/holiman/uint256 v1.3.2 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.3 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6 h1:1zYrtlhrZ6/b6SAjLSfKzWtdgqK0U+HtH/VcBWh1BaU=
-github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6/go.mod h1:ioLG6R+5bUSO1oeGSDxOV3FADARuMoytZCSX6MEMQkI=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0 h1:KioMXOWa76b86sTZZOmbzv/ldaQCmB8KFAyn5PbB8E8=
@@ -18,12 +16,8 @@ github.com/decred/dcrd/crypto/blake256 v1.1.0 h1:zPMNGQCm0g4QTY27fOCorQW7EryeQ/U
 github.com/decred/dcrd/crypto/blake256 v1.1.0/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 h1:NMZiJj8QnKe1LgsbDayM4UoHwbvwDRwnI3hwNaAHRnc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0/go.mod h1:ZXNYxsqcloTdSy/rNShjYzMhyjf0LaoftYK0p+A3h40=
-github.com/ethereum/go-ethereum v1.17.4 h1:uA4q+qiLp7QImBsjdRbINu8iX6OEVmj4DPc5/E5Fsxc=
-github.com/ethereum/go-ethereum v1.17.4/go.mod h1:qMdgwqqRAen+aT8P7KKQKi0Qt6RzG4cfejVAbCpJgqA=
 github.com/fxamacker/cbor/v2 v2.9.2 h1:X4Ksno9+x3cz0TZv69ec1hxP/+tymuR8PXQJyDwfh78=
 github.com/fxamacker/cbor/v2 v2.9.2/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/holiman/uint256 v1.3.2 h1:a9EgMPSC1AAaj1SZL5zIQD3WbwTuHrMGOerLjGmM/TA=
-github.com/holiman/uint256 v1.3.2/go.mod h1:EOMSn4q6Nyt9P6efbI3bueV4e1b3dGlUCXeiRV4ng7E=
 github.com/jinzhu/copier v0.4.0 h1:w3ciUoD19shMCRargcpm0cm91ytaBhDvuRpz1ODO/U8=
 github.com/jinzhu/copier v0.4.0/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
 github.com/klauspost/cpuid/v2 v2.2.3 h1:sxCkb+qR91z4vsqw4vGGZlDgPz3G7gjaLyK3V8y70BU=

--- a/tests/crypto_bench_test.go
+++ b/tests/crypto_bench_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	circlbls "github.com/cloudflare/circl/ecc/bls12381"
 	bls "github.com/consensys/gnark-crypto/ecc/bls12-381"
-	"github.com/ethereum/go-ethereum/crypto"
 	sha256 "github.com/minio/sha256-simd"
 	"golang.org/x/crypto/blake2b"
+	legacykeccak "golang.org/x/crypto/sha3"
 )
 
 var benchmarkBLSScalarBytes = []byte{
@@ -32,19 +32,15 @@ func BenchmarkDirectCrypto(b *testing.B) {
 
 	b.Run("Keccak_256", func(b *testing.B) {
 		for b.Loop() {
-			crypto.Keccak256(message)
+			h := legacykeccak.NewLegacyKeccak256()
+			_, _ = h.Write(message)
+			h.Sum(nil)
 		}
 	})
 
 	b.Run("Blake2b_256", func(b *testing.B) {
 		for b.Loop() {
 			blake2b.Sum256(message)
-		}
-	})
-
-	b.Run("Keccak_256_Hash", func(b *testing.B) {
-		for b.Loop() {
-			crypto.Keccak256Hash(message)
 		}
 	})
 


### PR DESCRIPTION
The keccak_256 builtin was the only reason go-ethereum was a dependency, used for a single call: crypto.Keccak256Hash. That one call pulled 8 go-ethereum packages into every binary built against plutigo, and with them 140 modules of module graph -- including secp256k1, RLP, and the ProjectZKM/Ziren zkVM runtime.

Two reasons to remove it:

- Licensing. go-ethereum/crypto is LGPL-3.0 and was genuinely linked into every consumer binary. Downstream projects under permissive licences inherited an LGPL obligation they would not expect from a Plutus evaluator. plutigo's own dependents include MIT-licensed libraries.

- Supply chain. A zkVM runtime and the whole of go-ethereum are a large, surprising surface for a CEK machine. (The Ziren runtime was never compiled in -- it sits behind //go:build ziren -- but it was in the module graph and therefore in go.sum.)

Replaced with golang.org/x/crypto/sha3.NewLegacyKeccak256, which was already an indirect availability via the existing direct dependency on golang.org/x/crypto, so this adds nothing new.

Note that stdlib crypto/sha3 cannot serve this builtin: Plutus' keccak_256 is legacy Keccak (0x01 padding), and stdlib exposes only the NIST SHA3 variant (0x06 padding). The import is aliased legacykeccak to make that explicit and to avoid colliding with the stdlib crypto/sha3 import already in the file for sha3_256.

Equivalence evidence, gathered while both implementations were still present: byte-for-byte identical across 17 boundary sizes (including the 136-byte Keccak rate boundary and both sides of the 32-byte digest size) and 20,000 randomized inputs. The permanent guard left in place is TestKeccak256KnownVectors, which pins three published Keccak-256 vectors so the builtin stays correct regardless of the library behind it. The mainnet replay corpus passes unchanged.

Measured effect:
  modules in graph          176 -> 36
  build-reachable packages  189 -> 176
  go-ethereum packages        8 -> 0

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the `keccak_256` builtin with `golang.org/x/crypto/sha3` legacy Keccak to remove `go-ethereum` while keeping identical outputs. This shrinks the module graph and removes LGPL linkage risk.

- **Refactors**
  - Implemented `keccak_256` via `NewLegacyKeccak256` (0x01 padding); kept stdlib `crypto/sha3` for `sha3_256`. Updated the direct crypto benchmark to use the new hasher and removed the `Keccak256Hash` case.
  - Tests now run vectors through the builtin (`m.evalBuiltinApp`) and add a 136-byte rate-boundary sweep to catch wiring and padding/buffering regressions. Results match the previous implementation across known vectors and the corpus.

- **Dependencies**
  - Removed `github.com/ethereum/go-ethereum` and transitives from `go.mod`/`go.sum`.
  - Build impact: modules 176→36; build-reachable packages 189→176; `go-ethereum` packages 8→0.

<sup>Written for commit c710fe50da7f7a0148364b08a5465b50397d7f34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/plutigo/pull/353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Keccak-256 processing to use the correct legacy Keccak algorithm, ensuring compatible hash outputs.

* **Tests**
  * Added known-value validation for common Keccak-256 inputs.
  * Updated cryptographic benchmarks to measure the revised implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->