### PR TITLE
style: format term interner switch

### DIFF
--- a/syn/builder.go
+++ b/syn/builder.go
@@ -21,7 +21,7 @@ func newTermInterner() *termInterner {
 }
 
 func (b *termInterner) intern(currentTerm Term[Name]) {
-	switch term := (currentTerm).(type) {
+	switch term := currentTerm.(type) {
 	case *Var[Name]:
 		b.internName(&term.Name)
 	case *Delay[Name]:


### PR DESCRIPTION
## Summary

- remove redundant parentheses from the term interner type switch
- restore a clean repository-wide `gofumpt` result

## Validation

- `GOWORK=off go test ./syn`
- `GOWORK=off golangci-lint run ./...`
- `gofmt -d syn/builder.go`

Fixes #363


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal type-handling syntax without changing interning behavior or user-visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->