### PR TITLE
perf(syn): decode large integers linearly

### DIFF
--- a/syn/flat_decode.go
+++ b/syn/flat_decode.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"math/bits"
 	"unicode/utf8"
 
 	"github.com/blinklabs-io/plutigo/builtin"
@@ -1781,9 +1782,7 @@ func (d *decoder) integer() (*big.Int, error) {
 }
 
 func (d *decoder) bigWordSmall() (uint64, *big.Int, error) {
-	var small uint64
-	var bigWord *big.Int
-	shift := uint(0)
+	var accumulator bigWordAccumulator
 
 	if d.usedBits == 0 {
 		for {
@@ -1793,27 +1792,10 @@ func (d *decoder) bigWordSmall() (uint64, *big.Int, error) {
 			word8 := d.buffer[d.pos]
 			d.pos++
 
-			chunk := uint64(word8 & 0x7F)
-			if bigWord == nil {
-				if canAccumulateUint64(chunk, shift) {
-					small |= chunk << shift
-				} else {
-					bigWord = new(big.Int).SetUint64(small)
-					if chunk != 0 {
-						part := new(big.Int).SetUint64(chunk)
-						part.Lsh(part, shift)
-						bigWord.Or(bigWord, part)
-					}
-				}
-			} else if chunk != 0 {
-				part := new(big.Int).SetUint64(chunk)
-				part.Lsh(part, shift)
-				bigWord.Or(bigWord, part)
-			}
-
-			shift += 7
+			accumulator.add(uint64(word8 & 0x7F))
 			if word8&0x80 == 0 {
-				return small, bigWord, nil
+				small, word := accumulator.value()
+				return small, word, nil
 			}
 		}
 	}
@@ -1824,38 +1806,86 @@ func (d *decoder) bigWordSmall() (uint64, *big.Int, error) {
 			return 0, nil, err
 		}
 
-		chunk := uint64(word8 & 0x7F)
-		if bigWord == nil {
-			if canAccumulateUint64(chunk, shift) {
-				small |= chunk << shift
-			} else {
-				bigWord = new(big.Int).SetUint64(small)
-				if chunk != 0 {
-					part := new(big.Int).SetUint64(chunk)
-					part.Lsh(part, shift)
-					bigWord.Or(bigWord, part)
-				}
-			}
-		} else if chunk != 0 {
-			part := new(big.Int).SetUint64(chunk)
-			part.Lsh(part, shift)
-			bigWord.Or(bigWord, part)
-		}
-
-		shift += 7
+		accumulator.add(uint64(word8 & 0x7F))
 		if word8&0x80 == 0 {
-			return small, bigWord, nil
+			small, word := accumulator.value()
+			return small, word, nil
 		}
 	}
 }
 
-func canAccumulateUint64(chunk uint64, shift uint) bool {
+// bigWordAccumulator packs little-endian base-128 groups directly into the
+// native-word representation consumed by big.Int.SetBits. Each input group is
+// written once, avoiding repeated operations over the growing integer.
+type bigWordAccumulator struct {
+	small uint64
+	words []big.Word
+	group int
+}
+
+func (a *bigWordAccumulator) add(chunk uint64) {
+	if a.words == nil && canAccumulateUint64(chunk, a.group) {
+		if chunk != 0 {
+			a.small |= chunk << uint(a.group*7)
+		}
+		a.group++
+		return
+	}
+
+	if a.words == nil {
+		a.words = make([]big.Word, 64/bits.UintSize)
+		a.words[0] = big.Word(a.small)
+		if bits.UintSize == 32 {
+			a.words[1] = big.Word(a.small >> 32)
+		}
+	}
+	if chunk != 0 {
+		a.words = accumulateBigWordChunk(a.words, a.group, chunk)
+	}
+	a.group++
+}
+
+func (a *bigWordAccumulator) value() (uint64, *big.Int) {
+	if a.words == nil {
+		return a.small, nil
+	}
+	return a.small, new(big.Int).SetBits(a.words)
+}
+
+func accumulateBigWordChunk(
+	words []big.Word,
+	group int,
+	chunk uint64,
+) []big.Word {
+	groupRemainder := group % bits.UintSize
+	bitInBlock := groupRemainder * 7
+	wordIndex := (group/bits.UintSize)*7 + bitInBlock/bits.UintSize
+	shift := uint(bitInBlock % bits.UintSize)
+	crossesWord := int(shift)+7 > bits.UintSize
+	requiredWords := wordIndex + 1
+	if crossesWord {
+		requiredWords++
+	}
+	for len(words) < requiredWords {
+		words = append(words, 0)
+	}
+
+	wordChunk := big.Word(chunk)
+	words[wordIndex] |= wordChunk << shift
+	if crossesWord {
+		words[wordIndex+1] |= wordChunk >> uint(bits.UintSize-int(shift))
+	}
+	return words
+}
+
+func canAccumulateUint64(chunk uint64, group int) bool {
 	if chunk == 0 {
 		return true
 	}
-	if shift >= 64 {
+	if group >= 10 {
 		return false
 	}
+	shift := uint(group * 7)
 	return chunk <= (math.MaxUint64 >> shift)
 }
 
@@ -1863,49 +1893,14 @@ func canAccumulateUint64(chunk uint64, shift uint) bool {
 // It is byte-alignment agnostic. Reads 8 bits at a time, using the 7 least
 // significant bits for the integer, continuing if the MSB is 1, stopping if 0.
 func (d *decoder) bigWord() (*big.Int, error) {
-	finalWord := new(big.Int)
-	shift := uint(0)
-
-	if d.usedBits == 0 {
-		for {
-			if d.pos >= len(d.buffer) {
-				return nil, errors.New("end of buffer")
-			}
-			word8 := d.buffer[d.pos]
-			d.pos++
-
-			finalWord.Or(finalWord, new(big.Int).Lsh(new(big.Int).SetInt64(int64(word8&0x7F)), shift))
-			shift += 7
-			if word8&0x80 == 0 {
-				return finalWord, nil
-			}
-		}
+	small, word, err := d.bigWordSmall()
+	if err != nil {
+		return nil, err
 	}
-
-	for {
-		word8, err := d.bits8(8)
-		if err != nil {
-			return nil, err
-		}
-		// Get 7 least significant bits: word8 & 0x7F
-		word7 := word8 & 0x7F
-
-		// Shift and OR into finalWord
-		part := new(big.Int).SetInt64(int64(word7))
-		shiftedPart := new(big.Int).Lsh(part, shift)
-		finalWord.Or(finalWord, shiftedPart)
-
-		// Increment shift by 7
-		shift += 7
-
-		// Check MSB: word8 & 0x80
-		leadingBit := word8 & 0x80
-		if leadingBit == 0 {
-			break
-		}
+	if word == nil {
+		return new(big.Int).SetUint64(small), nil
 	}
-
-	return finalWord, nil
+	return word, nil
 }
 
 func unzigzagUint64(n uint64) (int64, bool) {

--- a/syn/flat_decode_limits_test.go
+++ b/syn/flat_decode_limits_test.go
@@ -2,6 +2,7 @@ package syn
 
 import (
 	"bytes"
+	"math/big"
 	"math/bits"
 	"strings"
 	"testing"
@@ -217,5 +218,194 @@ func TestWord64Boundary(t *testing.T) {
 	}
 	if got != ^uint64(0) {
 		t.Fatalf("word64 = %d, want %d", got, ^uint64(0))
+	}
+}
+
+func TestBigWordSmallLargeValue(t *testing.T) {
+	values := []struct {
+		name string
+		word *big.Int
+	}{
+		{name: "zero", word: new(big.Int)},
+		{name: "uint64 max", word: new(big.Int).SetUint64(^uint64(0))},
+		{name: "above uint64", word: new(big.Int).Lsh(big.NewInt(1), 64)},
+		{
+			name: "crosses several machine words",
+			word: new(big.Int).Sub(
+				new(big.Int).Lsh(big.NewInt(1), 129),
+				big.NewInt(1),
+			),
+		},
+		{
+			name: "large",
+			word: new(big.Int).Sub(
+				new(big.Int).Lsh(big.NewInt(1), 4096),
+				big.NewInt(1),
+			),
+		},
+	}
+	alignments := []struct {
+		name       string
+		prefixBits byte
+		prefix     byte
+	}{
+		{name: "aligned"},
+		{name: "one bit", prefixBits: 1, prefix: 1},
+		{name: "unaligned", prefixBits: 3, prefix: 5},
+		{name: "seven bits", prefixBits: 7, prefix: 0x55},
+	}
+
+	for _, value := range values {
+		t.Run(value.name, func(t *testing.T) {
+			for _, alignment := range alignments {
+				t.Run(alignment.name, func(t *testing.T) {
+					e := newEncoder()
+					if alignment.prefixBits != 0 {
+						e.bits(alignment.prefixBits, alignment.prefix)
+					}
+					e.bigWord(value.word)
+					if e.usedBits != 0 {
+						e.nextWord()
+					}
+
+					d := newDecoder(e.buffer)
+					if alignment.prefixBits != 0 {
+						prefix, err := d.bits8(alignment.prefixBits)
+						if err != nil {
+							t.Fatalf("decode prefix: %v", err)
+						}
+						if prefix != alignment.prefix {
+							t.Fatalf("prefix = %d, want %d", prefix, alignment.prefix)
+						}
+					}
+
+					small, large, err := d.bigWordSmall()
+					if err != nil {
+						t.Fatalf("decode big word: %v", err)
+					}
+					got := large
+					if got == nil {
+						got = new(big.Int).SetUint64(small)
+					}
+					if got.Cmp(value.word) != 0 {
+						t.Fatalf(
+							"decoded word differs: bit length = %d, want %d",
+							got.BitLen(), value.word.BitLen(),
+						)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestBigWordSmallLargeValueAllocations(t *testing.T) {
+	const continuationGroups = 2048
+	encoded := append(
+		bytes.Repeat([]byte{0xff}, continuationGroups),
+		0x7f,
+	)
+
+	d := newDecoder(encoded)
+	_, decoded, err := d.bigWordSmall()
+	if err != nil {
+		t.Fatalf("decode big word: %v", err)
+	}
+	if decoded == nil {
+		t.Fatal("decoded large word is nil")
+	}
+	wantBitLen := len(encoded) * 7
+	if decoded.BitLen() != wantBitLen {
+		t.Fatalf("decoded bit length = %d, want %d", decoded.BitLen(), wantBitLen)
+	}
+
+	var decodedBitLen int
+	allocs := testing.AllocsPerRun(5, func() {
+		d := newDecoder(encoded)
+		_, decoded, _ := d.bigWordSmall()
+		if decoded != nil {
+			decodedBitLen = decoded.BitLen()
+		}
+	})
+	if decodedBitLen != wantBitLen {
+		t.Fatalf("measured decode bit length = %d, want %d", decodedBitLen, wantBitLen)
+	}
+	if allocs > 32 {
+		t.Fatalf("large integer decode allocated %.0f objects, want at most 32", allocs)
+	}
+}
+
+func TestBigWordSmallTruncatedError(t *testing.T) {
+	tests := []struct {
+		name       string
+		prefixBits byte
+		prefix     byte
+		want       string
+	}{
+		{name: "aligned", want: "end of buffer"},
+		{
+			name:       "unaligned",
+			prefixBits: 3,
+			prefix:     5,
+			want:       "NotEnoughBits(8)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := newEncoder()
+			if tt.prefixBits != 0 {
+				e.bits(tt.prefixBits, tt.prefix)
+			}
+			e.bits(8, 0x80)
+			if e.usedBits != 0 {
+				e.nextWord()
+			}
+
+			d := newDecoder(e.buffer)
+			if tt.prefixBits != 0 {
+				if _, err := d.bits8(tt.prefixBits); err != nil {
+					t.Fatalf("decode prefix: %v", err)
+				}
+			}
+			_, _, err := d.bigWordSmall()
+			if err == nil {
+				t.Fatal("truncated big word decoded without error")
+			}
+			if err.Error() != tt.want {
+				t.Fatalf("decode error = %q, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+var benchmarkBigWordSmall *big.Int
+
+func BenchmarkBigWordSmallLargeValue(b *testing.B) {
+	tests := []struct {
+		name               string
+		continuationGroups int
+	}{
+		{name: "128_groups", continuationGroups: 128},
+		{name: "2048_groups", continuationGroups: 2048},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			encoded := append(
+				bytes.Repeat([]byte{0xff}, tt.continuationGroups),
+				0x7f,
+			)
+			b.SetBytes(int64(len(encoded)))
+			b.ReportAllocs()
+			for b.Loop() {
+				d := newDecoder(encoded)
+				_, word, err := d.bigWordSmall()
+				if err != nil {
+					b.Fatalf("decode big word: %v", err)
+				}
+				benchmarkBigWordSmall = word
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- pack large FLAT integer groups directly into native `big.Word` storage
- preserve the `uint64` fast path, aligned and unaligned decoding, and truncation errors
- add value, allocation, error, benchmark, and cross-architecture coverage

## Checks

- `make test`
- focused race tests
- 10-second decoder fuzz run
- `go vet ./...`
- `go build -buildvcs=false ./...`
- `golangci-lint run --allow-parallel-runners ./...`
- NilAway
- Linux/386 cross-build

Closes #373
