### PR TITLE
fix: make constructor tags variant-aware

### DIFF
--- a/cek/builtins.go
+++ b/cek/builtins.go
@@ -579,20 +579,12 @@ func (m *Machine[T]) evalUnaryBuiltinFast(
 				Message: "data is not a constr",
 			}
 		}
-		// constr.Tag is a uint, whose width is platform-dependent. Compare via
-		// uint64 so this builds on 32-bit targets (where the untyped MaxInt64
-		// constant would otherwise overflow the uint comparison type). On 32-bit
-		// a uint tag can never exceed MaxInt64, so the guard is a no-op there; on
-		// 64-bit it behaves exactly as before.
-		if uint64(constr.Tag) > math.MaxInt64 {
-			return nil, true, &BuiltinError{
-				Code:    ErrCodeOverflow,
-				Builtin: "unConstrData",
-				Message: "constructor tag too large for integer conversion",
-			}
+		tag := constr.Tag
+		if tag == nil {
+			tag = new(big.Int)
 		}
 		return m.allocPairValue(
-			m.int64Constant(int64(constr.Tag)),
+			m.allocConstant(m.allocIntegerConstant(tag)),
 			m.allocDataListValue(constr.Fields),
 		), true, nil
 	case builtin.UnMapData:
@@ -1990,24 +1982,27 @@ func chooseData[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 	}
 }
 
-func validateConstrTag(arg *big.Int) (uint, error) {
-	// Keep constrData tags within the same range that unConstrData can decode
-	// back into an integer without overflow.
-	if arg.Sign() < 0 {
-		return 0, &BuiltinError{
+func validateConstrTag(
+	semantics SemanticsVariant,
+	arg *big.Int,
+) (*big.Int, error) {
+	if (semantics == SemanticsVariantD || semantics == SemanticsVariantE) &&
+		arg.Sign() < 0 {
+		return nil, &BuiltinError{
 			Code:    ErrCodeInvalidArgument,
 			Builtin: "constrData",
 			Message: "constructor tag must be non-negative",
 		}
 	}
-	if !arg.IsInt64() || arg.BitLen() > bits.UintSize {
-		return 0, &BuiltinError{
+	if (semantics == SemanticsVariantD || semantics == SemanticsVariantE) &&
+		!arg.IsUint64() {
+		return nil, &BuiltinError{
 			Code:    ErrCodeOverflow,
 			Builtin: "constrData",
-			Message: "constructor tag too large for unConstrData",
+			Message: "constructor tag does not fit in Word64",
 		}
 	}
-	return uint(arg.Uint64()), nil
+	return new(big.Int).Set(arg), nil
 }
 
 func constrData[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
@@ -2024,7 +2019,7 @@ func constrData[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 			return nil, err
 		}
 
-		tag, tagErr := validateConstrTag(arg1)
+		tag, tagErr := validateConstrTag(m.semantics, arg1)
 		if tagErr != nil {
 			return nil, tagErr
 		}
@@ -2059,7 +2054,7 @@ func constrData[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 		dataList[i] = itemData.Inner
 	}
 
-	tag, tagErr := validateConstrTag(arg1)
+	tag, tagErr := validateConstrTag(m.semantics, arg1)
 	if tagErr != nil {
 		return nil, tagErr
 	}

--- a/cek/builtins_test.go
+++ b/cek/builtins_test.go
@@ -740,7 +740,7 @@ func TestUnConstrDataBuiltin(t *testing.T) {
 
 	// Create a constr data
 	constr := &data.Constr{
-		Tag:    1,
+		Tag:    big.NewInt(1),
 		Fields: []data.PlutusData{&data.Integer{Inner: big.NewInt(99)}},
 	}
 	d := &syn.Data{Inner: constr}
@@ -1471,32 +1471,87 @@ func TestConstrDataBuiltin(t *testing.T) {
 		t.Fatalf("expected Constr data, got %T", dataConst.Inner)
 	}
 
-	if constrData.Tag != 0 {
+	if constrData.Tag.Cmp(big.NewInt(0)) != 0 {
 		t.Fatalf("expected constructor 0, got %d", constrData.Tag)
 	}
 }
 
-func TestConstrDataBuiltinRejectsTagAboveMaxInt64(t *testing.T) {
-	m := newTestMachine()
-	b := newTestBuiltin(builtin.ConstrData)
-
-	tooLarge := new(big.Int).Add(big.NewInt(math.MaxInt64), big.NewInt(1))
-	list := &syn.ProtoList{LTyp: &syn.TData{}}
-
-	b = b.ApplyArg(&Constant{&syn.Integer{Inner: tooLarge}})
-	b = b.ApplyArg(&Constant{list})
-
-	_, err := evalBuiltinWithError(t, m, b)
-	if err == nil {
-		t.Fatal("expected overflow error for constructor tag above MaxInt64")
+func TestConstrDataTagSemantics(t *testing.T) {
+	twoTo64 := new(big.Int).Lsh(big.NewInt(1), 64)
+	twoTo80 := new(big.Int).Lsh(big.NewInt(1), 80)
+	maxWord64 := new(big.Int).Sub(new(big.Int).Set(twoTo64), big.NewInt(1))
+	tests := []struct {
+		name      string
+		semantics SemanticsVariant
+		tag       *big.Int
+		wantCode  ErrorCode
+	}{
+		{name: "variant A accepts negative", semantics: SemanticsVariantA, tag: big.NewInt(-1)},
+		{name: "variant A accepts unbounded", semantics: SemanticsVariantA, tag: twoTo80},
+		{name: "variant B accepts negative", semantics: SemanticsVariantB, tag: big.NewInt(-1)},
+		{name: "variant B accepts unbounded", semantics: SemanticsVariantB, tag: twoTo80},
+		{name: "variant C accepts negative", semantics: SemanticsVariantC, tag: big.NewInt(-1)},
+		{name: "variant C accepts unbounded", semantics: SemanticsVariantC, tag: twoTo80},
+		{name: "variant D accepts Word64 max", semantics: SemanticsVariantD, tag: maxWord64},
+		{name: "variant D rejects negative", semantics: SemanticsVariantD, tag: big.NewInt(-1), wantCode: ErrCodeInvalidArgument},
+		{name: "variant D rejects above Word64", semantics: SemanticsVariantD, tag: twoTo64, wantCode: ErrCodeOverflow},
+		{name: "variant E accepts Word64 max", semantics: SemanticsVariantE, tag: maxWord64},
+		{name: "variant E rejects negative", semantics: SemanticsVariantE, tag: big.NewInt(-1), wantCode: ErrCodeInvalidArgument},
+		{name: "variant E rejects above Word64", semantics: SemanticsVariantE, tag: twoTo64, wantCode: ErrCodeOverflow},
 	}
 
-	builtinErr, ok := err.(*BuiltinError)
-	if !ok {
-		t.Fatalf("expected BuiltinError, got %T", err)
-	}
-	if builtinErr.Code != ErrCodeOverflow {
-		t.Fatalf("expected overflow code, got %v", builtinErr.Code)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &EvalContext{
+				CostModel:        DefaultCostModel,
+				SemanticsVariant: tt.semantics,
+			}
+			m := NewMachine[syn.DeBruijn](lang.LanguageVersionV3, 0, ctx)
+			constructed := &syn.Apply[syn.DeBruijn]{
+				Function: &syn.Apply[syn.DeBruijn]{
+					Function: &syn.Builtin{DefaultFunction: builtin.ConstrData},
+					Argument: &syn.Constant{Con: &syn.Integer{Inner: new(big.Int).Set(tt.tag)}},
+				},
+				Argument: &syn.Constant{Con: &syn.ProtoList{LTyp: &syn.TData{}}},
+			}
+			term := &syn.Apply[syn.DeBruijn]{
+				Function: &syn.Builtin{DefaultFunction: builtin.UnConstrData},
+				Argument: constructed,
+			}
+
+			value, err := m.Run(term)
+			if tt.wantCode != 0 {
+				if err == nil {
+					t.Fatalf("expected error code %v", tt.wantCode)
+				}
+				builtinErr, ok := err.(*BuiltinError)
+				if !ok {
+					t.Fatalf("expected BuiltinError, got %T: %v", err, err)
+				}
+				if builtinErr.Code != tt.wantCode {
+					t.Fatalf("error code = %v, want %v", builtinErr.Code, tt.wantCode)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Run returned error: %v", err)
+			}
+			constant, ok := value.(*syn.Constant)
+			if !ok {
+				t.Fatalf("Run result has type %T, want *syn.Constant", value)
+			}
+			pair, ok := constant.Con.(*syn.ProtoPair)
+			if !ok {
+				t.Fatalf("Run constant has type %T, want *syn.ProtoPair", constant.Con)
+			}
+			gotTag, ok := pair.First.(*syn.Integer)
+			if !ok {
+				t.Fatalf("constructor tag result has type %T, want *syn.Integer", pair.First)
+			}
+			if gotTag.Inner.Cmp(tt.tag) != 0 {
+				t.Fatalf("constructor tag = %s, want %s", gotTag.Inner, tt.tag)
+			}
+		})
 	}
 }
 

--- a/cek/builtins_test.go
+++ b/cek/builtins_test.go
@@ -802,6 +802,38 @@ func TestUnConstrDataBuiltin(t *testing.T) {
 	}
 }
 
+func TestUnConstrDataBuiltinZeroValueConstr(t *testing.T) {
+	m := NewMachine[syn.DeBruijn](lang.LanguageVersionV3, 0, nil)
+	b := (&Builtin[syn.DeBruijn]{
+		Func: builtin.UnConstrData,
+	}).ApplyArg(&Constant{
+		&syn.Data{Inner: &data.Constr{}},
+	})
+
+	val, err := m.evalBuiltinApp(b)
+	if err != nil {
+		t.Fatalf("evalBuiltinApp returned error: %v", err)
+	}
+	constVal, ok, err := materializeConstantValue[syn.DeBruijn](val)
+	if err != nil {
+		t.Fatalf("failed to materialize pair-like constant result: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected pair-like constant result, got %T", val)
+	}
+	pair, ok := constVal.(*syn.ProtoPair)
+	if !ok {
+		t.Fatalf("expected ProtoPair constant, got %T", constVal)
+	}
+	tag, ok := pair.First.(*syn.Integer)
+	if !ok {
+		t.Fatalf("expected Integer tag, got %T", pair.First)
+	}
+	if tag.Inner.Sign() != 0 {
+		t.Fatalf("expected constructor tag 0, got %s", tag.Inner)
+	}
+}
+
 func TestAppendStringBuiltin(t *testing.T) {
 	m := NewMachine[syn.DeBruijn](lang.LanguageVersionV3, 0, nil)
 

--- a/cek/context.go
+++ b/cek/context.go
@@ -63,7 +63,7 @@ func (f FrameForce[T]) isMachineContext() {}
 
 type FrameConstr[T syn.Eval] struct {
 	Env            *Env[T]
-	Tag            uint
+	Tag            uint64
 	Fields         []syn.Term[T]
 	ResolvedFields []Value[T]
 	Ctx            MachineContext[T]

--- a/cek/machine.go
+++ b/cek/machine.go
@@ -490,7 +490,7 @@ func (m *Machine[T]) allocDelay(term *syn.Delay[T], env *Env[T]) *Delay[T] {
 	return delay
 }
 
-func (m *Machine[T]) allocConstr(tag uint, fields []Value[T]) *Constr[T] {
+func (m *Machine[T]) allocConstr(tag uint64, fields []Value[T]) *Constr[T] {
 	constr := allocArenaSlot(&m.constrChunks, &m.constrChunkPos, m.valueArenaChunkSize)
 	constr.Tag = tag
 	constr.Fields = fields

--- a/cek/stack_machine.go
+++ b/cek/stack_machine.go
@@ -29,7 +29,7 @@ type stackFrame[T syn.Eval] struct {
 	env     *Env[T]
 	term    syn.Term[T]
 
-	tag            uint
+	tag            uint64
 	fields         []syn.Term[T]
 	resolvedFields []Value[T]
 	branches       []syn.Term[T]

--- a/cek/value.go
+++ b/cek/value.go
@@ -451,7 +451,7 @@ func (b *Builtin[T]) IsArrow() bool {
 }
 
 type Constr[T syn.Eval] struct {
-	Tag    uint
+	Tag    uint64
 	Fields []Value[T]
 }
 

--- a/data/arena_decoder.go
+++ b/data/arena_decoder.go
@@ -349,7 +349,7 @@ func (d *Decoder) decodeConstrNextEntered(
 		if err != nil {
 			return nil, nil, err
 		}
-		constr.Tag = uint(tagNumber) - 121
+		constr.Tag = d.bigInts.alloc().SetUint64(tagNumber - 121)
 		constr.Fields = tmpFields
 		constr.useIndef = tmpUseIndef
 		return constr, rest, nil
@@ -361,7 +361,7 @@ func (d *Decoder) decodeConstrNextEntered(
 		if err != nil {
 			return nil, nil, err
 		}
-		constr.Tag = uint(tagNumber) - 1280 + 7
+		constr.Tag = d.bigInts.alloc().SetUint64(tagNumber - 1280 + 7)
 		constr.Fields = tmpFields
 		constr.useIndef = tmpUseIndef
 		return constr, rest, nil
@@ -377,9 +377,6 @@ func (d *Decoder) decodeConstrNextEntered(
 		alternative, next, err := decodeCBORUint(rest)
 		if err != nil {
 			return nil, nil, err
-		}
-		if alternative > math.MaxUint {
-			return nil, nil, fmt.Errorf("constructor alternative too large: %d", alternative)
 		}
 		rest = next
 
@@ -399,7 +396,7 @@ func (d *Decoder) decodeConstrNextEntered(
 			rest = rest[1:]
 		}
 
-		constr.Tag = uint(alternative)
+		constr.Tag = d.bigInts.alloc().SetUint64(alternative)
 		constr.Fields = tmpFields
 		constr.useIndef = tmpUseIndef
 		return constr, rest, nil

--- a/data/data.go
+++ b/data/data.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"math"
 	"math/big"
 
 	"github.com/fxamacker/cbor/v2"
@@ -53,7 +52,7 @@ func useIndefPtr(useIndef bool) *bool {
 // Constr
 
 type Constr struct {
-	Tag      uint
+	Tag      *big.Int
 	Fields   []PlutusData
 	useIndef *bool
 }
@@ -75,6 +74,17 @@ func (c *Constr) UnmarshalCBOR(data []byte) error {
 }
 
 func (c Constr) MarshalCBOR() ([]byte, error) {
+	constrTag := c.Tag
+	if constrTag == nil {
+		constrTag = new(big.Int)
+	}
+	if !constrTag.IsUint64() {
+		return nil, fmt.Errorf(
+			"constructor tag %s is outside the Word64 CBOR range",
+			constrTag,
+		)
+	}
+
 	// Determine whether to use indefinite-length encoding for fields.
 	// If useIndef is explicitly set, honor it; otherwise default to
 	// Haskell's cborg behavior: indefinite for non-empty, definite for empty.
@@ -88,19 +98,19 @@ func (c Constr) MarshalCBOR() ([]byte, error) {
 		return nil, err
 	}
 
-	// Determine CBOR tag based on Constr tag value
+	// Determine CBOR tag based on Constr tag value.
 	var cborTag uint64
 	switch {
-	case c.Tag <= 6:
+	case constrTag.Uint64() <= 6:
 		// Tags 0-6 map to CBOR tags 121-127
-		cborTag = 121 + uint64(c.Tag)
-	case c.Tag >= 7 && c.Tag <= 127:
+		cborTag = 121 + constrTag.Uint64()
+	case constrTag.Uint64() <= 127:
 		// Tags 7-127 map to CBOR tags 1280-1400
-		cborTag = 1280 + uint64(c.Tag-7)
+		cborTag = 1280 + constrTag.Uint64() - 7
 	default:
 		// Tag 102 uses a definite-length 2-element outer list
 		cborTag = 102
-		fields = []any{c.Tag, fields}
+		fields = []any{constrTag, fields}
 	}
 
 	tmpTag := cbor.Tag{
@@ -116,7 +126,11 @@ func (c Constr) Clone() PlutusData {
 		tmpFields[i] = field.Clone()
 	}
 	tmpIndef := cloneUseIndef(c.useIndef)
-	return &Constr{Tag: c.Tag, Fields: tmpFields, useIndef: tmpIndef}
+	tmpTag := new(big.Int)
+	if c.Tag != nil {
+		tmpTag.Set(c.Tag)
+	}
+	return &Constr{Tag: tmpTag, Fields: tmpFields, useIndef: tmpIndef}
 }
 
 func (c Constr) Equal(pd PlutusData) bool {
@@ -124,7 +138,7 @@ func (c Constr) Equal(pd PlutusData) bool {
 	if !ok {
 		return false
 	}
-	if c.Tag != pdConstr.Tag {
+	if constrTagCmp(c.Tag, pdConstr.Tag) != 0 {
 		return false
 	}
 	if len(c.Fields) != len(pdConstr.Fields) {
@@ -139,25 +153,64 @@ func (c Constr) Equal(pd PlutusData) bool {
 }
 
 func (c Constr) String() string {
-	return fmt.Sprintf("Constr{tag: %d, fields: %v}", c.Tag, c.Fields)
+	return fmt.Sprintf("Constr{tag: %s, fields: %v}", constrTagString(c.Tag), c.Fields)
 }
 
 // NewConstr creates a new Constr variant.
-func NewConstr(tag uint, fields ...PlutusData) PlutusData {
+func NewConstr(tag uint64, fields ...PlutusData) PlutusData {
 	tmpFields := make([]PlutusData, len(fields))
 	copy(tmpFields, fields)
-	return &Constr{Tag: tag, Fields: tmpFields}
+	return &Constr{
+		Tag:    new(big.Int).SetUint64(tag),
+		Fields: tmpFields,
+	}
+}
+
+// NewConstrFromBigInt creates a Constr variant with an arbitrary integer tag.
+// The tag is copied so later caller mutations don't change the constructor.
+func NewConstrFromBigInt(tag *big.Int, fields ...PlutusData) PlutusData {
+	tmpFields := make([]PlutusData, len(fields))
+	copy(tmpFields, fields)
+	tmpTag := new(big.Int)
+	if tag != nil {
+		tmpTag.Set(tag)
+	}
+	return &Constr{Tag: tmpTag, Fields: tmpFields}
 }
 
 // NewConstrDefIndef creates a Constr with the ability to specify whether it should use definite- or indefinite-length encoding
 func NewConstrDefIndef(
 	useIndef bool,
-	tag uint,
+	tag uint64,
 	fields ...PlutusData,
 ) PlutusData {
 	tmpFields := make([]PlutusData, len(fields))
 	copy(tmpFields, fields)
-	return &Constr{Tag: tag, Fields: tmpFields, useIndef: useIndefPtr(useIndef)}
+	return &Constr{
+		Tag:      new(big.Int).SetUint64(tag),
+		Fields:   tmpFields,
+		useIndef: useIndefPtr(useIndef),
+	}
+}
+
+func constrTagCmp(a, b *big.Int) int {
+	switch {
+	case a == nil && b == nil:
+		return 0
+	case a == nil:
+		return -b.Sign()
+	case b == nil:
+		return a.Sign()
+	default:
+		return a.Cmp(b)
+	}
+}
+
+func constrTagString(tag *big.Int) string {
+	if tag == nil {
+		return "0"
+	}
+	return tag.String()
 }
 
 // encodeCBORArray encodes a slice of PlutusData items as a CBOR array.
@@ -496,7 +549,7 @@ func decodeConstrNextEntered(
 			return nil, nil, err
 		}
 		return &Constr{
-			Tag:      uint(tagNumber) - 121,
+			Tag:      new(big.Int).SetUint64(tagNumber - 121),
 			Fields:   tmpFields,
 			useIndef: tmpUseIndef,
 		}, rest, nil
@@ -509,7 +562,7 @@ func decodeConstrNextEntered(
 			return nil, nil, err
 		}
 		return &Constr{
-			Tag:      uint(tagNumber) - 1280 + 7,
+			Tag:      new(big.Int).SetUint64(tagNumber - 1280 + 7),
 			Fields:   tmpFields,
 			useIndef: tmpUseIndef,
 		}, rest, nil
@@ -525,9 +578,6 @@ func decodeConstrNextEntered(
 		alternative, next, err := decodeCBORUint(rest)
 		if err != nil {
 			return nil, nil, err
-		}
-		if alternative > math.MaxUint {
-			return nil, nil, fmt.Errorf("constructor alternative too large: %d", alternative)
 		}
 		rest = next
 
@@ -548,7 +598,7 @@ func decodeConstrNextEntered(
 		}
 
 		return &Constr{
-			Tag:      uint(alternative),
+			Tag:      new(big.Int).SetUint64(alternative),
 			Fields:   tmpFields,
 			useIndef: tmpUseIndef,
 		}, rest, nil

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"math/big"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -283,6 +284,74 @@ var testDefs = []struct {
 		),
 		CborHex: "a444364b6579413144354b6579413744364b65794044354b657940",
 	},
+}
+
+func TestConstrIntegerTagCBOR(t *testing.T) {
+	tests := []struct {
+		name    string
+		tag     *big.Int
+		wantHex string
+		wantErr string
+	}{
+		{
+			name:    "Word64 max",
+			tag:     new(big.Int).SetUint64(^uint64(0)),
+			wantHex: "d866821bffffffffffffffff80",
+		},
+		{
+			name:    "negative",
+			tag:     big.NewInt(-1),
+			wantErr: "outside the Word64 CBOR range",
+		},
+		{
+			name:    "above Word64",
+			tag:     new(big.Int).Lsh(big.NewInt(1), 64),
+			wantErr: "outside the Word64 CBOR range",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encoded, err := Encode(NewConstrFromBigInt(tt.tag))
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("Encode returned nil error, want %q", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("Encode error = %q, want text %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Encode returned error: %v", err)
+			}
+			if got := hex.EncodeToString(encoded); got != tt.wantHex {
+				t.Fatalf("encoded CBOR = %s, want %s", got, tt.wantHex)
+			}
+			decoded, err := Decode(encoded)
+			if err != nil {
+				t.Fatalf("Decode returned error: %v", err)
+			}
+			if !decoded.Equal(NewConstrFromBigInt(tt.tag)) {
+				t.Fatalf("decoded value = %v, want constructor tag %s", decoded, tt.tag)
+			}
+
+			arenaDecoded, err := NewDecoder().Decode(encoded)
+			if err != nil {
+				t.Fatalf("arena Decode returned error: %v", err)
+			}
+			if !arenaDecoded.Equal(NewConstrFromBigInt(tt.tag)) {
+				t.Fatalf("arena-decoded value = %v, want constructor tag %s", arenaDecoded, tt.tag)
+			}
+		})
+	}
+}
+
+func TestNewConstrWord64Boundary(t *testing.T) {
+	tag := ^uint64(0)
+	constr := NewConstr(tag).(*Constr)
+	if !constr.Tag.IsUint64() || constr.Tag.Uint64() != tag {
+		t.Fatalf("constructor tag = %s, want %d", constr.Tag, tag)
+	}
 }
 
 func TestUseIndefHonored(t *testing.T) {
@@ -879,6 +948,18 @@ func TestPlutusDataClone(t *testing.T) {
 		reflect.ValueOf(cloned).
 			Pointer() {
 		t.Error("Cloned data should be a different instance")
+	}
+}
+
+func TestConstrCloneCopiesTag(t *testing.T) {
+	original := NewConstrFromBigInt(
+		new(big.Int).Lsh(big.NewInt(1), 80),
+	).(*Constr)
+	cloned := original.Clone().(*Constr)
+
+	original.Tag.SetInt64(7)
+	if cloned.Tag.Cmp(new(big.Int).Lsh(big.NewInt(1), 80)) != 0 {
+		t.Fatalf("cloned tag changed with original: got %s", cloned.Tag)
 	}
 }
 

--- a/data/json.go
+++ b/data/json.go
@@ -155,7 +155,7 @@ func (m *Map) UnmarshalJSON(data []byte) error {
 
 // constrJSON is the JSON representation of a Constr.
 type constrJSON struct {
-	Constructor uint              `json:"constructor"`
+	Constructor *big.Int          `json:"constructor"`
 	Fields      []json.RawMessage `json:"fields"`
 }
 
@@ -169,7 +169,11 @@ func (c Constr) MarshalJSON() ([]byte, error) {
 		}
 		fields[i] = raw
 	}
-	return json.Marshal(constrJSON{Constructor: c.Tag, Fields: fields})
+	constructor := c.Tag
+	if constructor == nil {
+		constructor = new(big.Int)
+	}
+	return json.Marshal(constrJSON{Constructor: constructor, Fields: fields})
 }
 
 // UnmarshalJSON implements json.Unmarshaler for Constr.
@@ -182,9 +186,11 @@ func (c *Constr) UnmarshalJSON(data []byte) error {
 	if !ok {
 		return errors.New("missing \"constructor\" key in Constr JSON")
 	}
-	if err := json.Unmarshal(tagRaw, &c.Tag); err != nil {
+	var tag big.Int
+	if err := json.Unmarshal(tagRaw, &tag); err != nil {
 		return fmt.Errorf("failed to unmarshal Constr constructor tag: %w", err)
 	}
+	c.Tag = &tag
 	fieldsRaw, ok := raw["fields"]
 	if !ok {
 		return errors.New("missing \"fields\" key in Constr JSON")
@@ -610,7 +616,7 @@ func decodePlutusDataJSONValue(
 		}
 		return &Map{Pairs: pairs}, nil
 	case hasKey(keys, "constructor"):
-		var tag uint
+		var tag big.Int
 		if err := json.Unmarshal(jsonRawSpan(data, keys["constructor"]), &tag); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal Constr constructor tag: %w", err)
 		}
@@ -625,7 +631,7 @@ func decodePlutusDataJSONValue(
 		if err != nil {
 			return nil, fmt.Errorf("failed to unmarshal Constr fields: %w", err)
 		}
-		return &Constr{Tag: tag, Fields: fields}, nil
+		return &Constr{Tag: &tag, Fields: fields}, nil
 	default:
 		return nil, fmt.Errorf("unrecognized PlutusData JSON keys: %v", keysOf(keys))
 	}

--- a/data/json_parity_test.go
+++ b/data/json_parity_test.go
@@ -322,27 +322,17 @@ func TestDecodeJSONParityErrorMessages(t *testing.T) {
 		{
 			name: "constr tag error beats fields content error",
 			json: `{"constructor":"x","fields":[{"bad":1}]}`,
-			want: `failed to unmarshal Constr constructor tag: json: cannot unmarshal string into Go value of type uint`,
+			want: `failed to unmarshal Constr constructor tag: math/big: cannot unmarshal "\"x\"" into a *big.Int`,
 		},
 		{
 			name: "constr tag error when fields come first",
 			json: `{"fields":[{"bad":1}],"constructor":"x"}`,
-			want: `failed to unmarshal Constr constructor tag: json: cannot unmarshal string into Go value of type uint`,
-		},
-		{
-			name: "negative constructor tag",
-			json: `{"constructor":-1,"fields":[]}`,
-			want: `failed to unmarshal Constr constructor tag: json: cannot unmarshal number -1 into Go value of type uint`,
+			want: `failed to unmarshal Constr constructor tag: math/big: cannot unmarshal "\"x\"" into a *big.Int`,
 		},
 		{
 			name: "fractional constructor tag",
 			json: `{"constructor":1.5,"fields":[]}`,
-			want: `failed to unmarshal Constr constructor tag: json: cannot unmarshal number 1.5 into Go value of type uint`,
-		},
-		{
-			name: "overflowing constructor tag",
-			json: `{"constructor":18446744073709551616,"fields":[]}`,
-			want: `failed to unmarshal Constr constructor tag: json: cannot unmarshal number 18446744073709551616 into Go value of type uint`,
+			want: `failed to unmarshal Constr constructor tag: math/big: cannot unmarshal "1.5" into a *big.Int`,
 		},
 		{
 			name: "null int value",

--- a/data/json_test.go
+++ b/data/json_test.go
@@ -175,6 +175,16 @@ func TestPlutusDataJSONConstr(t *testing.T) {
 			data: NewConstr(999, NewInteger(big.NewInt(6)), NewInteger(big.NewInt(7))),
 			json: `{"constructor":999,"fields":[{"int":6},{"int":7}]}`,
 		},
+		{
+			name: "negative tag",
+			data: NewConstrFromBigInt(big.NewInt(-1)),
+			json: `{"constructor":-1,"fields":[]}`,
+		},
+		{
+			name: "tag above Word64",
+			data: NewConstrFromBigInt(new(big.Int).Lsh(big.NewInt(1), 80)),
+			json: `{"constructor":1208925819614629174706176,"fields":[]}`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -184,6 +194,21 @@ func TestPlutusDataJSONConstr(t *testing.T) {
 			}
 			if string(got) != tt.json {
 				t.Errorf("Marshal:\n  got:  %s\n  want: %s", got, tt.json)
+			}
+			decoded, err := DecodeJSON(got)
+			if err != nil {
+				t.Fatalf("DecodeJSON error: %v", err)
+			}
+			if !tt.data.Equal(decoded) {
+				t.Errorf("DecodeJSON: got %v, want %v", decoded, tt.data)
+			}
+
+			var direct Constr
+			if err := json.Unmarshal(got, &direct); err != nil {
+				t.Fatalf("Constr.UnmarshalJSON error: %v", err)
+			}
+			if !tt.data.Equal(&direct) {
+				t.Errorf("Constr.UnmarshalJSON: got %v, want %v", &direct, tt.data)
 			}
 		})
 	}

--- a/syn/encode_test.go
+++ b/syn/encode_test.go
@@ -269,7 +269,7 @@ func TestFlatRoundtrip(t *testing.T) {
 							&Constr[DeBruijn]{
 								Tag: 1,
 								Fields: []Term[DeBruijn]{
-									&Constant{Con: &Data{Inner: &data.Constr{Tag: 0, Fields: []data.PlutusData{}}}},
+									&Constant{Con: &Data{Inner: &data.Constr{Tag: big.NewInt(0), Fields: []data.PlutusData{}}}},
 									&Constant{Con: &ByteString{Inner: []byte{0xca, 0xfe}}},
 									&Constant{Con: &Bool{Inner: true}},
 								},
@@ -387,7 +387,7 @@ func TestDeBruijnDecoderReuse(t *testing.T) {
 							SndType: &TData{},
 							First:   &Integer{Inner: big.NewInt(-5)},
 							Second: &Data{Inner: &data.Constr{
-								Tag: 2,
+								Tag: big.NewInt(2),
 								Fields: []data.PlutusData{
 									&data.Integer{Inner: big.NewInt(9)},
 									&data.List{Items: []data.PlutusData{

--- a/syn/flat_decode.go
+++ b/syn/flat_decode.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math"
 	"math/big"
-	"math/bits"
 	"unicode/utf8"
 
 	"github.com/blinklabs-io/plutigo/builtin"
@@ -235,7 +234,7 @@ func decodeTermDeBruijnWithArena(
 		}
 		return arena.allocBuiltin(fn), nil
 	case ConstrTag:
-		constrTag, err := d.word()
+		constrTag, err := d.word64()
 		if err != nil {
 			return nil, err
 		}
@@ -340,7 +339,7 @@ func decodeTermWithArena[T Binder](d *decoder, arena *termArena[T]) (Term[T], er
 
 		term = arena.allocBuiltin(fn)
 	case ConstrTag:
-		constrTag, err := d.word()
+		constrTag, err := d.word64()
 		if err != nil {
 			return nil, err
 		}
@@ -668,7 +667,7 @@ func (a *termArena[T]) allocApply(function Term[T], argument Term[T]) *Apply[T] 
 	return apply
 }
 
-func (a *termArena[T]) allocConstr(tag uint, fields []Term[T]) *Constr[T] {
+func (a *termArena[T]) allocConstr(tag uint64, fields []Term[T]) *Constr[T] {
 	constr := a.constrs.alloc()
 	constr.Tag = tag
 	constr.Fields = fields
@@ -1429,7 +1428,18 @@ func (d *decoder) bit() (bool, error) {
 // so on. If the most significant bit was instead 0 we stop decoding
 // any more bits.
 func (d *decoder) word() (uint, error) {
-	var finalWord uint
+	word, err := d.word64()
+	if err != nil {
+		return 0, err
+	}
+	if word > math.MaxUint {
+		return 0, errors.New("varint overflows machine word")
+	}
+	return uint(word), nil
+}
+
+func (d *decoder) word64() (uint64, error) {
+	var finalWord uint64
 	shl := 0
 
 	if d.usedBits == 0 {
@@ -1440,8 +1450,8 @@ func (d *decoder) word() (uint, error) {
 			word8 := d.buffer[d.pos]
 			d.pos++
 
-			word7 := uint(word8 & 127)
-			if err := checkWordShift(word7, shl); err != nil {
+			word7 := uint64(word8 & 127)
+			if err := checkWord64Shift(word7, shl); err != nil {
 				return 0, err
 			}
 			finalWord |= word7 << shl
@@ -1458,8 +1468,8 @@ func (d *decoder) word() (uint, error) {
 			return 0, err
 		}
 
-		word7 := uint(word8 & 127)
-		if err := checkWordShift(word7, shl); err != nil {
+		word7 := uint64(word8 & 127)
+		if err := checkWord64Shift(word7, shl); err != nil {
 			return 0, err
 		}
 		finalWord |= word7 << shl
@@ -1476,18 +1486,16 @@ func (d *decoder) word() (uint, error) {
 	return finalWord, nil
 }
 
-// checkWordShift reports an overflow error if placing the 7-bit group word7 at
-// bit offset shl would discard any set bit beyond the machine word width. Go
-// defines shifts of >= the integer width as yielding 0, so without this guard
-// a varint with too many continuation bytes would be silently truncated to a
-// wrong value (and differently on 32-bit vs 64-bit targets) rather than
-// rejected.
-func checkWordShift(word7 uint, shl int) error {
+// checkWord64Shift reports an overflow error if placing the 7-bit group word7
+// at bit offset shl would discard any set bit beyond 64 bits. Go defines shifts
+// of >= the integer width as yielding 0, so without this guard a varint with too
+// many continuation bytes would be silently truncated rather than rejected.
+func checkWord64Shift(word7 uint64, shl int) error {
 	if word7 == 0 {
 		return nil
 	}
-	if shl >= bits.UintSize || word7>>(bits.UintSize-shl) != 0 {
-		return errors.New("varint overflows machine word")
+	if shl >= 64 || word7>>(64-shl) != 0 {
+		return errors.New("varint overflows uint64")
 	}
 	return nil
 }

--- a/syn/flat_decode_limits_test.go
+++ b/syn/flat_decode_limits_test.go
@@ -207,3 +207,15 @@ func TestWordOverflowRejected(t *testing.T) {
 		})
 	}
 }
+
+func TestWord64Boundary(t *testing.T) {
+	encoded := append(bytes.Repeat([]byte{0xff}, 9), 0x01)
+	d := newDecoder(encoded)
+	got, err := d.word64()
+	if err != nil {
+		t.Fatalf("word64 returned error: %v", err)
+	}
+	if got != ^uint64(0) {
+		t.Fatalf("word64 = %d, want %d", got, ^uint64(0))
+	}
+}

--- a/syn/flat_encode.go
+++ b/syn/flat_encode.go
@@ -115,7 +115,7 @@ func EncodeTerm[T Binder](e *encoder, term Term[T]) error {
 			return termError
 		}
 
-		e.word(t.Tag)
+		e.word64(t.Tag)
 
 		err := EncodeList(e, t.Fields, EncodeTerm[T])
 		if err != nil {
@@ -203,6 +203,10 @@ func (e *encoder) safeEncodeBits(numBits byte, val byte) error {
 // value is greater than 127 we encode a leading 1 followed by
 // repeating the above for the next 7 bits and so on.
 func (e *encoder) word(c uint) *encoder {
+	return e.word64(uint64(c))
+}
+
+func (e *encoder) word64(c uint64) *encoder {
 	d := c
 
 	for {

--- a/syn/parser.go
+++ b/syn/parser.go
@@ -331,7 +331,7 @@ func (p *Parser) parseConstr() (Term[Name], error) {
 		)
 	}
 
-	n, err := strconv.ParseUint(p.curToken.Literal, 10, strconv.IntSize)
+	n, err := strconv.ParseUint(p.curToken.Literal, 10, 64)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"invalid constr tag %s at position %d: %w",
@@ -340,8 +340,6 @@ func (p *Parser) parseConstr() (Term[Name], error) {
 			err,
 		)
 	}
-
-	tag := uint(n)
 
 	p.nextToken()
 
@@ -360,7 +358,7 @@ func (p *Parser) parseConstr() (Term[Name], error) {
 		return nil, err
 	}
 
-	return &Constr[Name]{Tag: uint(tag), Fields: fields}, nil
+	return &Constr[Name]{Tag: n, Fields: fields}, nil
 }
 
 func (p *Parser) parseCase() (Term[Name], error) {
@@ -1145,24 +1143,14 @@ func (p *Parser) parsePlutusData() (data.PlutusData, error) {
 			)
 		}
 
-		nu, err := strconv.ParseUint(p.curToken.Literal, 10, 64)
-		if err != nil {
+		tag, ok := new(big.Int).SetString(p.curToken.Literal, 10)
+		if !ok {
 			return nil, fmt.Errorf(
-				"invalid constr tag %s at position %d: %w",
+				"invalid constr tag %s at position %d",
 				p.curToken.Literal,
 				p.curToken.Position,
-				err,
 			)
 		}
-
-		if nu > uint64(^uint(0)) {
-			return nil, fmt.Errorf(
-				"constr tag %d out of range at position %d",
-				nu,
-				p.curToken.Position,
-			)
-		}
-		tag := uint(nu)
 
 		p.nextToken()
 
@@ -1191,7 +1179,7 @@ func (p *Parser) parsePlutusData() (data.PlutusData, error) {
 			return nil, err
 		}
 
-		return data.NewConstr(tag, fields...), nil
+		return data.NewConstrFromBigInt(tag, fields...), nil
 	default:
 		return nil, fmt.Errorf(
 			"expected PlutusData constructor (I, B, List, Map, Constr), got %v at position %d",

--- a/syn/parser_limits_test.go
+++ b/syn/parser_limits_test.go
@@ -35,6 +35,25 @@ func TestParseConstrVersionGate(t *testing.T) {
 	}
 }
 
+func TestParseConstrTagWord64Boundary(t *testing.T) {
+	program, err := Parse("(program 1.1.0 (constr 18446744073709551615))")
+	if err != nil {
+		t.Fatalf("Word64 constructor tag should parse: %v", err)
+	}
+	constr, ok := program.Term.(*Constr[Name])
+	if !ok {
+		t.Fatalf("parsed term has type %T, want *Constr[Name]", program.Term)
+	}
+	if constr.Tag != ^uint64(0) {
+		t.Fatalf("constructor tag = %d, want %d", constr.Tag, ^uint64(0))
+	}
+
+	_, err = Parse("(program 1.1.0 (constr 18446744073709551616))")
+	if err == nil {
+		t.Fatal("constructor tag above Word64 should be rejected")
+	}
+}
+
 // TestParseDepthLimit verifies the recursive-descent parser rejects
 // pathologically deep nesting with an error instead of overflowing the Go
 // stack. A modestly deep program still parses.

--- a/syn/parser_test.go
+++ b/syn/parser_test.go
@@ -10,6 +10,8 @@ func TestParsePrettyRoundTrip(t *testing.T) {
 		`(program 1.2.0 (con integer 42))`,
 		`(program 1.2.0 [(builtin addInteger) (con integer 1) (con integer 2)])`,
 		`(program 1.2.0 (lam x x))`,
+		`(program 1.2.0 (con data (Constr -1 [])))`,
+		`(program 1.2.0 (con data (Constr 1208925819614629174706176 [])))`,
 	}
 
 	for _, input := range programs {

--- a/syn/term.go
+++ b/syn/term.go
@@ -54,7 +54,7 @@ func (Builtin) isTerm() {}
 
 // (constr 0 (con integer 1) (con string "1234"))
 type Constr[T any] struct {
-	Tag    uint
+	Tag    uint64
 	Fields []Term[T]
 }
 


### PR DESCRIPTION
## Summary

- represent Plutus data constructor tags with arbitrary-precision integers
- apply the variant-specific `Integer` and `Word64` tag domains
- use fixed-width tags for UPLC text, FLAT, and CEK term paths
- keep ledger CBOR tags within the `Word64` wire-format range

## Validation

- `GOWORK=off go test -race ./...`
- `GOWORK=off go vet ./...`
- `GOWORK=off nilaway ./...`
- `GOWORK=off golangci-lint run --new-from-rev=HEAD ./...`
- focused 32-bit boundary tests
- bounded CBOR, parser, FLAT, and evaluator fuzz tests

Fixes #361
