### PR TITLE
test: address decoder reuse review feedback

### DIFF
--- a/data/data_test.go
+++ b/data/data_test.go
@@ -570,36 +570,59 @@ func assertDecodeLimitError(t *testing.T, err error, limit string) {
 }
 
 func TestDecoderResetOverwritesRetainedBigInts(t *testing.T) {
-	decoder := NewDecoder()
+	tests := []struct {
+		name       string
+		inputLarge *big.Int
+		inputSmall int64
+		expected   int64
+	}{
+		{
+			name:       "large_then_negative_small",
+			inputLarge: new(big.Int).Lsh(big.NewInt(1), 80),
+			inputSmall: -3,
+			expected:   -3,
+		},
+		{
+			name:       "larger_then_zero",
+			inputLarge: new(big.Int).Lsh(big.NewInt(1), 128),
+			inputSmall: 0,
+			expected:   0,
+		},
+	}
 
-	large := new(big.Int).Lsh(big.NewInt(1), 80)
-	largeEncoded, err := Encode(NewInteger(large))
-	if err != nil {
-		t.Fatalf("Encode large failed: %v", err)
-	}
-	smallEncoded, err := Encode(NewInteger(big.NewInt(-3)))
-	if err != nil {
-		t.Fatalf("Encode small failed: %v", err)
-	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			decoder := NewDecoder()
 
-	if _, err := decoder.Decode(largeEncoded); err != nil {
-		t.Fatalf("Decode large failed: %v", err)
-	}
-	decoder.Reset()
-	decoded, err := decoder.Decode(smallEncoded)
-	if err != nil {
-		t.Fatalf("Decode small failed: %v", err)
-	}
+			largeEncoded, err := Encode(NewInteger(tc.inputLarge))
+			if err != nil {
+				t.Fatalf("Encode large failed: %v", err)
+			}
+			smallEncoded, err := Encode(NewInteger(big.NewInt(tc.inputSmall)))
+			if err != nil {
+				t.Fatalf("Encode small failed: %v", err)
+			}
 
-	integer, ok := decoded.(*Integer)
-	if !ok {
-		t.Fatalf("decoded value = %T, want *Integer", decoded)
-	}
-	if got, want := integer.Inner.Int64(), int64(-3); got != want {
-		t.Fatalf("decoded integer = %d, want %d", got, want)
-	}
-	if !decoded.Equal(NewInteger(big.NewInt(-3))) {
-		t.Fatalf("decoded value changed after overwrite: got %s", decoded)
+			if _, err := decoder.Decode(largeEncoded); err != nil {
+				t.Fatalf("Decode large failed: %v", err)
+			}
+			decoder.Reset()
+			decoded, err := decoder.Decode(smallEncoded)
+			if err != nil {
+				t.Fatalf("Decode small failed: %v", err)
+			}
+
+			integer, ok := decoded.(*Integer)
+			if !ok {
+				t.Fatalf("decoded value = %T, want *Integer", decoded)
+			}
+			if got, want := integer.Inner.Int64(), tc.expected; got != want {
+				t.Fatalf("decoded integer = %d, want %d", got, want)
+			}
+			if !decoded.Equal(NewInteger(big.NewInt(tc.expected))) {
+				t.Fatalf("decoded value changed after overwrite: got %s", decoded)
+			}
+		})
 	}
 }
 

--- a/syn/encode_test.go
+++ b/syn/encode_test.go
@@ -427,25 +427,57 @@ func TestDeBruijnDecoderReuse(t *testing.T) {
 }
 
 func TestDeBruijnDecoderReuseOverwritesBigInts(t *testing.T) {
+	type programCase struct {
+		name          string
+		program       *Program[DeBruijn]
+		expectedValue *big.Int
+	}
+
+	newProgram := func(value *big.Int) *Program[DeBruijn] {
+		return &Program[DeBruijn]{
+			Version: lang.LanguageVersionV3,
+			Term:    &Constant{Con: &Integer{Inner: value}},
+		}
+	}
+	newProgramCase := func(name string, value *big.Int) programCase {
+		return programCase{
+			name:          name,
+			program:       newProgram(value),
+			expectedValue: value,
+		}
+	}
+
 	tests := []struct {
 		name            string
-		programSequence []string
+		programSequence []programCase
 	}{
 		{
-			name:            "large_then_small",
-			programSequence: []string{"large", "small"},
+			name: "large_then_small",
+			programSequence: []programCase{
+				newProgramCase("large", new(big.Int).Lsh(big.NewInt(1), 80)),
+				newProgramCase("small", big.NewInt(-3)),
+			},
 		},
 		{
-			name:            "small_then_large",
-			programSequence: []string{"small", "large"},
+			name: "small_then_large",
+			programSequence: []programCase{
+				newProgramCase("small", big.NewInt(-3)),
+				newProgramCase("large", new(big.Int).Lsh(big.NewInt(1), 80)),
+			},
 		},
 		{
-			name:            "same_size_large_values",
-			programSequence: []string{"same_size_a", "same_size_b"},
+			name: "same_size_large_values",
+			programSequence: []programCase{
+				newProgramCase("same_size_a", new(big.Int).Add(new(big.Int).Lsh(big.NewInt(1), 80), big.NewInt(5))),
+				newProgramCase("same_size_b", new(big.Int).Add(new(big.Int).Lsh(big.NewInt(1), 80), big.NewInt(9))),
+			},
 		},
 		{
-			name:            "large_then_zero",
-			programSequence: []string{"large", "zero"},
+			name: "large_then_zero",
+			programSequence: []programCase{
+				newProgramCase("large", new(big.Int).Lsh(big.NewInt(1), 80)),
+				newProgramCase("zero", big.NewInt(0)),
+			},
 		},
 	}
 
@@ -453,49 +485,10 @@ func TestDeBruijnDecoderReuseOverwritesBigInts(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			decoder := NewDeBruijnDecoder()
 
-			large := new(big.Int).Lsh(big.NewInt(1), 80)
-			sameSizeA := new(big.Int).Add(new(big.Int).Lsh(big.NewInt(1), 80), big.NewInt(5))
-			sameSizeB := new(big.Int).Add(new(big.Int).Lsh(big.NewInt(1), 80), big.NewInt(9))
-
-			largeProgram := &Program[DeBruijn]{
-				Version: lang.LanguageVersionV3,
-				Term:    &Constant{Con: &Integer{Inner: large}},
-			}
-			smallProgram := &Program[DeBruijn]{
-				Version: lang.LanguageVersionV3,
-				Term:    &Constant{Con: &Integer{Inner: big.NewInt(-3)}},
-			}
-			sameSizeAProgram := &Program[DeBruijn]{
-				Version: lang.LanguageVersionV3,
-				Term:    &Constant{Con: &Integer{Inner: sameSizeA}},
-			}
-			sameSizeBProgram := &Program[DeBruijn]{
-				Version: lang.LanguageVersionV3,
-				Term:    &Constant{Con: &Integer{Inner: sameSizeB}},
-			}
-			zeroProgram := &Program[DeBruijn]{
-				Version: lang.LanguageVersionV3,
-				Term:    &Constant{Con: &Integer{Inner: big.NewInt(0)}},
-			}
-
-			programs := map[string]*Program[DeBruijn]{
-				"large":       largeProgram,
-				"small":       smallProgram,
-				"same_size_a": sameSizeAProgram,
-				"same_size_b": sameSizeBProgram,
-				"zero":        zeroProgram,
-			}
-			expectedValues := map[string]*big.Int{
-				"large":       large,
-				"small":       big.NewInt(-3),
-				"same_size_a": sameSizeA,
-				"same_size_b": sameSizeB,
-				"zero":        big.NewInt(0),
-			}
-
-			for _, programName := range tt.programSequence {
-				program := programs[programName]
-				expectedValue := expectedValues[programName]
+			for _, programCase := range tt.programSequence {
+				programName := programCase.name
+				program := programCase.program
+				expectedValue := programCase.expectedValue
 
 				expectedEncoded, err := Encode(program)
 				if err != nil {


### PR DESCRIPTION
Address review feedback for decoder reuse tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor decoder reuse tests to be table-driven and add cases validating `big.Int` overwrite after decoder reset. Improves test clarity and coverage for both standard and De Bruijn decoders.

- **Refactors**
  - `data/data_test.go`: Convert `TestDecoderResetOverwritesRetainedBigInts` to table-driven with cases for large→negative small and larger→zero; assert integer value and no retained state after `Reset()`.
  - `syn/encode_test.go`: Rewrite `TestDeBruijnDecoderReuseOverwritesBigInts` using a `programCase` struct and helpers; cover sequences large↔small, same-size large values, and large→zero; reduce duplication and tighten assertions.

<sup>Written for commit 84af7d8437a9e2e5c4d84f89f8e4c011e02494bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/plutigo/pull/355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for decoder reset and reuse scenarios involving large integers, negative values, zero, and 128-bit values.
  * Refactored test cases to improve clarity while preserving existing validation of integer encoding, decoding, and round-trip behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->