### PR TITLE
fix(cek)!: remove non-reference final slippage skip

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## Unreleased
+
+### Breaking Changes
+
+* Removed `EvalContext.SkipFinalSlippageFlush`. Successful CEK evaluation now
+  always charges the trailing accumulated machine-step batch, matching the
+  Haskell Plutus implementation. Consumers that enabled the removed option
+  must stop doing so; retaining the option could accept scripts whose declared
+  execution budget the reference ledger rejects.
+
 ## v0.2.0 - mainnet replay tooling, V4 builtin alignment, and runtime improvements
 
 - Date: 2026-07-31

--- a/cek/eval_context.go
+++ b/cek/eval_context.go
@@ -10,11 +10,6 @@ type EvalContext struct {
 	CostModel        CostModel
 	SemanticsVariant SemanticsVariant
 	ProtoMajor       uint
-
-	// SkipFinalSlippageFlush leaves a successful evaluation's trailing
-	// unbudgeted machine-step batch unspent. This matches Cardano ledger's
-	// restricting validation mode; exact cost evaluation should leave it false.
-	SkipFinalSlippageFlush bool
 }
 
 // NewDefaultEvalContext builds an EvalContext using the default cost model

--- a/cek/machine.go
+++ b/cek/machine.go
@@ -61,24 +61,23 @@ func getFilteredBuiltins[T syn.Eval](
 }
 
 type Machine[T syn.Eval] struct {
-	costs                  CostModel
-	stepCosts              [9]ExBudget
-	stepCostCpu            [9]int64
-	stepCostMem            [9]int64
-	builtins               *Builtins[T]
-	builtinValues          *[builtin.TotalBuiltinCount]*Builtin[T]
-	builtinNoArgValues     *[builtin.TotalBuiltinCount][3]*Builtin[T]
-	oneArgCosts            [builtin.TotalBuiltinCount]oneArgCost
-	twoArgCosts            [builtin.TotalBuiltinCount]twoArgCost
-	threeArgCosts          [builtin.TotalBuiltinCount]threeArgCost
-	available              *[builtin.TotalBuiltinCount]bool
-	slippage               uint32
-	version                lang.LanguageVersion
-	semantics              SemanticsVariant
-	protoMajor             uint
-	skipFinalSlippageFlush bool
-	ExBudget               ExBudget
-	Logs                   []string
+	costs              CostModel
+	stepCosts          [9]ExBudget
+	stepCostCpu        [9]int64
+	stepCostMem        [9]int64
+	builtins           *Builtins[T]
+	builtinValues      *[builtin.TotalBuiltinCount]*Builtin[T]
+	builtinNoArgValues *[builtin.TotalBuiltinCount][3]*Builtin[T]
+	oneArgCosts        [builtin.TotalBuiltinCount]oneArgCost
+	twoArgCosts        [builtin.TotalBuiltinCount]twoArgCost
+	threeArgCosts      [builtin.TotalBuiltinCount]threeArgCost
+	available          *[builtin.TotalBuiltinCount]bool
+	slippage           uint32
+	version            lang.LanguageVersion
+	semantics          SemanticsVariant
+	protoMajor         uint
+	ExBudget           ExBudget
+	Logs               []string
 
 	argHolder       argHolder[T]
 	frameStack      []stackFrame[T]
@@ -687,24 +686,23 @@ func NewMachine[T syn.Eval](
 		stepCostMem[i] = s.Mem
 	}
 	return &Machine[T]{
-		costs:                  evalContext.CostModel,
-		stepCosts:              stepCosts,
-		stepCostCpu:            stepCostCpu,
-		stepCostMem:            stepCostMem,
-		builtins:               chooseBuiltins[T](version, evalContext.ProtoMajor),
-		builtinValues:          getSharedBuiltinValues[T](),
-		builtinNoArgValues:     getSharedBuiltinNoArgValues[T](),
-		oneArgCosts:            newOneArgCostCache(evalContext.CostModel.builtinCosts),
-		twoArgCosts:            newTwoArgCostCache(evalContext.CostModel.builtinCosts),
-		threeArgCosts:          newThreeArgCostCache(evalContext.CostModel.builtinCosts),
-		available:              chooseAvailableBuiltins(version, evalContext.ProtoMajor),
-		slippage:               slippage,
-		version:                version,
-		semantics:              evalContext.SemanticsVariant,
-		protoMajor:             evalContext.ProtoMajor,
-		skipFinalSlippageFlush: evalContext.SkipFinalSlippageFlush,
-		ExBudget:               DefaultExBudget,
-		Logs:                   make([]string, 0),
+		costs:              evalContext.CostModel,
+		stepCosts:          stepCosts,
+		stepCostCpu:        stepCostCpu,
+		stepCostMem:        stepCostMem,
+		builtins:           chooseBuiltins[T](version, evalContext.ProtoMajor),
+		builtinValues:      getSharedBuiltinValues[T](),
+		builtinNoArgValues: getSharedBuiltinNoArgValues[T](),
+		oneArgCosts:        newOneArgCostCache(evalContext.CostModel.builtinCosts),
+		twoArgCosts:        newTwoArgCostCache(evalContext.CostModel.builtinCosts),
+		threeArgCosts:      newThreeArgCostCache(evalContext.CostModel.builtinCosts),
+		available:          chooseAvailableBuiltins(version, evalContext.ProtoMajor),
+		slippage:           slippage,
+		version:            version,
+		semantics:          evalContext.SemanticsVariant,
+		protoMajor:         evalContext.ProtoMajor,
+		ExBudget:           DefaultExBudget,
+		Logs:               make([]string, 0),
 
 		argHolder:       newArgHolder[T](),
 		frameStack:      make([]stackFrame[T], 0, 32),
@@ -939,13 +937,8 @@ func (m *Machine[T]) finishReturn(ret *Return[T]) (syn.Term[T], error) {
 
 func (m *Machine[T]) finishValue(value Value[T]) (syn.Term[T], error) {
 	if m.unbudgetedTotal > 0 {
-		if m.skipFinalSlippageFlush {
-			clear(m.unbudgetedSteps[:])
-			m.unbudgetedTotal = 0
-		} else {
-			if err := m.spendUnbudgetedSteps(); err != nil {
-				return nil, err
-			}
+		if err := m.spendUnbudgetedSteps(); err != nil {
+			return nil, err
 		}
 	}
 	return dischargeValue[T](value)

--- a/cek/machine_test.go
+++ b/cek/machine_test.go
@@ -305,48 +305,44 @@ func TestRunStackLambdaImmediateFastPathSkipsLambdaArena(t *testing.T) {
 	}
 }
 
-func TestRunRestrictingModeSkipsSuccessfulFinalSlippageFlush(t *testing.T) {
+func TestRunFlushesSuccessfulFinalSlippageBatch(t *testing.T) {
 	ctx := NewDefaultEvalContext(
-		lang.LanguageVersionV3,
-		ProtoVersion{},
+		lang.LanguageVersionV1,
+		ProtoVersion{Major: 7},
 	)
-	ctx.SkipFinalSlippageFlush = true
-	m := NewMachine[syn.DeBruijn](lang.LanguageVersionV3, 200, ctx)
-	startupBudget := m.costs.machineCosts.startup
-	m.ExBudget = startupBudget
+	// Preview PV7 Haskell plutus-core charges startup (100 CPU, 100 memory)
+	// immediately and flushes the trailing constant step (29,773 CPU,
+	// 100 memory) when the CEK machine returns successfully.
+	ctx.CostModel.machineCosts.startup = ExBudget{Cpu: 100, Mem: 100}
+	ctx.CostModel.machineCosts.constant = ExBudget{Cpu: 29_773, Mem: 100}
+	haskellBudget := ExBudget{Cpu: 29_873, Mem: 200}
 
 	term := &syn.Constant{Con: &syn.Integer{Inner: big.NewInt(42)}}
-	if _, err := m.Run(term); err != nil {
-		t.Fatalf("Run returned error: %v", err)
-	}
-	if m.ExBudget != (ExBudget{}) {
-		t.Fatalf("remaining budget = %+v, want zero after startup only", m.ExBudget)
-	}
-	if got := m.unbudgetedTotal; got != 0 {
-		t.Fatalf("unbudgetedTotal after Run = %d, want 0", got)
-	}
-	if got := m.unbudgetedSteps; got != [9]uint32{} {
-		t.Fatalf("unbudgetedSteps after Run = %v, want zeroed", got)
-	}
-}
+	t.Run("exact Haskell budget", func(t *testing.T) {
+		m := NewMachine[syn.DeBruijn](lang.LanguageVersionV1, 200, ctx)
+		m.ExBudget = haskellBudget
 
-func TestRunDefaultModeFlushesSuccessfulFinalSlippageBatch(t *testing.T) {
-	ctx := NewDefaultEvalContext(
-		lang.LanguageVersionV3,
-		ProtoVersion{},
-	)
-	m := NewMachine[syn.DeBruijn](lang.LanguageVersionV3, 200, ctx)
-	m.ExBudget = m.costs.machineCosts.startup
+		if _, err := m.Run(term); err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+		if m.ExBudget != (ExBudget{}) {
+			t.Fatalf("remaining budget = %+v, want zero", m.ExBudget)
+		}
+	})
 
-	term := &syn.Constant{Con: &syn.Integer{Inner: big.NewInt(42)}}
-	_, err := m.Run(term)
-	if err == nil {
-		t.Fatal("expected final slippage flush to exhaust budget")
-	}
-	var budgetErr *BudgetError
-	if !errors.As(err, &budgetErr) {
-		t.Fatalf("Run error = %T %v, want BudgetError", err, err)
-	}
+	t.Run("missing final constant memory", func(t *testing.T) {
+		m := NewMachine[syn.DeBruijn](lang.LanguageVersionV1, 200, ctx)
+		m.ExBudget = ExBudget{Cpu: haskellBudget.Cpu, Mem: haskellBudget.Mem - 1}
+
+		_, err := m.Run(term)
+		if err == nil {
+			t.Fatal("expected final slippage flush to exhaust budget")
+		}
+		var budgetErr *BudgetError
+		if !errors.As(err, &budgetErr) {
+			t.Fatalf("Run error = %T %v, want BudgetError", err, err)
+		}
+	})
 }
 
 func TestResetEnvArenaRetainsOnlyTrackedChunkHeaders(t *testing.T) {


### PR DESCRIPTION
## Summary
- remove EvalContext.SkipFinalSlippageFlush and the machine path that discarded successful trailing CEK steps
- replace the permissive test with an exact Preview PV7 Haskell budget regression
- document the breaking API correction

## Haskell evidence
- cardano-node 1.35.3 pinned plutus-core calls spendAccumulatedBudget when returnCek reaches NoFrame
- PV7 evaluateScriptRestricting rejects a budget missing the final batch
- the regression uses the Preview PV7 startup plus constant budget: 29,873 CPU and 200 memory

## Validation
- env GOCACHE=/tmp/plutigo-3123-gocache make validate

Related to blinklabs-io/dingo#3123.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always charge the final accumulated CEK step batch on successful evaluation and remove the `EvalContext.SkipFinalSlippageFlush` option to match the Haskell Plutus behavior (PV7). This prevents accepting scripts that the reference ledger would reject due to undercharged final costs.

- **Migration**
  - Remove any use of `EvalContext.SkipFinalSlippageFlush`; it no longer exists.
  - Ensure execution budgets include the startup cost and the final constant batch; update tests that assumed leftover budget after success.

<sup>Written for commit ebb1eda8d59fa9a71788083a5a0cc9e88822df10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/plutigo/pull/356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the option to skip the final accumulated machine-step charge.
  * Successful evaluations now always apply the final CPU and memory charges, aligning behavior with Haskell Plutus.
  * Update integrations that relied on disabling this charge; insufficient resources may now result in a budget error.

* **Tests**
  * Added coverage for final-batch charging with exact and insufficient budgets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->