### PR TITLE
fix(data): enforce 64-byte CBOR bytestring leaves

### DIFF
--- a/data/arena_decoder.go
+++ b/data/arena_decoder.go
@@ -698,6 +698,9 @@ func (d *Decoder) decodeByteStringContent(data []byte) ([]byte, []byte, error) {
 		return nil, nil, err
 	}
 	if !indefinite {
+		if err := checkByteStringLeafSize(value); err != nil {
+			return nil, nil, err
+		}
 		if value > uint64(len(rest)) {
 			return nil, nil, errors.New("truncated CBOR payload")
 		}
@@ -721,6 +724,9 @@ func (d *Decoder) decodeByteStringContent(data []byte) ([]byte, []byte, error) {
 		}
 		if chunkIndef || chunkType != CborTypeByteString {
 			return nil, nil, fmt.Errorf("invalid CBOR chunk type 0x%02x", chunkType)
+		}
+		if err := checkByteStringLeafSize(chunkValue); err != nil {
+			return nil, nil, err
 		}
 		if chunkValue > uint64(len(chunkRest)) {
 			return nil, nil, errors.New("truncated CBOR payload")

--- a/data/data.go
+++ b/data/data.go
@@ -387,7 +387,7 @@ func (b *ByteString) UnmarshalCBOR(data []byte) error {
 func (b ByteString) MarshalCBOR() ([]byte, error) {
 	// Haskell's Plutus encodes ByteStrings <= 64 bytes as definite-length,
 	// and ByteStrings > 64 bytes as indefinite-length with 64-byte chunks.
-	if len(b.Inner) <= 64 {
+	if len(b.Inner) <= MaxByteStringLeafSize {
 		if b.Inner == nil {
 			return cborMarshal([]byte{})
 		}
@@ -396,8 +396,8 @@ func (b ByteString) MarshalCBOR() ([]byte, error) {
 	// Indefinite-length byte string with 64-byte chunks
 	var buf bytes.Buffer
 	buf.WriteByte(0x5f) // Start indefinite-length byte string
-	for i := 0; i < len(b.Inner); i += 64 {
-		end := i + 64
+	for i := 0; i < len(b.Inner); i += MaxByteStringLeafSize {
+		end := i + MaxByteStringLeafSize
 		if end > len(b.Inner) {
 			end = len(b.Inner)
 		}

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -793,6 +793,81 @@ func TestByteStringUnmarshalCBORIndefinite(t *testing.T) {
 	}
 }
 
+func TestDecodeRejectsOversizedByteStringLeaves(t *testing.T) {
+	byteString := bytes.Repeat([]byte{0xab}, 65)
+	tests := []struct {
+		name  string
+		input []byte
+	}{
+		{
+			name:  "definite bytestring",
+			input: append([]byte{0x58, 0x41}, byteString...),
+		},
+		{
+			name:  "indefinite bytestring chunk",
+			input: append(append([]byte{0x5f, 0x58, 0x41}, byteString...), 0xff),
+		},
+		{
+			name:  "positive bignum payload",
+			input: append([]byte{0xc2, 0x58, 0x41}, byteString...),
+		},
+		{
+			name:  "negative bignum payload",
+			input: append([]byte{0xc3, 0x58, 0x41}, byteString...),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := Decode(tt.input); err == nil {
+				t.Fatal("Decode accepted an oversized bytestring leaf")
+			}
+
+			if _, err := NewDecoder().Decode(tt.input); err == nil {
+				t.Fatal("Decoder.Decode accepted an oversized bytestring leaf")
+			}
+		})
+	}
+}
+
+func TestUnmarshalRejectsOversizedByteStringLeaves(t *testing.T) {
+	byteString := bytes.Repeat([]byte{0xab}, 65)
+	definite := append([]byte{0x58, 0x41}, byteString...)
+	indefinite := append(append([]byte{0x5f, 0x58, 0x41}, byteString...), 0xff)
+
+	var decoded ByteString
+	if err := decoded.UnmarshalCBOR(definite); err == nil {
+		t.Fatal("ByteString.UnmarshalCBOR accepted an oversized definite leaf")
+	}
+	if err := decoded.UnmarshalCBOR(indefinite); err == nil {
+		t.Fatal("ByteString.UnmarshalCBOR accepted an oversized indefinite chunk")
+	}
+
+	var integer Integer
+	if err := integer.UnmarshalCBOR(append([]byte{0xc2}, definite...)); err == nil {
+		t.Fatal("Integer.UnmarshalCBOR accepted an oversized bignum payload")
+	}
+}
+
+func TestDecodeAcceptsBoundedByteStringChunks(t *testing.T) {
+	byteString := bytes.Repeat([]byte{0xab}, 65)
+	indefinite := append([]byte{0x5f, 0x58, 0x40}, byteString[:64]...)
+	indefinite = append(indefinite, 0x41, byteString[64], 0xff)
+
+	decoded, err := Decode(indefinite)
+	if err != nil {
+		t.Fatalf("Decode rejected bounded indefinite bytestring chunks: %v", err)
+	}
+	if got := decoded.(*ByteString).Inner; !bytes.Equal(got, byteString) {
+		t.Fatalf("decoded bytes = %x, want %x", got, byteString)
+	}
+
+	bignum := append([]byte{0xc2}, indefinite...)
+	if _, err := Decode(bignum); err != nil {
+		t.Fatalf("Decode rejected bounded bignum bytestring chunks: %v", err)
+	}
+}
+
 func TestByteStringMarshalCBOREmptyDecoded(t *testing.T) {
 	var decoded ByteString
 	if err := decoded.UnmarshalCBOR([]byte{0x40}); err != nil {

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -534,6 +534,18 @@ func TestDecodeRejectsExcessiveNesting(t *testing.T) {
 	assertDecodeLimitError(t, err, "nesting depth")
 }
 
+func TestDirectUnmarshalRejectsExcessiveNesting(t *testing.T) {
+	encoded := nestedListCBOR(MaxDecodeNestingDepth + 1)
+
+	var byteString ByteString
+	err := byteString.UnmarshalCBOR(encoded)
+	assertDefaultNestingDepthLimit(t, err)
+
+	var integer Integer
+	err = integer.UnmarshalCBOR(encoded)
+	assertDefaultNestingDepthLimit(t, err)
+}
+
 func TestDecodeRejectsExcessiveNodeCount(t *testing.T) {
 	encoded := []byte{0x84, 0x00, 0x00, 0x00, 0x00}
 	limits := decodeLimits{maxDepth: MaxDecodeNestingDepth, maxNodes: 4}
@@ -566,6 +578,30 @@ func assertDecodeLimitError(t *testing.T, err error, limit string) {
 	}
 	if limitErr.Limit != limit {
 		t.Fatalf("DecodeLimitError limit = %q, want %q", limitErr.Limit, limit)
+	}
+}
+
+func assertDefaultNestingDepthLimit(t *testing.T, err error) {
+	t.Helper()
+	assertDecodeLimitError(t, err, "nesting depth")
+
+	var limitErr *DecodeLimitError
+	if !errors.As(err, &limitErr) {
+		t.Fatalf("expected DecodeLimitError, got %T: %v", err, err)
+	}
+	if limitErr.Max != MaxDecodeNestingDepth {
+		t.Fatalf(
+			"DecodeLimitError max = %d, want %d",
+			limitErr.Max,
+			MaxDecodeNestingDepth,
+		)
+	}
+	if limitErr.Actual != MaxDecodeNestingDepth+1 {
+		t.Fatalf(
+			"DecodeLimitError actual = %d, want %d",
+			limitErr.Actual,
+			MaxDecodeNestingDepth+1,
+		)
 	}
 }
 

--- a/data/decode.go
+++ b/data/decode.go
@@ -143,11 +143,7 @@ func cborUnmarshal(dataBytes []byte, dest any) error {
 }
 
 func validateCBORByteStringLeaves(data []byte) error {
-	// The CBOR decoder already enforces its own nesting limit. Use input-sized
-	// bounds here so direct UnmarshalCBOR methods get the bytestring rule without
-	// changing the package's independent Data nesting and node limits.
-	limits := decodeLimits{maxDepth: len(data) + 1, maxNodes: len(data) + 1}
-	rest, err := skipCBORItemWithState(data, newDecodeStateWithLimits(limits))
+	rest, err := skipCBORItemWithState(data, newDecodeState())
 	if err != nil {
 		return err
 	}

--- a/data/decode.go
+++ b/data/decode.go
@@ -24,6 +24,7 @@ const (
 
 	CborIndefFlag uint8 = 0x1f
 
+	MaxByteStringLeafSize = 64
 	MaxDecodeNestingDepth = 256
 	MaxDecodeNodes        = 1_000_000
 )
@@ -135,7 +136,25 @@ func cborUnmarshal(dataBytes []byte, dest any) error {
 	if dm == nil {
 		panic("CBOR decoder not initialized")
 	}
+	if err := validateCBORByteStringLeaves(dataBytes); err != nil {
+		return err
+	}
 	return dm.Unmarshal(dataBytes, dest)
+}
+
+func validateCBORByteStringLeaves(data []byte) error {
+	// The CBOR decoder already enforces its own nesting limit. Use input-sized
+	// bounds here so direct UnmarshalCBOR methods get the bytestring rule without
+	// changing the package's independent Data nesting and node limits.
+	limits := decodeLimits{maxDepth: len(data) + 1, maxNodes: len(data) + 1}
+	rest, err := skipCBORItemWithState(data, newDecodeStateWithLimits(limits))
+	if err != nil {
+		return err
+	}
+	if len(rest) > 0 {
+		return fmt.Errorf("unexpected %d trailing bytes", len(rest))
+	}
+	return nil
 }
 
 // decode is a low-level decode function that detects the CBOR type and uses the correct
@@ -462,6 +481,9 @@ func skipCBORBytesLike(
 	cborType uint8,
 ) ([]byte, error) {
 	if !indefinite {
+		if err := checkByteStringLeafSize(value); err != nil {
+			return nil, err
+		}
 		if value > uint64(len(rest)) {
 			return nil, errors.New("truncated CBOR payload")
 		}
@@ -483,10 +505,28 @@ func skipCBORBytesLike(
 		if chunkIndef || chunkType != cborType {
 			return nil, fmt.Errorf("invalid CBOR chunk type 0x%02x", chunkType)
 		}
+		if err := checkByteStringLeafSize(chunkValue); err != nil {
+			return nil, err
+		}
 		if chunkValue > uint64(len(chunkRest)) {
 			return nil, errors.New("truncated CBOR payload")
 		}
 		rest = chunkRest[chunkValue:]
+	}
+}
+
+func checkByteStringLeafSize(size uint64) error {
+	if size <= MaxByteStringLeafSize {
+		return nil
+	}
+	actual := math.MaxInt
+	if size <= uint64(math.MaxInt) {
+		actual = int(size)
+	}
+	return &DecodeLimitError{
+		Limit:  "bytestring leaf",
+		Max:    MaxByteStringLeafSize,
+		Actual: actual,
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #376.

- Enforce the 64-byte limit for definite-length Plutus Data bytestring leaves.
- Enforce the same limit for each chunk of an indefinite-length bytestring, including tag 2 and tag 3 integer payloads.
- Apply the check to package decoding, the reusable decoder, and direct CBOR unmarshalling.

## Validation

- `go test -v -race ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- NilAway
