### PR TITLE
fix(cek): preserve V1/V2 consByteString semantics

### DIFF
--- a/cek/builtins.go
+++ b/cek/builtins.go
@@ -991,10 +991,11 @@ func consByteString[T syn.Eval](
 	var firstByte byte
 
 	switch m.semantics {
-	case SemanticsVariantA, SemanticsVariantB:
-		// Pre-Chang semantics reduce the first argument modulo 256 (floored)
-		// for any integer. Use the low byte directly so the post-costing work
-		// remains constant even for very large integer inputs.
+	case SemanticsVariantA, SemanticsVariantB, SemanticsVariantD:
+		// V1/V2 semantics reduce the first argument modulo 256 (floored) for
+		// any integer, including after the Van Rossem protocol upgrade. Use the
+		// low byte directly so the post-costing work remains constant even for
+		// very large integer inputs.
 		firstByte = bigIntMod256Byte(arg1)
 	default:
 		// consByteString requires the integer to be in the range 0-255 in V3+

--- a/cek/builtins_test.go
+++ b/cek/builtins_test.go
@@ -4608,12 +4608,11 @@ func TestBigIntMod256Byte(t *testing.T) {
 	}
 }
 
-// TestConsByteStringVariantABBigInt verifies that under the pre-Chang
-// semantics variants (A/B used by V1/V2), consByteString reduces an
-// arbitrarily large first argument modulo 256 (floored), rather than failing
-// because it does not fit in an int64. The V3+ variant (C) still requires the
-// value to be in 0-255.
-func TestConsByteStringVariantABBigInt(t *testing.T) {
+// TestConsByteStringVariantABDBigInt verifies that under the V1/V2 semantics
+// variants (A/B/D), consByteString reduces an arbitrarily large first argument
+// modulo 256 (floored), rather than failing because it does not fit in an
+// int64. The V3+ variants (C/E) still require the value to be in 0-255.
+func TestConsByteStringVariantABDBigInt(t *testing.T) {
 	twoPow64Plus5, _ := new(big.Int).SetString("18446744073709551621", 10)     // 2^64 + 5
 	negTwoPow64Plus5, _ := new(big.Int).SetString("-18446744073709551621", 10) // -(2^64 + 5)
 	twoPow4096Plus5 := new(big.Int).Lsh(big.NewInt(1), 4096)
@@ -4643,6 +4642,20 @@ func TestConsByteStringVariantABBigInt(t *testing.T) {
 			expected: []byte{0xfb, 0xff},
 		},
 		{
+			name:     "variant D reduces large positive mod 256",
+			variant:  SemanticsVariantD,
+			first:    twoPow64Plus5,
+			rest:     []byte{0xff},
+			expected: []byte{0x05, 0xff},
+		},
+		{
+			name:     "variant D floored-reduces large negative mod 256",
+			variant:  SemanticsVariantD,
+			first:    negTwoPow64Plus5,
+			rest:     []byte{0xff},
+			expected: []byte{0xfb, 0xff},
+		},
+		{
 			name:     "variant B reduces huge positive mod 256",
 			variant:  SemanticsVariantB,
 			first:    twoPow4096Plus5,
@@ -4659,6 +4672,13 @@ func TestConsByteStringVariantABBigInt(t *testing.T) {
 		{
 			name:      "variant C rejects out-of-range",
 			variant:   SemanticsVariantC,
+			first:     twoPow64Plus5,
+			rest:      []byte{0xff},
+			expectErr: true,
+		},
+		{
+			name:      "variant E rejects out-of-range",
+			variant:   SemanticsVariantE,
 			first:     twoPow64Plus5,
 			rest:      []byte{0xff},
 			expectErr: true,


### PR DESCRIPTION
## Summary

- Preserve modulo-256 `consByteString` behavior for Plutus V1/V2 semantics variants A, B, and D.
- Keep strict 0-255 validation for V3+ variants C and E.
- Add regression coverage for large positive and negative integers at the variant boundary.

Fixes #375

## Validation

- `go test -race ./...`
- `make validate-quick`

## Review summary (Cubic)

- Variant D now uses modulo-256 flooring semantics for integer prefixes.
- Variants C and E retain strict 0-255 validation.
- Regression tests cover large positive and negative integers across the supported variants.
