### PR TITLE
feat(cek): add synchronous context cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ go get github.com/blinklabs-io/plutigo
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/blinklabs-io/plutigo/cek"
@@ -114,10 +115,14 @@ func main() {
 	program, _ := syn.NameToDeBruijn(pprogram)
 
 	// Create a machine using the default cost model at protocol major 200.
-	ctx := cek.NewDefaultEvalContext(program.Version, cek.ProtoVersion{Major: 200})
-	machine := cek.NewMachine[syn.DeBruijn](program.Version, 0, ctx)
+	evalCtx := cek.NewDefaultEvalContext(
+		program.Version,
+		cek.ProtoVersion{Major: 200},
+	)
+	machine := cek.NewMachine[syn.DeBruijn](program.Version, 0, evalCtx)
 
-	term, _ := machine.Run(program.Term)
+	runCtx := context.Background()
+	term, _ := machine.RunContext(runCtx, program.Term)
 
 	prettyTerm := syn.PrettyTerm[syn.DeBruijn](term)
 
@@ -125,7 +130,7 @@ func main() {
 }
 ```
 
-Use `machine.RunContext(ctx, program.Term)` when the caller has a cancellation
+Pass the caller's `context.Context` as `runCtx` when it has a cancellation
 scope. Cancellation is cooperative and synchronous: the call returns only
 after CEK evaluation and result discharge have stopped, and it does not start
 an evaluator goroutine. A builtin already executing must return before the

--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ func main() {
 }
 ```
 
+Use `machine.RunContext(ctx, program.Term)` when the caller has a cancellation
+scope. Cancellation is cooperative and synchronous: the call returns only
+after CEK evaluation and result discharge have stopped, and it does not start
+an evaluator goroutine. A builtin already executing must return before the
+machine can observe cancellation.
+
 ## Plutus Version Support
 
 plutigo supports all major Plutus protocol versions:

--- a/cek/doc.go
+++ b/cek/doc.go
@@ -31,6 +31,10 @@
 //	}
 //	// result is a Value[syn.DeBruijn]
 //
+// [Machine.RunContext] adds cooperative, synchronous cancellation. It does not
+// start a goroutine; a builtin already executing must return before
+// cancellation can be observed.
+//
 // # Performance
 //
 // The machine uses object pooling (sync.Pool) for state objects to reduce

--- a/cek/machine.go
+++ b/cek/machine.go
@@ -1,6 +1,7 @@
 package cek
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"math"
@@ -139,6 +140,8 @@ type Machine[T syn.Eval] struct {
 	budgetTemplate         ExBudget
 	lastRunRemaining       ExBudget
 	hasRun                 bool
+
+	lastRunEnvHighWatermark int
 }
 
 const (
@@ -936,12 +939,20 @@ func (m *Machine[T]) finishReturn(ret *Return[T]) (syn.Term[T], error) {
 }
 
 func (m *Machine[T]) finishValue(value Value[T]) (syn.Term[T], error) {
+	return m.finishValueContext(context.Background(), false, value)
+}
+
+func (m *Machine[T]) finishValueContext(
+	ctx context.Context,
+	checkCancellation bool,
+	value Value[T],
+) (syn.Term[T], error) {
 	if m.unbudgetedTotal > 0 {
 		if err := m.spendUnbudgetedSteps(); err != nil {
 			return nil, err
 		}
 	}
-	return dischargeValue[T](value)
+	return dischargeValueContext[T](ctx, checkCancellation, value)
 }
 
 // Run executes a Plutus term using the CEK (Control, Environment, Kontinuation) abstract machine.
@@ -955,6 +966,28 @@ func (m *Machine[T]) finishValue(value Value[T]) (syn.Term[T], error) {
 // budget restoration and frame-stack reset (the latter also defends against
 // tests or other callers that tamper with the frame stack between runs).
 func (m *Machine[T]) Run(term syn.Term[T]) (syn.Term[T], error) {
+	return m.runContext(context.Background(), false, term)
+}
+
+// RunContext executes a Plutus term using the CEK machine.
+func (m *Machine[T]) RunContext(
+	ctx context.Context,
+	term syn.Term[T],
+) (syn.Term[T], error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return m.runContext(ctx, true, term)
+}
+
+func (m *Machine[T]) runContext(
+	ctx context.Context,
+	checkCancellation bool,
+	term syn.Term[T],
+) (syn.Term[T], error) {
 	firstRun := !m.hasRun
 	if m.hasRun {
 		if m.valueArenaChunkSize <= 0 {
@@ -976,6 +1009,7 @@ func (m *Machine[T]) Run(term syn.Term[T]) (syn.Term[T], error) {
 	m.unbudgetedTotal = 0
 	defer func() {
 		nextChunkSize := nextValueArenaChunkSize(m.valueArenaHighWatermark())
+		m.lastRunEnvHighWatermark = m.envChunkPos
 		m.lastRunRemaining = m.ExBudget
 		m.hasRun = true
 		m.resetFrameStack()
@@ -1011,7 +1045,12 @@ func (m *Machine[T]) Run(term syn.Term[T]) (syn.Term[T], error) {
 				),
 			}
 		}
-		dbResult, err := runStackNoSlippageDeBruijn(dbMachine, dbTerm)
+		dbResult, err := runStackNoSlippageDeBruijn(
+			ctx,
+			checkCancellation,
+			dbMachine,
+			dbTerm,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -1027,7 +1066,7 @@ func (m *Machine[T]) Run(term syn.Term[T]) (syn.Term[T], error) {
 		}
 		return result, nil
 	}
-	return m.runStack(term)
+	return m.runStack(ctx, checkCancellation, term)
 }
 
 // compute handles the Compute state of the CEK machine.
@@ -1804,13 +1843,28 @@ func dischargeDepthLimitError() *BudgetError {
 }
 
 func dischargeValue[T syn.Eval](value Value[T]) (syn.Term[T], error) {
-	return dischargeValueDepth[T](value, 0)
+	return dischargeValueContext[T](context.Background(), false, value)
+}
+
+func dischargeValueContext[T syn.Eval](
+	ctx context.Context,
+	checkCancellation bool,
+	value Value[T],
+) (syn.Term[T], error) {
+	return dischargeValueDepth[T](ctx, checkCancellation, value, 0)
 }
 
 func dischargeValueDepth[T syn.Eval](
+	ctx context.Context,
+	checkCancellation bool,
 	value Value[T],
 	depth int,
 ) (syn.Term[T], error) {
+	if checkCancellation {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+	}
 	if depth > maxDischargeDepth {
 		return nil, dischargeDepthLimitError()
 	}
@@ -1857,7 +1911,12 @@ func dischargeValueDepth[T syn.Eval](
 
 		// Add applications for each argument
 		for arg := range v.Args.Iter() {
-			discharged, err := dischargeValueDepth[T](arg, depth+1)
+			discharged, err := dischargeValueDepth[T](
+				ctx,
+				checkCancellation,
+				arg,
+				depth+1,
+			)
 			if err != nil {
 				return nil, err
 			}
@@ -1870,7 +1929,14 @@ func dischargeValueDepth[T syn.Eval](
 		return forcedTerm, nil
 	case *Delay[T]:
 		// Discharge delayed computation with environment
-		body, err := withEnv(0, v.Env, v.AST.Term, depth+1)
+		body, err := withEnv(
+			ctx,
+			checkCancellation,
+			0,
+			v.Env,
+			v.AST.Term,
+			depth+1,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -1878,7 +1944,14 @@ func dischargeValueDepth[T syn.Eval](
 
 	case *Lambda[T]:
 		// Discharge lambda with environment (lamCnt=1 to account for parameter)
-		body, err := withEnv(1, v.Env, v.AST.Body, depth+1)
+		body, err := withEnv(
+			ctx,
+			checkCancellation,
+			1,
+			v.Env,
+			v.AST.Body,
+			depth+1,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -1892,7 +1965,12 @@ func dischargeValueDepth[T syn.Eval](
 		fields := make([]syn.Term[T], len(v.Fields))
 
 		for i, f := range v.Fields {
-			discharged, err := dischargeValueDepth[T](f, depth+1)
+			discharged, err := dischargeValueDepth[T](
+				ctx,
+				checkCancellation,
+				f,
+				depth+1,
+			)
 			if err != nil {
 				return nil, err
 			}
@@ -1926,11 +2004,18 @@ func dischargeValueDepth[T syn.Eval](
 // The function handles variable lookup with proper de Bruijn index adjustment,
 // recursively processing complex terms while maintaining environment bindings.
 func withEnv[T syn.Eval](
+	ctx context.Context,
+	checkCancellation bool,
 	lamCnt int,
 	env *Env[T],
 	term syn.Term[T],
 	depth int,
 ) (syn.Term[T], error) {
+	if checkCancellation {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+	}
 	if depth > maxDischargeDepth {
 		return nil, dischargeDepthLimitError()
 	}
@@ -1945,14 +2030,26 @@ func withEnv[T syn.Eval](
 		value, ok := lookupEnv(env, t.Name.LookupIndex()-lamCnt)
 		if ok {
 			// Variable found in environment, discharge its value
-			return dischargeValueDepth[T](value, depth+1)
+			return dischargeValueDepth[T](
+				ctx,
+				checkCancellation,
+				value,
+				depth+1,
+			)
 		}
 		// Free variable (shouldn't happen in well-formed terms)
 		return t, nil
 
 	case *syn.Lambda[T]:
 		// Lambda: increase lambda count for body processing
-		body, err := withEnv(lamCnt+1, env, t.Body, depth+1)
+		body, err := withEnv(
+			ctx,
+			checkCancellation,
+			lamCnt+1,
+			env,
+			t.Body,
+			depth+1,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -1963,11 +2060,25 @@ func withEnv[T syn.Eval](
 
 	case *syn.Apply[T]:
 		// Application: process both function and argument
-		fn, err := withEnv(lamCnt, env, t.Function, depth+1)
+		fn, err := withEnv(
+			ctx,
+			checkCancellation,
+			lamCnt,
+			env,
+			t.Function,
+			depth+1,
+		)
 		if err != nil {
 			return nil, err
 		}
-		arg, err := withEnv(lamCnt, env, t.Argument, depth+1)
+		arg, err := withEnv(
+			ctx,
+			checkCancellation,
+			lamCnt,
+			env,
+			t.Argument,
+			depth+1,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -1978,7 +2089,14 @@ func withEnv[T syn.Eval](
 
 	case *syn.Delay[T]:
 		// Delay: process delayed term
-		inner, err := withEnv(lamCnt, env, t.Term, depth+1)
+		inner, err := withEnv(
+			ctx,
+			checkCancellation,
+			lamCnt,
+			env,
+			t.Term,
+			depth+1,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -1986,7 +2104,14 @@ func withEnv[T syn.Eval](
 
 	case *syn.Force[T]:
 		// Force: process term to be forced
-		inner, err := withEnv(lamCnt, env, t.Term, depth+1)
+		inner, err := withEnv(
+			ctx,
+			checkCancellation,
+			lamCnt,
+			env,
+			t.Term,
+			depth+1,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -1996,7 +2121,14 @@ func withEnv[T syn.Eval](
 		// Constructor: recursively process all fields
 		fields := make([]syn.Term[T], len(t.Fields))
 		for i, f := range t.Fields {
-			d, err := withEnv(lamCnt, env, f, depth+1)
+			d, err := withEnv(
+				ctx,
+				checkCancellation,
+				lamCnt,
+				env,
+				f,
+				depth+1,
+			)
 			if err != nil {
 				return nil, err
 			}
@@ -2011,13 +2143,27 @@ func withEnv[T syn.Eval](
 		// Case expression: process scrutinee and all branches
 		branches := make([]syn.Term[T], len(t.Branches))
 		for i, b := range t.Branches {
-			d, err := withEnv(lamCnt, env, b, depth+1)
+			d, err := withEnv(
+				ctx,
+				checkCancellation,
+				lamCnt,
+				env,
+				b,
+				depth+1,
+			)
 			if err != nil {
 				return nil, err
 			}
 			branches[i] = d
 		}
-		constr, err := withEnv(lamCnt, env, t.Constr, depth+1)
+		constr, err := withEnv(
+			ctx,
+			checkCancellation,
+			lamCnt,
+			env,
+			t.Constr,
+			depth+1,
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/cek/machine_context_test.go
+++ b/cek/machine_context_test.go
@@ -1,0 +1,127 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cek
+
+import (
+	"context"
+	"errors"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/plutigo/lang"
+	"github.com/blinklabs-io/plutigo/syn"
+)
+
+type cancelAfterChecksContext struct {
+	checks   int
+	limit    int
+	done     chan struct{}
+	canceled bool
+}
+
+func (*cancelAfterChecksContext) Deadline() (time.Time, bool) {
+	return time.Time{}, false
+}
+
+func (c *cancelAfterChecksContext) Done() <-chan struct{} { return c.done }
+
+func (c *cancelAfterChecksContext) Err() error {
+	c.checks++
+	if c.checks >= c.limit && !c.canceled {
+		close(c.done)
+		c.canceled = true
+	}
+	if c.canceled {
+		return context.Canceled
+	}
+	return nil
+}
+
+func (*cancelAfterChecksContext) Value(any) any { return nil }
+
+func TestRunContextStopsOnCancellation(t *testing.T) {
+	term := divergentTerm()
+	machine := NewMachine[syn.DeBruijn](
+		lang.LanguageVersionV1,
+		200,
+		nil,
+	)
+	machine.ExBudget = ExBudget{Cpu: 1_000_000, Mem: 1_000_000}
+	ctx := &cancelAfterChecksContext{limit: 64, done: make(chan struct{})}
+
+	_, err := machine.RunContext(ctx, term)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("RunContext() error = %v, want context.Canceled", err)
+	}
+	if ctx.checks != ctx.limit {
+		t.Errorf("context checks = %d, want %d", ctx.checks, ctx.limit)
+	}
+	maxEnvironments := ctx.limit + 1
+	if machine.lastRunEnvHighWatermark > maxEnvironments {
+		t.Errorf(
+			"environment high-watermark = %d, exceeds cancellation-derived cap %d",
+			machine.lastRunEnvHighWatermark,
+			maxEnvironments,
+		)
+	}
+}
+
+func TestRunBudgetBoundsDivergentEnvironmentGrowth(t *testing.T) {
+	machine := NewMachine[syn.DeBruijn](
+		lang.LanguageVersionV1,
+		200,
+		nil,
+	)
+	initial := ExBudget{Cpu: 100_000_000, Mem: 100_000}
+	machine.ExBudget = initial
+
+	_, err := machine.Run(divergentTerm())
+	var budgetErr *BudgetError
+	if !errors.As(err, &budgetErr) {
+		t.Fatalf("Run() error = %T %v, want BudgetError", err, err)
+	}
+
+	minStepMem := int64(math.MaxInt64)
+	for _, cost := range machine.stepCostMem {
+		if cost > 0 && cost < minStepMem {
+			minStepMem = cost
+		}
+	}
+	if minStepMem == math.MaxInt64 {
+		t.Fatal("machine cost model has no positive step memory cost")
+	}
+	maxEnvironments := int(initial.Mem/minStepMem) + 1
+	if machine.lastRunEnvHighWatermark > maxEnvironments {
+		t.Fatalf(
+			"environment high-watermark = %d, exceeds budget-derived cap %d",
+			machine.lastRunEnvHighWatermark,
+			maxEnvironments,
+		)
+	}
+}
+
+func divergentTerm() syn.Term[syn.DeBruijn] {
+	selfApply := &syn.Lambda[syn.DeBruijn]{
+		Body: &syn.Apply[syn.DeBruijn]{
+			Function: &syn.Var[syn.DeBruijn]{Name: 1},
+			Argument: &syn.Var[syn.DeBruijn]{Name: 1},
+		},
+	}
+	return &syn.Apply[syn.DeBruijn]{
+		Function: selfApply,
+		Argument: selfApply,
+	}
+}

--- a/cek/stack_machine.go
+++ b/cek/stack_machine.go
@@ -3,6 +3,7 @@
 package cek
 
 import (
+	"context"
 	"math"
 
 	"github.com/blinklabs-io/plutigo/syn"
@@ -550,13 +551,22 @@ func (m *Machine[T]) runStackNoSlippage(term syn.Term[T]) (syn.Term[T], error) {
 	}
 }
 
-func (m *Machine[T]) runStack(term syn.Term[T]) (syn.Term[T], error) {
+func (m *Machine[T]) runStack(
+	ctx context.Context,
+	checkCancellation bool,
+	term syn.Term[T],
+) (syn.Term[T], error) {
 	var currentEnv *Env[T]
 	currentTerm := term
 	var currentValue Value[T]
 	returning := false
 
 	for {
+		if checkCancellation {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
 		if !returning {
 			if currentTerm == nil {
 				return nil, internalError("stack machine current term is nil")
@@ -742,7 +752,11 @@ func (m *Machine[T]) runStack(term syn.Term[T]) (syn.Term[T], error) {
 			return nil, internalError("stack machine current value is nil")
 		}
 		if len(m.frameStack) == 0 {
-			return m.finishValue(currentValue)
+			return m.finishValueContext(
+				ctx,
+				checkCancellation,
+				currentValue,
+			)
 		}
 		frameIdx := len(m.frameStack) - 1
 		frame := &m.frameStack[frameIdx]

--- a/cek/stack_machine_debruijn.go
+++ b/cek/stack_machine_debruijn.go
@@ -2,6 +2,7 @@
 package cek
 
 import (
+	"context"
 	"math/bits"
 	"unsafe"
 
@@ -195,6 +196,8 @@ func computeKnownImmediateValueNoSlippageDeBruijn(
 }
 
 func runStackNoSlippageDeBruijn(
+	ctx context.Context,
+	checkCancellation bool,
 	m *Machine[syn.DeBruijn],
 	term syn.Term[syn.DeBruijn],
 ) (syn.Term[syn.DeBruijn], error) {
@@ -204,6 +207,11 @@ func runStackNoSlippageDeBruijn(
 	returning := false
 
 	for {
+		if checkCancellation {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
 		if !returning {
 			if currentTerm == nil {
 				return nil, internalError("DeBruijn stack machine current term is nil")
@@ -442,7 +450,11 @@ func runStackNoSlippageDeBruijn(
 			return nil, internalError("DeBruijn stack machine current value is nil")
 		}
 		if len(m.frameStack) == 0 {
-			return m.finishValue(currentValue)
+			return m.finishValueContext(
+				ctx,
+				checkCancellation,
+				currentValue,
+			)
 		}
 		frameIdx := len(m.frameStack) - 1
 		frame := &m.frameStack[frameIdx]


### PR DESCRIPTION
## Summary

- add `Machine.RunContext` with cooperative cancellation through CEK evaluation and result discharge
- keep `Run` behavior unchanged and avoid detached evaluator goroutines
- add deterministic regressions for cancellation-bounded and budget-bounded divergent environment growth
- document synchronous cancellation and the builtin cancellation boundary

## Testing

- `go test -race ./...`
- `golangci-lint run ./...`
- `nilaway -include-pkgs=github.com/blinklabs-io/plutigo -exclude-file-docstrings="<nilaway skip stack-machine>" ./...`

The commit includes the required DCO `Signed-off-by` trailer.

Related to blinklabs-io/dingo#3435.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds synchronous, cooperative cancellation to the CEK via `Machine.RunContext(ctx, term)` so runs stop deterministically when the caller’s context is canceled. `Machine.Run` is unchanged; docs now distinguish the run context from the evaluation context.

- Checks cancellation during CEK steps and during result discharge.
- Observes cancellation only after a builtin returns.
- Records the last run’s environment high-watermark to cap cancellation- and budget-driven growth.
- Adds deterministic tests for cancellation and budget-bounded divergent evaluations.
- Updates README and `cek` docs to show `RunContext` usage and clarify run vs evaluation contexts.

<sup>Written for commit 8044d78369a7a91b6e93a5264d031f17dc14f40a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/plutigo/pull/379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added context-aware evaluation with cooperative cancellation support.
  * Added `RunContext` for stopping evaluation when the provided context is canceled.
  * Cancellation is checked during evaluation and builtin execution, with cancellation errors returned safely.

* **Documentation**
  * Documented cancellation behavior and usage in the README and package documentation.

* **Tests**
  * Added coverage for cancellation handling and bounded memory growth during divergent evaluations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->