### PR TITLE
fix(builtin): key availability by language and protocol

### DIFF
--- a/builtin/availability.go
+++ b/builtin/availability.go
@@ -1,5 +1,7 @@
 package builtin
 
+import "slices"
+
 // PlutusVersion represents a Plutus ledger language version.
 // This is used to determine which builtins are available.
 type PlutusVersion int
@@ -10,13 +12,15 @@ const (
 	PlutusV3 PlutusVersion = 3
 	PlutusV4 PlutusVersion = 4
 
-	// PlutusVUnreleased represents builtins that are defined but not yet
-	// available on mainnet. These will fail availability checks for all versions.
+	// PlutusVUnreleased is reserved for protocol-independent legacy metadata.
+	// Live availability must be checked with IsAvailableInWithProto.
 	PlutusVUnreleased PlutusVersion = 999
 )
 
-// builtinIntroducedIn maps each builtin to the Plutus version it was introduced in.
-// Builtins can only be used in their introduced version or later.
+// builtinIntroducedIn maps each builtin to its protocol-independent legacy
+// language metadata. Live availability must be checked with
+// IsAvailableInWithProto because ledger languages receive batches at different
+// protocol versions.
 var builtinIntroducedIn = [TotalBuiltinCount]PlutusVersion{
 	// V1 (Alonzo) - Original builtins
 	// Integer functions
@@ -150,42 +154,122 @@ var builtinIntroducedIn = [TotalBuiltinCount]PlutusVersion{
 	DropList: PlutusVUnreleased,
 }
 
-// VanRossemProtoVersion is the Cardano protocol major version at which
-// all builtins become available in all Plutus language versions.
+// VanRossemProtoVersion is the Cardano protocol major version at which batch 6
+// becomes available. Availability remains specific to the Plutus ledger
+// language; it is not a global switch for every builtin.
 const VanRossemProtoVersion uint = 11
 
-// IntroducedIn returns the Plutus version in which the builtin was introduced.
+const (
+	alonzoProtoVersion    uint = 5
+	vasilProtoVersion     uint = 7
+	valentineProtoVersion uint = 8
+	changProtoVersion     uint = 9
+	plominProtoVersion    uint = 10
+	dijkstraProtoVersion  uint = 12
+)
+
+type availabilityBatch struct {
+	introducedAt uint
+	functions    []DefaultFunction
+}
+
+func builtinRange(first, last DefaultFunction) []DefaultFunction {
+	ret := make([]DefaultFunction, 0, int(last-first)+1)
+	for f := first; f <= last; f++ {
+		ret = append(ret, f)
+	}
+	return ret
+}
+
+func combineBatches(batches ...[]DefaultFunction) []DefaultFunction {
+	length := 0
+	for _, batch := range batches {
+		length += len(batch)
+	}
+	ret := make([]DefaultFunction, 0, length)
+	for _, batch := range batches {
+		ret = append(ret, batch...)
+	}
+	return ret
+}
+
+var (
+	batch1  = builtinRange(AddInteger, MkNilPairData)
+	batch2  = []DefaultFunction{SerialiseData}
+	batch3  = []DefaultFunction{VerifyEcdsaSecp256k1Signature, VerifySchnorrSecp256k1Signature}
+	batch4a = builtinRange(Bls12_381_G1_Add, Blake2b_224)
+	batch4b = []DefaultFunction{IntegerToByteString, ByteStringToInteger}
+	batch5  = builtinRange(AndByteString, Ripemd_160)
+	batch6  = builtinRange(ExpModInteger, ScaleValue)
+)
+
+// builtinAvailability mirrors PlutusLedgerApi.Common.Versions. A builtin's
+// availability depends on the (ledger language, protocol version) pair: later
+// protocol versions can extend an existing language without extending every
+// other language at the same time.
+var builtinAvailability = map[PlutusVersion][]availabilityBatch{
+	PlutusV1: {
+		{introducedAt: alonzoProtoVersion, functions: batch1},
+		{
+			introducedAt: VanRossemProtoVersion,
+			functions:    combineBatches(batch2, batch3, batch4a, batch4b, batch5, batch6),
+		},
+	},
+	PlutusV2: {
+		{introducedAt: vasilProtoVersion, functions: combineBatches(batch1, batch2)},
+		{introducedAt: valentineProtoVersion, functions: batch3},
+		{introducedAt: plominProtoVersion, functions: batch4b},
+		{
+			introducedAt: VanRossemProtoVersion,
+			functions:    combineBatches(batch4a, batch5, batch6),
+		},
+	},
+	PlutusV3: {
+		{
+			introducedAt: changProtoVersion,
+			functions:    combineBatches(batch1, batch2, batch3, batch4a, batch4b),
+		},
+		{introducedAt: plominProtoVersion, functions: batch5},
+		{introducedAt: VanRossemProtoVersion, functions: batch6},
+	},
+	PlutusV4: {
+		{
+			introducedAt: dijkstraProtoVersion,
+			functions:    combineBatches(batch1, batch2, batch3, batch4a, batch4b, batch5, batch6),
+		},
+	},
+}
+
+// IntroducedIn returns the builtin's protocol-independent legacy language
+// metadata. Use IsAvailableInWithProto for live ledger availability.
 func (f DefaultFunction) IntroducedIn() PlutusVersion {
 	return builtinIntroducedIn[f]
 }
 
-// IsAvailableIn returns true if the builtin is available in the given Plutus version.
+// IsAvailableIn returns the legacy language-only availability. Use
+// IsAvailableInWithProto for live ledger availability.
 func (f DefaultFunction) IsAvailableIn(version PlutusVersion) bool {
 	return builtinIntroducedIn[f] <= version
 }
 
-// IsAvailableInWithProto returns true if the builtin is available given the
-// Plutus language version and Cardano protocol major version.
-//
-// At protocol version >= 11 (van Rossem hard fork), all builtins become
-// available in all language versions. DropList is also activated at PV11.
-//
-// For protocol versions < 11, the original version-based gating applies.
+// IsAvailableInWithProto returns true if the builtin is available for the
+// supplied Plutus ledger language and Cardano protocol major version.
 func (f DefaultFunction) IsAvailableInWithProto(
 	version PlutusVersion,
 	protoMajor uint,
 ) bool {
-	if protoMajor >= VanRossemProtoVersion {
-		introduced := builtinIntroducedIn[f]
-		// DropList becomes available at PV11 in all versions
-		if introduced == PlutusVUnreleased {
-			return f == DropList
-		}
-		// All other builtins are available in all versions at PV11
-		return true
+	if protoMajor == 0 {
+		return f.IsAvailableIn(version)
 	}
-	// Pre-PV11: use language version gating
-	return builtinIntroducedIn[f] <= version
+	for _, batch := range builtinAvailability[version] {
+		if protoMajor < batch.introducedAt {
+			continue
+		}
+		if slices.Contains(batch.functions, f) {
+			return true
+		}
+	}
+	return false
 }
 
 // LanguageVersionToPlutusVersion converts a [3]uint32 language version to PlutusVersion.

--- a/builtin/availability_test.go
+++ b/builtin/availability_test.go
@@ -98,44 +98,32 @@ func TestBuiltinAvailabilityWithProto(t *testing.T) {
 		protoMajor uint
 		available  bool
 	}{
-		// Pre-PV11: existing behavior preserved
-		{"V1 builtin in V1 at PV10", AddInteger, PlutusV1, 10, true},
-		{"V2 builtin in V1 at PV10", SerialiseData, PlutusV1, 10, false},
-		{"V3 builtin in V2 at PV10", Bls12_381_G1_Add, PlutusV2, 10, false},
-		{"V3 builtin in V3 at PV10", Bls12_381_G1_Add, PlutusV3, 10, true},
-		{"V4 builtin in V3 at PV10", LengthOfArray, PlutusV3, 10, false},
-		{"V4 builtin in V4 at PV10", LengthOfArray, PlutusV4, 10, true},
-		{"dropList in V4 at PV10", DropList, PlutusV4, 10, false},
+		// Plutus V1 receives only batch 1 before PV11.
+		{"batch 1 in V1 at PV5", AddInteger, PlutusV1, 5, true},
+		{"batch 2 in V1 at PV10", SerialiseData, PlutusV1, 10, false},
+		{"batch 4b in V1 at PV10", IntegerToByteString, PlutusV1, 10, false},
+		{"batch 6 in V1 at PV11", DropList, PlutusV1, 11, true},
 
-		// PV11: all builtins available across all versions
-		{"V1 builtin in V1 at PV11", AddInteger, PlutusV1, 11, true},
-		{"V2 builtin in V1 at PV11", SerialiseData, PlutusV1, 11, true},
-		{"V3 builtin in V1 at PV11", Bls12_381_G1_Add, PlutusV1, 11, true},
-		{"V3 builtin in V2 at PV11", Bls12_381_G1_Add, PlutusV2, 11, true},
-		{"V4 builtin in V1 at PV11", LengthOfArray, PlutusV1, 11, true},
-		{"V4 builtin in V2 at PV11", InsertCoin, PlutusV2, 11, true},
-		{"V4 builtin in V3 at PV11", ScaleValue, PlutusV3, 11, true},
-		{"expModInteger in V1 at PV11", ExpModInteger, PlutusV1, 11, true},
-		{"bitwise in V1 at PV11", AndByteString, PlutusV1, 11, true},
-		{
-			"BLS MSM in V2 at PV11",
-			Bls12_381_G1_MultiScalarMul,
-			PlutusV2,
-			11,
-			true,
-		},
-		{"valueData in V1 at PV11", ValueData, PlutusV1, 11, true},
-		{"unValueData in V2 at PV11", UnValueData, PlutusV2, 11, true},
+		// Plutus V2 receives batch 3 at PV8 and batch 4b at PV10.
+		{"batch 2 in V2 at PV7", SerialiseData, PlutusV2, 7, true},
+		{"batch 3 in V2 at PV7", VerifyEcdsaSecp256k1Signature, PlutusV2, 7, false},
+		{"batch 3 in V2 at PV8", VerifyEcdsaSecp256k1Signature, PlutusV2, 8, true},
+		{"batch 4b in V2 at PV9", IntegerToByteString, PlutusV2, 9, false},
+		{"batch 4b in V2 at PV10", IntegerToByteString, PlutusV2, 10, true},
+		{"batch 4a in V2 at PV10", Bls12_381_G1_Add, PlutusV2, 10, false},
+		{"batch 4a in V2 at PV11", Bls12_381_G1_Add, PlutusV2, 11, true},
 
-		// PV11: DropList becomes available
-		{"dropList in V1 at PV11", DropList, PlutusV1, 11, true},
-		{"dropList in V2 at PV11", DropList, PlutusV2, 11, true},
-		{"dropList in V3 at PV11", DropList, PlutusV3, 11, true},
-		{"dropList in V4 at PV11", DropList, PlutusV4, 11, true},
+		// Plutus V3 receives batches 1 through 4 at PV9 and batch 5 at PV10.
+		{"batch 1 in V3 at PV8", AddInteger, PlutusV3, 8, false},
+		{"batch 4a in V3 at PV9", Bls12_381_G1_Add, PlutusV3, 9, true},
+		{"batch 5 in V3 at PV9", AndByteString, PlutusV3, 9, false},
+		{"batch 5 in V3 at PV10", AndByteString, PlutusV3, 10, true},
+		{"batch 6 in V3 at PV10", DropList, PlutusV3, 10, false},
+		{"batch 6 in V3 at PV11", DropList, PlutusV3, 11, true},
 
-		// PV12+: same as PV11
-		{"V3 builtin in V1 at PV12", Bls12_381_G1_Add, PlutusV1, 12, true},
-		{"dropList in V1 at PV12", DropList, PlutusV1, 12, true},
+		// Plutus V4 is introduced at PV12 with batches 1 through 6.
+		{"batch 1 in V4 at PV11", AddInteger, PlutusV4, 11, false},
+		{"batch 6 in V4 at PV12", DropList, PlutusV4, 12, true},
 	}
 
 	for _, tt := range tests {

--- a/cek/pv11_test.go
+++ b/cek/pv11_test.go
@@ -63,7 +63,7 @@ func TestGetSemanticsVanRossemMapping(t *testing.T) {
 	}
 }
 
-func TestPV11BuiltinAvailabilityInMachine(t *testing.T) {
+func TestBuiltinAvailabilityMatrixInMachine(t *testing.T) {
 	tests := []struct {
 		name        string
 		langVersion lang.LanguageVersion
@@ -71,60 +71,77 @@ func TestPV11BuiltinAvailabilityInMachine(t *testing.T) {
 		builtin     builtin.DefaultFunction
 		wantAvail   bool
 	}{
-		// Pre-PV11: V3 builtin NOT available in V1
 		{
-			"V3 builtin in V1 at PV10",
-			lang.LanguageVersionV1,
-			10,
-			builtin.Bls12_381_G1_Add,
+			"batch 3 in V2 at PV7",
+			lang.LanguageVersionV2,
+			7,
+			builtin.VerifyEcdsaSecp256k1Signature,
 			false,
 		},
-		// PV11: V3 builtin available in V1
 		{
-			"V3 builtin in V1 at PV11",
-			lang.LanguageVersionV1,
-			11,
-			builtin.Bls12_381_G1_Add,
+			"batch 4b in V2 at PV10",
+			lang.LanguageVersionV2,
+			10,
+			builtin.IntegerToByteString,
 			true,
 		},
-		// PV11: V4 builtin available in V1
 		{
-			"V4 builtin in V1 at PV11",
-			lang.LanguageVersionV1,
-			11,
-			builtin.LengthOfArray,
+			"batch 5 in V2 at PV10",
+			lang.LanguageVersionV2,
+			10,
+			builtin.AndByteString,
+			false,
+		},
+		{
+			"batch 5 in V3 at PV10",
+			lang.LanguageVersionV3,
+			10,
+			builtin.AndByteString,
 			true,
 		},
-		// PV11: DropList available in V1
 		{
-			"DropList in V1 at PV11",
+			"batch 6 in V1 at PV11",
 			lang.LanguageVersionV1,
 			11,
 			builtin.DropList,
 			true,
 		},
-		// PV11: DropList not available pre-PV11
 		{
-			"DropList in V4 at PV10",
+			"batch 1 in V4 at PV11",
 			lang.LanguageVersionV4,
-			10,
-			builtin.DropList,
+			11,
+			builtin.AddInteger,
 			false,
+		},
+		{
+			"batch 6 in V4 at PV12",
+			lang.LanguageVersionV4,
+			12,
+			builtin.DropList,
+			true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			plutusVersion := builtin.LanguageVersionToPlutusVersion(
+			m := NewMachine[syn.DeBruijn](
 				tt.langVersion,
+				0,
+				NewDefaultEvalContext(
+					tt.langVersion,
+					ProtoVersion{Major: tt.protoMajor},
+				),
 			)
-			got := tt.builtin.IsAvailableInWithProto(
-				plutusVersion,
-				tt.protoMajor,
-			)
+			got := m.builtins[tt.builtin] != nil &&
+				(m.available == nil || m.available[tt.builtin])
 			if got != tt.wantAvail {
-				t.Errorf("IsAvailableInWithProto(%v, %d) = %v, want %v",
-					plutusVersion, tt.protoMajor, got, tt.wantAvail)
+				t.Errorf(
+					"machine availability for %s at PV%d = %v, want %v",
+					tt.builtin,
+					tt.protoMajor,
+					got,
+					tt.wantAvail,
+				)
 			}
 		})
 	}

--- a/tests/conformance_test.go
+++ b/tests/conformance_test.go
@@ -278,8 +278,10 @@ func TestConformance(t *testing.T) {
 					// Determine appropriate Plutus version based on test path
 					// V4 builtins require V4; otherwise use V3
 					plutusVersion := lang.LanguageVersionV3
+					protoVersion := uint(11)
 					if isV4BuiltinTest(path) {
 						plutusVersion = lang.LanguageVersionV4
+						protoVersion = 12
 					}
 
 					machine := cek.NewMachine[syn.DeBruijn](
@@ -287,7 +289,7 @@ func TestConformance(t *testing.T) {
 						200,
 						cek.NewDefaultEvalContext(
 							plutusVersion,
-							cek.ProtoVersion{Major: 11},
+							cek.ProtoVersion{Major: protoVersion},
 						),
 					)
 					machine.ExBudget = initialBudget


### PR DESCRIPTION
Fixes #371

## Summary

- evaluate builtin availability from the Plutus ledger language and protocol version
- model the ledger release batches explicitly, including protocol additions to existing languages
- exercise accepted and rejected combinations through both the public API and CEK runtime
- run Plutus V4 conformance fixtures at the protocol version that introduces V4

## Validation

- `make test`
- `go test -race ./tests`
- `go build -buildvcs=false ./...`
- `go vet ./...`
- repository and full golangci-lint runs
- `nilaway ./...`
- Linux/386 test compilation for `./builtin`, `./cek`, and `./tests`

## Summary by Cubic

Enforces builtin availability by Plutus ledger language and Cardano protocol version using explicit batches. Replaces the PV11 global unlock with a per-language matrix; V4 builtins activate at PV12.

- Availability follows the Alonzo, Vasil, Valentine, Chang, Plomin, Van Rossem, and Dijkstra release boundaries.
- `builtin.IsAvailableInWithProto` consults the matrix; protocol major zero retains legacy language-only gating.
- CEK evaluation and conformance coverage use the same matrix.
- Callers expecting V4 availability must use protocol major 12.
