### PR TITLE
fix(syn): decode supported universe types

### DIFF
--- a/cek/builtins.go
+++ b/cek/builtins.go
@@ -4298,34 +4298,44 @@ func dropList[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 // Functions: lengthOfArray, listToArray, indexArray
 // ============================================================================
 
-func lengthOfArray[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
-	b.Args.Extract(&m.argHolder, b.ArgCount)
-	// The tests use (con (array t) [ ... ]) which is parsed to a ProtoList.
-	lstConst, ok := m.argHolder[0].(*Constant)
+func unwrapArray[T syn.Eval](value Value[T]) (syn.Typ, []syn.IConstant, error) {
+	constant, ok := value.(*Constant)
 	if !ok {
-		return nil, &BuiltinError{
-			Code:    ErrCodeInvalidArgument,
-			Builtin: "lengthOfArray",
-			Message: "expected constant",
+		return nil, nil, &TypeError{
+			Code:     ErrCodeTypeMismatch,
+			Expected: "Array",
+			Got:      fmt.Sprintf("%T", value),
+			Message:  "type mismatch",
 		}
 	}
 
-	switch c := lstConst.Constant.(type) {
-	case *syn.ProtoList:
-		if err := m.CostOne(&b.Func, func() ExMem { return listExMem(c.List)() }); err != nil {
-			return nil, err
-		}
-		l := big.NewInt(int64(len(c.List)))
-		return &Constant{&syn.Integer{Inner: l}}, nil
+	switch array := constant.Constant.(type) {
+	case *syn.ProtoArray:
+		return array.ATyp, array.Array, nil
 	default:
-		return nil, &BuiltinError{Code: ErrCodeInvalidArgument, Builtin: "lengthOfArray", Message: "expected array/list constant"}
+		return nil, nil, &TypeError{
+			Code:     ErrCodeTypeMismatch,
+			Expected: "Array",
+			Got:      fmt.Sprintf("%T", constant.Constant),
+			Message:  "type mismatch",
+		}
 	}
+}
+
+func lengthOfArray[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
+	b.Args.Extract(&m.argHolder, b.ArgCount)
+	_, items, err := unwrapArray[T](m.argHolder[0])
+	if err != nil {
+		return nil, err
+	}
+	if err := m.CostOne(&b.Func, func() ExMem { return listExMem(items)() }); err != nil {
+		return nil, err
+	}
+	return &Constant{&syn.Integer{Inner: big.NewInt(int64(len(items)))}}, nil
 }
 
 func listToArray[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 	b.Args.Extract(&m.argHolder, b.ArgCount)
-	// Convert a list constant to an array constant representation; both are
-	// represented as ProtoList in this implementation, so return as-is.
 	lst, err := unwrapList[T](nil, m.argHolder[0])
 	if err != nil {
 		return nil, err
@@ -4334,13 +4344,13 @@ func listToArray[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 	if err := m.CostOne(&b.Func, func() ExMem { return listLengthExMem(lst.List)() }); err != nil {
 		return nil, err
 	}
-	return &Constant{&syn.ProtoList{LTyp: lst.LTyp, List: lst.List}}, nil
+	return &Constant{&syn.ProtoArray{ATyp: lst.LTyp, Array: lst.List}}, nil
 }
 
 func indexArray[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 	b.Args.Extract(&m.argHolder, b.ArgCount)
 	// Args: (con (array t) arr) (con integer idx)
-	lst, err := unwrapList[T](nil, m.argHolder[0])
+	_, items, err := unwrapArray[T](m.argHolder[0])
 	if err != nil {
 		return nil, err
 	}
@@ -4353,7 +4363,7 @@ func indexArray[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 	// Spend budget
 	err = m.CostTwo(
 		&b.Func,
-		func() ExMem { return listExMem(lst.List)() },
+		func() ExMem { return listExMem(items)() },
 		bigIntExMem(idx),
 	)
 	if err != nil {
@@ -4385,15 +4395,15 @@ func indexArray[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 		}
 	}
 	i := int(idx64)
-	if i >= len(lst.List) {
+	if i >= len(items) {
 		return nil, &BuiltinError{
 			Code:    ErrCodeOutOfBounds,
 			Builtin: "indexArray",
-			Message: fmt.Sprintf("index %d out of bounds for array of length %d", i, len(lst.List)),
+			Message: fmt.Sprintf("index %d out of bounds for array of length %d", i, len(items)),
 		}
 	}
 
-	return &Constant{lst.List[i]}, nil
+	return &Constant{items[i]}, nil
 }
 
 // ============================================================================
@@ -4402,10 +4412,19 @@ func indexArray[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 // Helpers: valueToMap, mapToValue
 // ============================================================================
 
-// Helper: converts a ProtoList representation of Value to map[string]map[string]*big.Int
-func valueToMap[T syn.Eval](c *syn.ProtoList) map[string]map[string]*big.Int {
+func valueEntries(constant syn.IConstant) ([]syn.IConstant, bool) {
+	switch value := constant.(type) {
+	case *syn.Value:
+		return value.Entries, true
+	default:
+		return nil, false
+	}
+}
+
+// valueToMap converts a Value payload to map[string]map[string]*big.Int.
+func valueToMap(entries []syn.IConstant) map[string]map[string]*big.Int {
 	out := make(map[string]map[string]*big.Int)
-	for _, entry := range c.List {
+	for _, entry := range entries {
 		pair, ok := entry.(*syn.ProtoPair)
 		if !ok {
 			continue
@@ -4449,8 +4468,9 @@ func valueToMap[T syn.Eval](c *syn.ProtoList) map[string]map[string]*big.Int {
 	return out
 }
 
-// Helper: convert map back to ProtoList canonical order: empty policy entries removed, token lists sorted by key
-func mapToValueProto(mapp map[string]map[string]*big.Int) *syn.ProtoList {
+// mapToValue converts a map back to canonical Value order: empty policy
+// entries are removed and policy/token keys are sorted.
+func mapToValue(mapp map[string]map[string]*big.Int) *syn.Value {
 	res := make([]syn.IConstant, 0)
 	// deterministically sort policies
 	policies := make([]string, 0, len(mapp))
@@ -4458,13 +4478,6 @@ func mapToValueProto(mapp map[string]map[string]*big.Int) *syn.ProtoList {
 		policies = append(policies, p)
 	}
 	sort.Strings(policies)
-	// value element type: (pair bytestring (list (pair bytestring integer)))
-	valType := &syn.TPair{
-		First: &syn.TByteString{},
-		Second: &syn.TList{
-			Typ: &syn.TPair{First: &syn.TByteString{}, Second: &syn.TInteger{}},
-		},
-	}
 	for _, policy := range policies {
 		tokens := mapp[policy]
 		if len(tokens) == 0 {
@@ -4513,7 +4526,7 @@ func mapToValueProto(mapp map[string]map[string]*big.Int) *syn.ProtoList {
 		})
 	}
 
-	return &syn.ProtoList{LTyp: valType, List: res}
+	return &syn.Value{Entries: res}
 }
 
 func insertCoin[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
@@ -4541,12 +4554,12 @@ func insertCoin[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 		}
 	}
 
-	plist, ok := valConst.Constant.(*syn.ProtoList)
+	entries, ok := valueEntries(valConst.Constant)
 	if !ok {
 		return nil, &BuiltinError{
 			Code:    ErrCodeInvalidArgument,
 			Builtin: "insertCoin",
-			Message: "expected value proto list",
+			Message: "expected value constant",
 		}
 	}
 	// Spend budget for insertCoin (4 args: policy, token, amount, value)
@@ -4555,7 +4568,7 @@ func insertCoin[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 		byteArrayExMem(policyBs),
 		byteArrayExMem(tokenBs),
 		bigIntExMem(amt),
-		valueListSizeExMem(plist.List),
+		valueListSizeExMem(entries),
 	); err != nil {
 		return nil, err
 	}
@@ -4590,7 +4603,7 @@ func insertCoin[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 		}
 	}
 
-	vm := valueToMap[T](plist)
+	vm := valueToMap(entries)
 	pol := string(policyBs)
 	if _, ok := vm[pol]; !ok {
 		vm[pol] = make(map[string]*big.Int)
@@ -4606,7 +4619,7 @@ func insertCoin[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 		vm[pol][string(tokenBs)] = new(big.Int).Set(amt)
 	}
 
-	return &Constant{mapToValueProto(vm)}, nil
+	return &Constant{mapToValue(vm)}, nil
 }
 
 func lookupCoin[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
@@ -4628,12 +4641,12 @@ func lookupCoin[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 			Message: "expected value constant",
 		}
 	}
-	plist, ok := valConst.Constant.(*syn.ProtoList)
+	entries, ok := valueEntries(valConst.Constant)
 	if !ok {
 		return nil, &BuiltinError{
 			Code:    ErrCodeInvalidArgument,
 			Builtin: "lookupCoin",
-			Message: "expected value proto list",
+			Message: "expected value constant",
 		}
 	}
 	// Spend budget for lookupCoin (3 args: policy, token, value)
@@ -4641,11 +4654,11 @@ func lookupCoin[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 	if err := m.CostThree(&b.Func,
 		byteArrayExMem(policyBs),
 		byteArrayExMem(tokenBs),
-		valueListSizeExMem(plist.List),
+		valueListSizeExMem(entries),
 	); err != nil {
 		return nil, err
 	}
-	vm := valueToMap[T](plist)
+	vm := valueToMap(entries)
 	if tokens, ok := vm[string(policyBs)]; ok {
 		if amt, ok2 := tokens[string(tokenBs)]; ok2 {
 			return &Constant{&syn.Integer{Inner: amt}}, nil
@@ -4670,23 +4683,23 @@ func scaleValue[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 			Message: "expected value constant",
 		}
 	}
-	plist, ok := valConst.Constant.(*syn.ProtoList)
+	entries, ok := valueEntries(valConst.Constant)
 	if !ok {
 		return nil, &BuiltinError{
 			Code:    ErrCodeInvalidArgument,
 			Builtin: "scaleValue",
-			Message: "expected value proto list",
+			Message: "expected value constant",
 		}
 	}
 	// Spend budget for scaleValue (2 args: factor, value)
 	// Cost model uses linear_in_y (the value size with minus-one formula)
 	if err := m.CostTwo(&b.Func,
 		bigIntExMem(factor),
-		valueListSizeMinusOneExMem(plist.List),
+		valueListSizeMinusOneExMem(entries),
 	); err != nil {
 		return nil, err
 	}
-	vm := valueToMap[T](plist)
+	vm := valueToMap(entries)
 	if vm == nil {
 		vm = make(map[string]map[string]*big.Int)
 	}
@@ -4717,7 +4730,7 @@ func scaleValue[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 			toks[t] = prod
 		}
 	}
-	return &Constant{mapToValueProto(vm)}, nil
+	return &Constant{mapToValue(vm)}, nil
 }
 
 func unionValue[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
@@ -4738,32 +4751,32 @@ func unionValue[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 			Message: "expected value constant for b",
 		}
 	}
-	aList, ok := aConst.Constant.(*syn.ProtoList)
+	aEntries, ok := valueEntries(aConst.Constant)
 	if !ok {
 		return nil, &BuiltinError{
 			Code:    ErrCodeInvalidArgument,
 			Builtin: "unionValue",
-			Message: "expected proto list for a",
+			Message: "expected value constant for a",
 		}
 	}
-	bList, ok := bConst.Constant.(*syn.ProtoList)
+	bEntries, ok := valueEntries(bConst.Constant)
 	if !ok {
 		return nil, &BuiltinError{
 			Code:    ErrCodeInvalidArgument,
 			Builtin: "unionValue",
-			Message: "expected proto list for b",
+			Message: "expected value constant for b",
 		}
 	}
 	// Spend budget for unionValue (2 args: value a, value b)
 	// Cost model uses with_interaction_in_x_and_y (outer count only - number of policies)
 	if err := m.CostTwo(&b.Func,
-		valueOuterCountExMem(aList.List),
-		valueOuterCountExMem(bList.List),
+		valueOuterCountExMem(aEntries),
+		valueOuterCountExMem(bEntries),
 	); err != nil {
 		return nil, err
 	}
-	am := valueToMap[T](aList)
-	bm := valueToMap[T](bList)
+	am := valueToMap(aEntries)
+	bm := valueToMap(bEntries)
 	// sum
 	limit := new(big.Int).Lsh(big.NewInt(1), 127)
 	limitMinusOne := new(big.Int).Sub(limit, big.NewInt(1))
@@ -4795,7 +4808,7 @@ func unionValue[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 			am[pol][t] = cur
 		}
 	}
-	return &Constant{mapToValueProto(am)}, nil
+	return &Constant{mapToValue(am)}, nil
 }
 
 func valueContains[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
@@ -4817,33 +4830,33 @@ func valueContains[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 			Message: "expected required value constant",
 		}
 	}
-	valList, ok := valConst.Constant.(*syn.ProtoList)
+	valEntries, ok := valueEntries(valConst.Constant)
 	if !ok {
 		return nil, &BuiltinError{
 			Code:    ErrCodeInvalidArgument,
 			Builtin: "valueContains",
-			Message: "expected proto list for value",
+			Message: "expected value constant",
 		}
 	}
-	reqList, ok := reqConst.Constant.(*syn.ProtoList)
+	reqEntries, ok := valueEntries(reqConst.Constant)
 	if !ok {
 		return nil, &BuiltinError{
 			Code:    ErrCodeInvalidArgument,
 			Builtin: "valueContains",
-			Message: "expected proto list for required value",
+			Message: "expected required value constant",
 		}
 	}
 	// Spend budget for valueContains (2 args: value, required value)
 	// Cost model uses const_above_diagonal with linear_in_x_and_y (token count)
 	if err := m.CostTwo(&b.Func,
-		valueInnerCountExMem(valList.List),
-		valueInnerCountExMem(reqList.List),
+		valueInnerCountExMem(valEntries),
+		valueInnerCountExMem(reqEntries),
 	); err != nil {
 		return nil, err
 	}
 
-	vm := valueToMap[T](valList)
-	rm := valueToMap[T](reqList)
+	vm := valueToMap(valEntries)
+	rm := valueToMap(reqEntries)
 	// Neither value nor required value may contain negative amounts
 	for _, tokens := range rm {
 		for _, amt := range tokens {
@@ -4886,7 +4899,7 @@ func valueContains[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 	return &Constant{&syn.Bool{Inner: true}}, nil
 }
 
-// valueData converts a Value (ProtoList) to a Data (Map)
+// valueData converts a Value to a Data Map.
 // The Value format is: [(policy_bs, [(token_bs, amount_int), ...]), ...]
 // The Data format is: Map [(B policy, Map [(B token, I amount), ...]), ...]
 func valueData[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
@@ -4901,24 +4914,24 @@ func valueData[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 		}
 	}
 
-	plist, ok := valConst.Constant.(*syn.ProtoList)
+	valueItems, ok := valueEntries(valConst.Constant)
 	if !ok {
 		return nil, &BuiltinError{
 			Code:    ErrCodeInvalidArgument,
 			Builtin: "valueData",
-			Message: "expected value proto list",
+			Message: "expected value constant",
 		}
 	}
 
 	// Spend budget for valueData (1 arg: value)
 	// Cost model uses linear_in_x with max(outer, inner) size
-	if err := m.CostOne(&b.Func, valueMaxCountExMem(plist.List)); err != nil {
+	if err := m.CostOne(&b.Func, valueMaxCountExMem(valueItems)); err != nil {
 		return nil, err
 	}
 
 	// Convert value to data map
-	entries := make([][2]data.PlutusData, 0, len(plist.List))
-	for _, entry := range plist.List {
+	entries := make([][2]data.PlutusData, 0, len(valueItems))
+	for _, entry := range valueItems {
 		pair, ok := entry.(*syn.ProtoPair)
 		if !ok {
 			continue
@@ -4959,7 +4972,7 @@ func valueData[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 	return &Constant{&syn.Data{Inner: &data.Map{Pairs: entries}}}, nil
 }
 
-// unValueData converts a Data (Map) to a Value (ProtoList)
+// unValueData converts a Data Map to a Value.
 // The Data format is: Map [(B policy, Map [(B token, I amount), ...]), ...]
 // The Value format is: [(policy_bs, [(token_bs, amount_int), ...]), ...]
 // The input must be well-formed: keys in ascending order, no duplicates,
@@ -5160,12 +5173,5 @@ func unValueData[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 		})
 	}
 
-	// Type for Value: list (pair bytestring (list (pair bytestring integer)))
-	valType := &syn.TPair{
-		First: &syn.TByteString{},
-		Second: &syn.TList{
-			Typ: &syn.TPair{First: &syn.TByteString{}, Second: &syn.TInteger{}},
-		},
-	}
-	return &Constant{&syn.ProtoList{LTyp: valType, List: result}}, nil
+	return &Constant{&syn.Value{Entries: result}}, nil
 }

--- a/cek/builtins_test.go
+++ b/cek/builtins_test.go
@@ -518,14 +518,14 @@ func TestLengthOfArrayBuiltin(t *testing.T) {
 	m := newTestMachineV4() // V4 builtin
 	b := newTestBuiltin(builtin.LengthOfArray)
 
-	// Create a ProtoList with 3 elements
+	// Create an array with 3 elements.
 	list := []syn.IConstant{
 		&syn.Integer{Inner: big.NewInt(1)},
 		&syn.Integer{Inner: big.NewInt(2)},
 		&syn.Integer{Inner: big.NewInt(3)},
 	}
-	protoList := &syn.ProtoList{List: list}
-	arrayVal := &Constant{protoList}
+	array := &syn.ProtoArray{ATyp: &syn.TInteger{}, Array: list}
+	arrayVal := &Constant{array}
 
 	b = b.ApplyArg(arrayVal)
 

--- a/cek/cost_model.go
+++ b/cek/cost_model.go
@@ -121,6 +121,10 @@ func iconstantExMem(c syn.IConstant) func() ExMem {
 			ex = unitExMem()
 		case *syn.ProtoList:
 			ex = listExMem(x.List)
+		case *syn.ProtoArray:
+			ex = listLengthExMem(x.Array)
+		case *syn.Value:
+			ex = valueInnerCountExMem(x.Entries)
 		case *syn.ProtoPair:
 			ex = pairExMem(x.First, x.Second)
 		case *syn.Data:

--- a/cek/flat_universe_types_test.go
+++ b/cek/flat_universe_types_test.go
@@ -1,0 +1,242 @@
+package cek
+
+import (
+	"bytes"
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	"github.com/blinklabs-io/plutigo/builtin"
+	"github.com/blinklabs-io/plutigo/data"
+	"github.com/blinklabs-io/plutigo/lang"
+	"github.com/blinklabs-io/plutigo/syn"
+)
+
+func TestDecodedFlatUniverseConstantsEvaluate(t *testing.T) {
+	tests := []struct {
+		name     string
+		flatHex  string
+		validate func(*testing.T, syn.IConstant)
+	}{
+		{
+			name:    "lengthOfArray",
+			flatHex: "010300357b297e4001",
+			validate: func(t *testing.T, constant syn.IConstant) {
+				t.Helper()
+				integer, ok := constant.(*syn.Integer)
+				if !ok {
+					t.Fatalf("result type = %T, want *syn.Integer", constant)
+				}
+				if integer.Inner.Cmp(big.NewInt(0)) != 0 {
+					t.Fatalf("result = %s, want 0", integer.Inner)
+				}
+			},
+		},
+		{
+			name:    "valueData empty",
+			flatHex: "01030037c49d01",
+			validate: func(t *testing.T, constant syn.IConstant) {
+				t.Helper()
+				wrapped, ok := constant.(*syn.Data)
+				if !ok {
+					t.Fatalf("result type = %T, want *syn.Data", constant)
+				}
+				valueMap, ok := wrapped.Inner.(*data.Map)
+				if !ok {
+					t.Fatalf("result data type = %T, want *data.Map", wrapped.Inner)
+				}
+				if len(valueMap.Pairs) != 0 {
+					t.Fatalf("result map length = %d, want 0", len(valueMap.Pairs))
+				}
+			},
+		},
+		{
+			name:    "valueData populated",
+			flatHex: "01030037c49d410081000201",
+			validate: func(t *testing.T, constant syn.IConstant) {
+				t.Helper()
+				wrapped, ok := constant.(*syn.Data)
+				if !ok {
+					t.Fatalf("result type = %T, want *syn.Data", constant)
+				}
+				valueMap, ok := wrapped.Inner.(*data.Map)
+				if !ok {
+					t.Fatalf("result data type = %T, want *data.Map", wrapped.Inner)
+				}
+				if len(valueMap.Pairs) != 1 {
+					t.Fatalf("result map length = %d, want 1", len(valueMap.Pairs))
+				}
+			},
+		},
+	}
+
+	ctx := NewDefaultEvalContext(
+		lang.LanguageVersionV4,
+		ProtoVersion{Major: 12},
+	)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			flat, err := hex.DecodeString(test.flatHex)
+			if err != nil {
+				t.Fatalf("decode fixture: %v", err)
+			}
+			program, err := syn.Decode[syn.DeBruijn](flat)
+			if err != nil {
+				t.Fatalf("decode FLAT program: %v", err)
+			}
+
+			machine := NewMachine[syn.DeBruijn](
+				lang.LanguageVersionV4,
+				0,
+				ctx,
+			)
+			result, err := machine.Run(program.Term)
+			if err != nil {
+				t.Fatalf("evaluate decoded program: %v", err)
+			}
+			constant, ok := result.(*syn.Constant)
+			if !ok {
+				t.Fatalf("result term type = %T, want *syn.Constant", result)
+			}
+			test.validate(t, constant.Con)
+		})
+	}
+}
+
+func TestDecodedFlatUniverseConstantsPreserveTypeOnDischarge(t *testing.T) {
+	for name, flatHex := range map[string]string{
+		"empty BLS list":  "0101004bd721",
+		"empty BLS array": "0101004bf321",
+		"integer array":   "0101004bf201",
+		"empty value":     "0101004e81",
+		"populated value": "0101004ea10081000201",
+	} {
+		t.Run(name, func(t *testing.T) {
+			flat, err := hex.DecodeString(flatHex)
+			if err != nil {
+				t.Fatalf("decode fixture: %v", err)
+			}
+			program, err := syn.Decode[syn.DeBruijn](flat)
+			if err != nil {
+				t.Fatalf("decode FLAT program: %v", err)
+			}
+			machine := NewMachine[syn.DeBruijn](
+				lang.LanguageVersionV4,
+				0,
+				NewDefaultEvalContext(
+					lang.LanguageVersionV4,
+					ProtoVersion{Major: 12},
+				),
+			)
+			result, err := machine.Run(program.Term)
+			if err != nil {
+				t.Fatalf("evaluate decoded constant: %v", err)
+			}
+			reencoded, err := syn.Encode(&syn.Program[syn.DeBruijn]{
+				Version: program.Version,
+				Term:    result,
+			})
+			if err != nil {
+				t.Fatalf("encode discharged constant: %v", err)
+			}
+			if !bytes.Equal(reencoded, flat) {
+				t.Fatalf("re-encoded bytes = %x, want %x", reencoded, flat)
+			}
+		})
+	}
+}
+
+func TestArrayAndValueBuiltinsPreserveConstantTypes(t *testing.T) {
+	t.Run("listToArray", func(t *testing.T) {
+		machine := newTestMachineV4()
+		fn := newTestBuiltin(builtin.ListToArray)
+		fn = fn.ApplyArg(&Constant{Constant: &syn.ProtoList{
+			LTyp: &syn.TInteger{},
+		}})
+		result := expectConstant(t, evalBuiltin(t, machine, fn))
+		if _, ok := result.Constant.(*syn.ProtoArray); !ok {
+			t.Fatalf("result type = %T, want *syn.ProtoArray", result.Constant)
+		}
+		assertConstantEncoding(t, result.Constant, "0103004bf201")
+	})
+
+	t.Run("unValueData", func(t *testing.T) {
+		machine := newTestMachineV4()
+		fn := newTestBuiltin(builtin.UnValueData)
+		fn = fn.ApplyArg(&Constant{Constant: &syn.Data{Inner: &data.Map{}}})
+		result := expectConstant(t, evalBuiltin(t, machine, fn))
+		if _, ok := result.Constant.(*syn.Value); !ok {
+			t.Fatalf("result type = %T, want *syn.Value", result.Constant)
+		}
+		assertConstantEncoding(t, result.Constant, "0103004e81")
+	})
+}
+
+func TestFlatUniverseConstantExMem(t *testing.T) {
+	t.Run("array uses element count", func(t *testing.T) {
+		constant := &syn.ProtoArray{
+			ATyp: &syn.TByteString{},
+			Array: []syn.IConstant{
+				&syn.ByteString{Inner: make([]byte, 64)},
+				&syn.ByteString{Inner: make([]byte, 64)},
+			},
+		}
+		if got, want := iconstantExMem(constant)(), ExMem(2); got != want {
+			t.Fatalf("array ExMem = %d, want element count %d", got, want)
+		}
+	})
+
+	t.Run("value uses total token count", func(t *testing.T) {
+		constant := &syn.Value{Entries: []syn.IConstant{
+			&syn.ProtoPair{
+				FstType: &syn.TByteString{},
+				SndType: &syn.TList{Typ: &syn.TPair{
+					First:  &syn.TByteString{},
+					Second: &syn.TInteger{},
+				}},
+				First: &syn.ByteString{Inner: []byte{1}},
+				Second: &syn.ProtoList{
+					LTyp: &syn.TPair{
+						First:  &syn.TByteString{},
+						Second: &syn.TInteger{},
+					},
+					List: []syn.IConstant{
+						&syn.ProtoPair{
+							FstType: &syn.TByteString{},
+							SndType: &syn.TInteger{},
+							First:   &syn.ByteString{Inner: []byte{1}},
+							Second:  &syn.Integer{Inner: big.NewInt(1)},
+						},
+						&syn.ProtoPair{
+							FstType: &syn.TByteString{},
+							SndType: &syn.TInteger{},
+							First:   &syn.ByteString{Inner: []byte{2}},
+							Second:  &syn.Integer{Inner: big.NewInt(1)},
+						},
+					},
+				},
+			},
+		}}
+		if got, want := iconstantExMem(constant)(), ExMem(2); got != want {
+			t.Fatalf("value ExMem = %d, want total token count %d", got, want)
+		}
+	})
+}
+
+func assertConstantEncoding(t *testing.T, constant syn.IConstant, wantHex string) {
+	t.Helper()
+	encoded, err := syn.Encode(&syn.Program[syn.DeBruijn]{
+		Version: lang.LanguageVersionV4,
+		Term:    &syn.Constant{Con: constant},
+	})
+	if err != nil {
+		t.Fatalf("encode constant: %v", err)
+	}
+	want, err := hex.DecodeString(wantHex)
+	if err != nil {
+		t.Fatalf("decode expected bytes: %v", err)
+	}
+	if !bytes.Equal(encoded, want) {
+		t.Fatalf("encoded bytes = %x, want %x", encoded, want)
+	}
+}

--- a/cek/value.go
+++ b/cek/value.go
@@ -335,6 +335,21 @@ func cloneConstant(constant syn.IConstant) syn.IConstant {
 			LTyp: c.LTyp,
 			List: items,
 		}
+	case *syn.ProtoArray:
+		items := make([]syn.IConstant, len(c.Array))
+		for i := range c.Array {
+			items[i] = cloneConstant(c.Array[i])
+		}
+		return &syn.ProtoArray{
+			ATyp:  c.ATyp,
+			Array: items,
+		}
+	case *syn.Value:
+		entries := make([]syn.IConstant, len(c.Entries))
+		for i := range c.Entries {
+			entries[i] = cloneConstant(c.Entries[i])
+		}
+		return &syn.Value{Entries: entries}
 	case *syn.ProtoPair:
 		return &syn.ProtoPair{
 			FstType: c.FstType,

--- a/syn/constant.go
+++ b/syn/constant.go
@@ -134,6 +134,27 @@ func (pl ProtoList) Typ() Typ {
 	return &TList{Typ: pl.LTyp}
 }
 
+type ProtoArray struct {
+	ATyp  Typ
+	Array []IConstant
+}
+
+func (ProtoArray) isConstant() {}
+
+func (pa ProtoArray) Typ() Typ {
+	return &TArray{Typ: pa.ATyp}
+}
+
+type Value struct {
+	Entries []IConstant
+}
+
+func (Value) isConstant() {}
+
+func (Value) Typ() Typ {
+	return &TValue{}
+}
+
 type ProtoPair struct {
 	FstType Typ
 	SndType Typ

--- a/syn/flat_decode.go
+++ b/syn/flat_decode.go
@@ -1,6 +1,7 @@
 package syn
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"math"
@@ -710,7 +711,9 @@ type constantArena struct {
 	units       arenaChunks[Unit]
 	bools       arenaChunks[Bool]
 	protoLists  arenaChunks[ProtoList]
+	protoArrays arenaChunks[ProtoArray]
 	protoPairs  arenaChunks[ProtoPair]
+	values      arenaChunks[Value]
 	datas       arenaChunks[Data]
 	lists       arenaSlices[IConstant]
 	bytes       arenaSlices[byte]
@@ -725,7 +728,9 @@ func (a *constantArena) reset() {
 	a.units.reset(1)
 	a.bools.reset(1)
 	a.protoLists.reset(decodeRetainVarCap)
+	a.protoArrays.reset(decodeRetainVarCap)
 	a.protoPairs.reset(decodeRetainVarCap)
+	a.values.reset(decodeRetainVarCap)
 	a.datas.reset(decodeRetainVarCap)
 	a.lists.reset(decodeRetainVarCap)
 	resetByteSlices(&a.bytes, decodeRetainBytesCap)
@@ -768,6 +773,19 @@ func (a *constantArena) allocProtoList(typ Typ, items []IConstant) *ProtoList {
 	value := a.protoLists.alloc()
 	value.LTyp = typ
 	value.List = items
+	return value
+}
+
+func (a *constantArena) allocProtoArray(typ Typ, items []IConstant) *ProtoArray {
+	value := a.protoArrays.alloc()
+	value.ATyp = typ
+	value.Array = items
+	return value
+}
+
+func (a *constantArena) allocValue(entries []IConstant) *Value {
+	value := a.values.alloc()
+	value.Entries = entries
 	return value
 }
 
@@ -981,6 +999,12 @@ func decodeConstantValueWithArena(
 			return nil, err
 		}
 		return arena.allocProtoList(t.Typ, items), nil
+	case *TArray:
+		items, err := decodeConstantListWithArena(d, t.Typ, arena)
+		if err != nil {
+			return nil, err
+		}
+		return arena.allocProtoArray(t.Typ, items), nil
 	case *TPair:
 		first, err := decodeConstantValueWithArena(d, t.First, arena)
 		if err != nil {
@@ -1001,6 +1025,21 @@ func decodeConstantValueWithArena(
 			return nil, err
 		}
 		return arena.allocData(pd), nil
+	case *TValue:
+		entries, err := decodeConstantListWithArena(d, valueEntryType, arena)
+		if err != nil {
+			return nil, err
+		}
+		if err := validateValueEntries(entries); err != nil {
+			return nil, err
+		}
+		return arena.allocValue(entries), nil
+	case *TBls12_381G1Element:
+		return nil, errors.New("cannot decode bls12_381_G1_element constants")
+	case *TBls12_381G2Element:
+		return nil, errors.New("cannot decode bls12_381_G2_element constants")
+	case *TBls12_381MlResult:
+		return nil, errors.New("cannot decode bls12_381_mlresult constants")
 	default:
 		return nil, errors.New("unknown constant constructor")
 	}
@@ -1113,6 +1152,15 @@ func decodeConstantValue(d *decoder, typ Typ) (IConstant, error) {
 			List: items,
 		}
 
+	case *TArray:
+		items, err := DecodeList(d, func(d *decoder) (IConstant, error) {
+			return decodeConstantValue(d, t.Typ)
+		})
+		if err != nil {
+			return nil, err
+		}
+		constant = &ProtoArray{ATyp: t.Typ, Array: items}
+
 	// ProtoPair
 	case *TPair:
 		first, err := decodeConstantValue(d, t.First)
@@ -1144,11 +1192,94 @@ func decodeConstantValue(d *decoder, typ Typ) (IConstant, error) {
 
 		constant = &Data{pd}
 
+	case *TValue:
+		entries, err := DecodeList(d, func(d *decoder) (IConstant, error) {
+			return decodeConstantValue(d, valueEntryType)
+		})
+		if err != nil {
+			return nil, err
+		}
+		if err := validateValueEntries(entries); err != nil {
+			return nil, err
+		}
+		constant = &Value{Entries: entries}
+
+	case *TBls12_381G1Element:
+		return nil, errors.New("cannot decode bls12_381_G1_element constants")
+	case *TBls12_381G2Element:
+		return nil, errors.New("cannot decode bls12_381_G2_element constants")
+	case *TBls12_381MlResult:
+		return nil, errors.New("cannot decode bls12_381_mlresult constants")
+
 	default:
 		return nil, errors.New("unknown constant constructor")
 	}
 
 	return constant, nil
+}
+
+func validateValueEntries(entries []IConstant) error {
+	quantityLimit := new(big.Int).Lsh(big.NewInt(1), 127)
+	maxQuantity := new(big.Int).Sub(new(big.Int).Set(quantityLimit), big.NewInt(1))
+	minQuantity := new(big.Int).Neg(new(big.Int).Set(quantityLimit))
+
+	var previousPolicy []byte
+	for policyIndex, entry := range entries {
+		policy, ok := entry.(*ProtoPair)
+		if !ok {
+			return fmt.Errorf("value policy entry %d is not a pair", policyIndex)
+		}
+		policyID, ok := policy.First.(*ByteString)
+		if !ok {
+			return fmt.Errorf("value policy entry %d has a non-bytestring key", policyIndex)
+		}
+		if len(policyID.Inner) > 32 {
+			return fmt.Errorf("value policy entry %d key exceeds 32 bytes", policyIndex)
+		}
+		if policyIndex > 0 && bytes.Compare(previousPolicy, policyID.Inner) >= 0 {
+			return errors.New("value policy keys must be strictly ascending")
+		}
+
+		tokens, ok := policy.Second.(*ProtoList)
+		if !ok {
+			return fmt.Errorf("value policy entry %d has a non-list payload", policyIndex)
+		}
+		if len(tokens.List) == 0 {
+			return fmt.Errorf("value policy entry %d has no tokens", policyIndex)
+		}
+
+		var previousToken []byte
+		for tokenIndex, entry := range tokens.List {
+			token, ok := entry.(*ProtoPair)
+			if !ok {
+				return fmt.Errorf("value token entry %d:%d is not a pair", policyIndex, tokenIndex)
+			}
+			tokenID, ok := token.First.(*ByteString)
+			if !ok {
+				return fmt.Errorf("value token entry %d:%d has a non-bytestring key", policyIndex, tokenIndex)
+			}
+			if len(tokenID.Inner) > 32 {
+				return fmt.Errorf("value token entry %d:%d key exceeds 32 bytes", policyIndex, tokenIndex)
+			}
+			if tokenIndex > 0 && bytes.Compare(previousToken, tokenID.Inner) >= 0 {
+				return errors.New("value token keys must be strictly ascending")
+			}
+
+			quantity, ok := token.Second.(*Integer)
+			if !ok || quantity.Inner == nil {
+				return fmt.Errorf("value token entry %d:%d has a non-integer quantity", policyIndex, tokenIndex)
+			}
+			if quantity.Inner.Sign() == 0 {
+				return fmt.Errorf("value token entry %d:%d has a zero quantity", policyIndex, tokenIndex)
+			}
+			if quantity.Inner.Cmp(minQuantity) < 0 || quantity.Inner.Cmp(maxQuantity) > 0 {
+				return fmt.Errorf("value token entry %d:%d quantity is out of range", policyIndex, tokenIndex)
+			}
+			previousToken = tokenID.Inner
+		}
+		previousPolicy = policyID.Inner
+	}
+	return nil
 }
 
 var (
@@ -1158,6 +1289,18 @@ var (
 	cachedTUnit       Typ = &TUnit{}
 	cachedTBool       Typ = &TBool{}
 	cachedTData       Typ = &TData{}
+	cachedTBlsG1      Typ = &TBls12_381G1Element{}
+	cachedTBlsG2      Typ = &TBls12_381G2Element{}
+	cachedTBlsMl      Typ = &TBls12_381MlResult{}
+	cachedTValue      Typ = &TValue{}
+)
+
+var (
+	valueTokenType = &TPair{First: &TByteString{}, Second: &TInteger{}}
+	valueEntryType = &TPair{
+		First:  &TByteString{},
+		Second: &TList{Typ: valueTokenType},
+	}
 )
 
 type constantTagSeq struct {
@@ -1218,6 +1361,14 @@ func decodeConstantTypeAt(tags *constantTagSeq, idx int) (Typ, int, error) {
 		return cachedTBool, idx, nil
 	case DataTag:
 		return cachedTData, idx, nil
+	case Bls12_381G1Tag:
+		return cachedTBlsG1, idx, nil
+	case Bls12_381G2Tag:
+		return cachedTBlsG2, idx, nil
+	case Bls12_381MlTag:
+		return cachedTBlsMl, idx, nil
+	case ValueTag:
+		return cachedTValue, idx, nil
 	// NOTE: this also covers ProtoPairOneTag, but it's the same value as ProtoListOneTag.
 	case ProtoListOneTag:
 		if idx >= tags.len() {
@@ -1230,6 +1381,12 @@ func decodeConstantTypeAt(tags *constantTagSeq, idx int) (Typ, int, error) {
 				return nil, next, err
 			}
 			return &TList{Typ: subType}, next, nil
+		case ProtoArrayTag:
+			subType, next, err := decodeConstantTypeAt(tags, idx+1)
+			if err != nil {
+				return nil, next, err
+			}
+			return &TArray{Typ: subType}, next, nil
 		case ProtoPairTwoTag:
 			idx++
 			if idx >= tags.len() || tags.at(idx) != ProtoPairThreeTag {

--- a/syn/flat_encode.go
+++ b/syn/flat_encode.go
@@ -430,11 +430,28 @@ func encodeConstantTypeTags(e *encoder, typ Typ) error {
 	case *TData:
 		e.one()
 		e.bits(ConstTagWidth, DataTag)
+	case *TBls12_381G1Element:
+		e.one()
+		e.bits(ConstTagWidth, Bls12_381G1Tag)
+	case *TBls12_381G2Element:
+		e.one()
+		e.bits(ConstTagWidth, Bls12_381G2Tag)
+	case *TBls12_381MlResult:
+		e.one()
+		e.bits(ConstTagWidth, Bls12_381MlTag)
 	case *TList:
 		e.one()
 		e.bits(ConstTagWidth, ProtoListOneTag)
 		e.one()
 		e.bits(ConstTagWidth, ProtoListTwoTag)
+		if err := encodeConstantTypeTags(e, t.Typ); err != nil {
+			return err
+		}
+	case *TArray:
+		e.one()
+		e.bits(ConstTagWidth, ProtoListOneTag)
+		e.one()
+		e.bits(ConstTagWidth, ProtoArrayTag)
 		if err := encodeConstantTypeTags(e, t.Typ); err != nil {
 			return err
 		}
@@ -451,6 +468,9 @@ func encodeConstantTypeTags(e *encoder, typ Typ) error {
 		if err := encodeConstantTypeTags(e, t.Second); err != nil {
 			return err
 		}
+	case *TValue:
+		e.one()
+		e.bits(ConstTagWidth, ValueTag)
 	default:
 		return errors.New("unsupported constant type")
 	}
@@ -477,6 +497,17 @@ func encodeConstantValue(e *encoder, constant IConstant) error {
 		return EncodeList(e, c.List, func(e *encoder, item IConstant) error {
 			return encodeConstantValue(e, item)
 		})
+	case *ProtoArray:
+		return EncodeList(e, c.Array, func(e *encoder, item IConstant) error {
+			return encodeConstantValue(e, item)
+		})
+	case *Value:
+		if err := validateValueEntries(c.Entries); err != nil {
+			return err
+		}
+		return EncodeList(e, c.Entries, func(e *encoder, item IConstant) error {
+			return encodeConstantValue(e, item)
+		})
 	case *ProtoPair:
 		if err := encodeConstantValue(e, c.First); err != nil {
 			return err
@@ -488,6 +519,12 @@ func encodeConstantValue(e *encoder, constant IConstant) error {
 			return err
 		}
 		return e.bytes(cborBytes)
+	case *Bls12_381G1Element:
+		return errors.New("cannot encode bls12_381_G1_element constants")
+	case *Bls12_381G2Element:
+		return errors.New("cannot encode bls12_381_G2_element constants")
+	case *Bls12_381MlResult:
+		return errors.New("cannot encode bls12_381_mlresult constants")
 	default:
 		return errors.New("unsupported constant value")
 	}

--- a/syn/flat_universe_types_test.go
+++ b/syn/flat_universe_types_test.go
@@ -1,0 +1,213 @@
+package syn
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestDecodeFlatUniverseTypes(t *testing.T) {
+	tests := []struct {
+		name     string
+		hexInput string
+		check    func(*testing.T, IConstant)
+	}{
+		{
+			name:     "empty list of BLS G1 elements",
+			hexInput: "0101004bd721",
+			check: func(t *testing.T, constant IConstant) {
+				t.Helper()
+				list, ok := constant.(*ProtoList)
+				if !ok {
+					t.Fatalf("constant type = %T, want *ProtoList", constant)
+				}
+				if _, ok := list.LTyp.(*TBls12_381G1Element); !ok {
+					t.Fatalf("list element type = %T, want *TBls12_381G1Element", list.LTyp)
+				}
+				if len(list.List) != 0 {
+					t.Fatalf("list length = %d, want 0", len(list.List))
+				}
+			},
+		},
+		{
+			name:     "empty list of BLS G2 elements",
+			hexInput: "0101004bd741",
+			check: func(t *testing.T, constant IConstant) {
+				t.Helper()
+				list, ok := constant.(*ProtoList)
+				if !ok {
+					t.Fatalf("constant type = %T, want *ProtoList", constant)
+				}
+				if _, ok := list.LTyp.(*TBls12_381G2Element); !ok {
+					t.Fatalf("list element type = %T, want *TBls12_381G2Element", list.LTyp)
+				}
+				if len(list.List) != 0 {
+					t.Fatalf("list length = %d, want 0", len(list.List))
+				}
+			},
+		},
+		{
+			name:     "empty list of BLS Miller-loop results",
+			hexInput: "0101004bd761",
+			check: func(t *testing.T, constant IConstant) {
+				t.Helper()
+				list, ok := constant.(*ProtoList)
+				if !ok {
+					t.Fatalf("constant type = %T, want *ProtoList", constant)
+				}
+				if _, ok := list.LTyp.(*TBls12_381MlResult); !ok {
+					t.Fatalf("list element type = %T, want *TBls12_381MlResult", list.LTyp)
+				}
+				if len(list.List) != 0 {
+					t.Fatalf("list length = %d, want 0", len(list.List))
+				}
+			},
+		},
+		{
+			name:     "empty array of BLS G1 elements",
+			hexInput: "0101004bf321",
+			check: func(t *testing.T, constant IConstant) {
+				t.Helper()
+				if got := fmt.Sprintf("%T", constant); got != "*syn.ProtoArray" {
+					t.Fatalf("constant type = %s, want *syn.ProtoArray", got)
+				}
+				if got := fmt.Sprintf("%T", constant.Typ()); got != "*syn.TArray" {
+					t.Fatalf("constant Typ() = %s, want *syn.TArray", got)
+				}
+			},
+		},
+		{
+			name:     "empty integer array",
+			hexInput: "0101004bf201",
+			check: func(t *testing.T, constant IConstant) {
+				t.Helper()
+				if got := fmt.Sprintf("%T", constant); got != "*syn.ProtoArray" {
+					t.Fatalf("constant type = %s, want *syn.ProtoArray", got)
+				}
+				if got := fmt.Sprintf("%T", constant.Typ()); got != "*syn.TArray" {
+					t.Fatalf("constant Typ() = %s, want *syn.TArray", got)
+				}
+			},
+		},
+		{
+			name:     "empty value",
+			hexInput: "0101004e81",
+			check: func(t *testing.T, constant IConstant) {
+				t.Helper()
+				if got := fmt.Sprintf("%T", constant); got != "*syn.Value" {
+					t.Fatalf("constant type = %s, want *syn.Value", got)
+				}
+				if _, ok := constant.Typ().(*TValue); !ok {
+					t.Fatalf("constant Typ() = %T, want *TValue", constant.Typ())
+				}
+			},
+		},
+		{
+			name:     "single-entry value",
+			hexInput: "0101004ea10081000201",
+			check: func(t *testing.T, constant IConstant) {
+				t.Helper()
+				if got := fmt.Sprintf("%T", constant); got != "*syn.Value" {
+					t.Fatalf("constant type = %s, want *syn.Value", got)
+				}
+				if _, ok := constant.Typ().(*TValue); !ok {
+					t.Fatalf("constant Typ() = %T, want *TValue", constant.Typ())
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			input, err := hex.DecodeString(test.hexInput)
+			if err != nil {
+				t.Fatalf("decode fixture: %v", err)
+			}
+
+			program, err := Decode[DeBruijn](input)
+			if err != nil {
+				t.Fatalf("Decode[DeBruijn](): %v", err)
+			}
+			constant, ok := program.Term.(*Constant)
+			if !ok {
+				t.Fatalf("term type = %T, want *Constant", program.Term)
+			}
+			test.check(t, constant.Con)
+
+			encoded, err := Encode(program)
+			if err != nil {
+				t.Fatalf("Encode(): %v", err)
+			}
+			if !bytes.Equal(encoded, input) {
+				t.Fatalf("re-encoded bytes = %x, want %x", encoded, input)
+			}
+
+			genericProgram, err := Decode[NamedDeBruijn](input)
+			if err != nil {
+				t.Fatalf("Decode[NamedDeBruijn](): %v", err)
+			}
+			genericConstant, ok := genericProgram.Term.(*Constant)
+			if !ok {
+				t.Fatalf("generic term type = %T, want *Constant", genericProgram.Term)
+			}
+			test.check(t, genericConstant.Con)
+		})
+	}
+}
+
+func TestDecodeUnsupportedBLSConstantsFailsClosed(t *testing.T) {
+	tests := []struct {
+		name     string
+		hexInput string
+		wantType string
+	}{
+		{name: "G1", hexInput: "0101004c81", wantType: "bls12_381_G1_element"},
+		{name: "G2", hexInput: "0101004d01", wantType: "bls12_381_G2_element"},
+		{name: "Miller-loop result", hexInput: "0101004d81", wantType: "bls12_381_mlresult"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			input, err := hex.DecodeString(test.hexInput)
+			if err != nil {
+				t.Fatalf("decode fixture: %v", err)
+			}
+
+			for name, decode := range map[string]func([]byte) error{
+				"DeBruijn": func(input []byte) error {
+					_, err := Decode[DeBruijn](input)
+					return err
+				},
+				"NamedDeBruijn": func(input []byte) error {
+					_, err := Decode[NamedDeBruijn](input)
+					return err
+				},
+			} {
+				err := decode(input)
+				if err == nil {
+					t.Fatalf("Decode[%s]() error = nil, want unsupported BLS constant error", name)
+				}
+				if !strings.Contains(err.Error(), test.wantType) {
+					t.Fatalf("Decode[%s]() error = %q, want type %q", name, err, test.wantType)
+				}
+			}
+		})
+	}
+}
+
+func TestDecodeValueRejectsZeroQuantity(t *testing.T) {
+	input, err := hex.DecodeString("0101004ea10081000001")
+	if err != nil {
+		t.Fatalf("decode fixture: %v", err)
+	}
+
+	_, err = Decode[DeBruijn](input)
+	if err == nil {
+		t.Fatal("Decode() error = nil, want zero-quantity rejection")
+	}
+	if !strings.Contains(err.Error(), "zero quantity") {
+		t.Fatalf("Decode() error = %q, want zero-quantity rejection", err)
+	}
+}

--- a/syn/parser.go
+++ b/syn/parser.go
@@ -1202,8 +1202,10 @@ func (p *Parser) parseTypeSpec() (Typ, error) {
 	}
 	defer p.leave()
 
-	// Check for invalid bare list or pair
-	if p.curToken.Type == lex.TokenList || p.curToken.Type == lex.TokenPair {
+	// Check for invalid bare composite types.
+	if p.curToken.Type == lex.TokenList ||
+		p.curToken.Type == lex.TokenArray ||
+		p.curToken.Type == lex.TokenPair {
 		return nil, fmt.Errorf(
 			"expected left parenthesis for %d type, got %v (literal: %s) at position %d",
 			p.curToken.Type,

--- a/syn/parser.go
+++ b/syn/parser.go
@@ -506,40 +506,23 @@ func (p *Parser) parseConstant() (Term[Name], error) {
 
 		return &Constant{Con: &Data{Inner: dataVal}}, nil
 	case *TList:
-		if err := p.expect(lex.TokenLBracket); err != nil {
+		items, err := p.parseConstantCollection(ts.Typ, "list")
+		if err != nil {
 			return nil, err
 		}
-
-		var items []IConstant
-
-		for p.curToken.Type != lex.TokenRBracket {
-			item, err := p.parseConstantValue(ts.Typ)
-			if err != nil {
-				return nil, err
-			}
-
-			if !EqualType(item.Typ(), ts.Typ) {
-				return nil, fmt.Errorf("list element of type %T does not match expected type %T at position %d", item.Typ(), ts.Typ, p.curToken.Position)
-			}
-
-			items = append(items, item)
-
-			if p.curToken.Type != lex.TokenRBracket {
-				if err := p.expect(lex.TokenComma); err != nil {
-					return nil, err
-				}
-			}
-		}
-
-		if err := p.expect(lex.TokenRBracket); err != nil {
-			return nil, err
-		}
-
 		if err := p.expect(lex.TokenRParen); err != nil {
 			return nil, err
 		}
-
 		return &Constant{Con: &ProtoList{LTyp: ts.Typ, List: items}}, nil
+	case *TArray:
+		items, err := p.parseConstantCollection(ts.Typ, "array")
+		if err != nil {
+			return nil, err
+		}
+		if err := p.expect(lex.TokenRParen); err != nil {
+			return nil, err
+		}
+		return &Constant{Con: &ProtoArray{ATyp: ts.Typ, Array: items}}, nil
 	case *TPair:
 		if err := p.expect(lex.TokenLParen); err != nil {
 			return nil, err
@@ -800,12 +783,46 @@ func (p *Parser) parseConstant() (Term[Name], error) {
 			}
 		}
 
-		valType := &TPair{First: &TByteString{}, Second: &TList{Typ: &TPair{First: &TByteString{}, Second: &TInteger{}}}}
-
-		return &Constant{Con: &ProtoList{LTyp: valType, List: items}}, nil
+		return &Constant{Con: &Value{Entries: items}}, nil
 	default:
 		return nil, fmt.Errorf("unexpected type spec %v at position %d", typeSpec, p.curToken.Position)
 	}
+}
+
+func (p *Parser) parseConstantCollection(
+	elementType Typ,
+	collectionName string,
+) ([]IConstant, error) {
+	if err := p.expect(lex.TokenLBracket); err != nil {
+		return nil, err
+	}
+
+	var items []IConstant
+	for p.curToken.Type != lex.TokenRBracket {
+		item, err := p.parseConstantValue(elementType)
+		if err != nil {
+			return nil, err
+		}
+		if !EqualType(item.Typ(), elementType) {
+			return nil, fmt.Errorf(
+				"%s element of type %T does not match expected type %T at position %d",
+				collectionName,
+				item.Typ(),
+				elementType,
+				p.curToken.Position,
+			)
+		}
+		items = append(items, item)
+		if p.curToken.Type != lex.TokenRBracket {
+			if err := p.expect(lex.TokenComma); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if err := p.expect(lex.TokenRBracket); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 func (p *Parser) parseConstantValue(typ Typ) (IConstant, error) {
@@ -937,36 +954,26 @@ func (p *Parser) parseConstantValue(typ Typ) (IConstant, error) {
 
 		return &Data{Inner: dataVal}, nil
 	case *TList:
-		if err := p.expect(lex.TokenLBracket); err != nil {
+		items, err := p.parseConstantCollection(t.Typ, "list")
+		if err != nil {
 			return nil, err
 		}
-
-		var items []IConstant
-
-		for p.curToken.Type != lex.TokenRBracket {
-			item, err := p.parseConstantValue(t.Typ)
-			if err != nil {
-				return nil, err
-			}
-
-			if !EqualType(item.Typ(), t.Typ) {
-				return nil, fmt.Errorf("list element of type %T does not match expected type %T at position %d", item.Typ(), t.Typ, p.curToken.Position)
-			}
-
-			items = append(items, item)
-
-			if p.curToken.Type != lex.TokenRBracket {
-				if err := p.expect(lex.TokenComma); err != nil {
-					return nil, err
-				}
-			}
-		}
-
-		if err := p.expect(lex.TokenRBracket); err != nil {
-			return nil, err
-		}
-
 		return &ProtoList{LTyp: t.Typ, List: items}, nil
+	case *TArray:
+		items, err := p.parseConstantCollection(t.Typ, "array")
+		if err != nil {
+			return nil, err
+		}
+		return &ProtoArray{ATyp: t.Typ, Array: items}, nil
+	case *TValue:
+		items, err := p.parseConstantCollection(valueEntryType, "value")
+		if err != nil {
+			return nil, err
+		}
+		if err := validateValueEntries(items); err != nil {
+			return nil, err
+		}
+		return &Value{Entries: items}, nil
 	case *TPair:
 		if err := p.expect(lex.TokenLParen); err != nil {
 			return nil, err
@@ -1257,6 +1264,8 @@ func (p *Parser) parseInnerTypeSpec() (Typ, error) {
 			return &TBls12_381G1Element{}, nil
 		case "bls12_381_G2_element":
 			return &TBls12_381G2Element{}, nil
+		case "bls12_381_mlresult":
+			return &TBls12_381MlResult{}, nil
 		case "value":
 			return &TValue{}, nil
 		default:
@@ -1266,7 +1275,7 @@ func (p *Parser) parseInnerTypeSpec() (Typ, error) {
 				p.curToken.Position,
 			)
 		}
-	case lex.TokenList, lex.TokenArray:
+	case lex.TokenList:
 		p.nextToken()
 
 		// Parse element type, which may be parenthesized (e.g., (list data)) or simple (e.g., data)
@@ -1276,6 +1285,15 @@ func (p *Parser) parseInnerTypeSpec() (Typ, error) {
 		}
 
 		return &TList{Typ: elemType}, nil
+	case lex.TokenArray:
+		p.nextToken()
+
+		elemType, err := p.parseTypeSpec()
+		if err != nil {
+			return nil, err
+		}
+
+		return &TArray{Typ: elemType}, nil
 	case lex.TokenPair:
 		p.nextToken()
 

--- a/syn/parser_test.go
+++ b/syn/parser_test.go
@@ -12,6 +12,13 @@ func TestParsePrettyRoundTrip(t *testing.T) {
 		`(program 1.2.0 (lam x x))`,
 		`(program 1.2.0 (con data (Constr -1 [])))`,
 		`(program 1.2.0 (con data (Constr 1208925819614629174706176 [])))`,
+		`(program 1.3.0 (con (array integer) []))`,
+		`(program 1.3.0 (con value []))`,
+		`(program 1.3.0 (con value [(#01, [(#02, 1)])]))`,
+		`(program 1.3.0 (con (array value) [[(#01, [(#02, 1)])]]))`,
+		`(program 1.3.0 (con (list bls12_381_G1_element) []))`,
+		`(program 1.3.0 (con (list bls12_381_G2_element) []))`,
+		`(program 1.3.0 (con (list bls12_381_mlresult) []))`,
 	}
 
 	for _, input := range programs {

--- a/syn/parser_test.go
+++ b/syn/parser_test.go
@@ -1,6 +1,7 @@
 package syn
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -21,30 +22,32 @@ func TestParsePrettyRoundTrip(t *testing.T) {
 		`(program 1.3.0 (con (list bls12_381_mlresult) []))`,
 	}
 
-	for _, input := range programs {
-		parsed, err := Parse(input)
-		if err != nil {
-			t.Fatalf("Failed to parse input %q: %v", input, err)
-		}
+	for i, input := range programs {
+		t.Run(fmt.Sprintf("program-%02d", i), func(t *testing.T) {
+			parsed, err := Parse(input)
+			if err != nil {
+				t.Fatalf("Failed to parse input %q: %v", input, err)
+			}
 
-		pretty := Pretty(parsed)
+			pretty := Pretty(parsed)
 
-		parsedAgain, err := Parse(pretty)
-		if err != nil {
-			t.Errorf("Failed to parse pretty output %q: %v", pretty, err)
-			continue
-		}
+			parsedAgain, err := Parse(pretty)
+			if err != nil {
+				t.Errorf("Failed to parse pretty output %q: %v", pretty, err)
+				return
+			}
 
-		// Check that pretty printing again gives the same result
-		prettyAgain := Pretty(parsedAgain)
-		if pretty != prettyAgain {
-			t.Errorf(
-				"Round-trip failed for input %q: first pretty %q, second %q",
-				input,
-				pretty,
-				prettyAgain,
-			)
-		}
+			// Check that pretty printing again gives the same result
+			prettyAgain := Pretty(parsedAgain)
+			if pretty != prettyAgain {
+				t.Errorf(
+					"Round-trip failed for input %q: first pretty %q, second %q",
+					input,
+					pretty,
+					prettyAgain,
+				)
+			}
+		})
 	}
 }
 

--- a/syn/parser_test.go
+++ b/syn/parser_test.go
@@ -48,6 +48,13 @@ func TestParsePrettyRoundTrip(t *testing.T) {
 	}
 }
 
+func TestParseRejectsBareArrayType(t *testing.T) {
+	_, err := Parse(`(program 1.3.0 (con array integer []))`)
+	if err == nil {
+		t.Fatal("expected bare array type to be rejected")
+	}
+}
+
 func FuzzParse(f *testing.F) {
 	for _, input := range fuzzProgramSeeds() {
 		f.Add(input)

--- a/syn/pretty.go
+++ b/syn/pretty.go
@@ -251,8 +251,9 @@ func (pp *PrettyPrinter) printConstant(c *Constant, inCollection bool) {
 		pp.write(con.Inner.String())
 	case *ByteString:
 		if !inCollection {
-			pp.write("bytestring #")
+			pp.write("bytestring ")
 		}
+		pp.write("#")
 
 		for _, b := range con.Inner {
 			fmt.Fprintf(&pp.builder, "%02x", b)
@@ -290,23 +291,19 @@ func (pp *PrettyPrinter) printConstant(c *Constant, inCollection bool) {
 			pp.write(") ")
 		}
 
-		if len(con.List) == 0 {
-			pp.write("[]")
-		} else {
-			pp.write("[\n")
-			pp.increaseIndent()
-			for i, item := range con.List {
-				pp.writeIndent()
-				pp.printConstant(&Constant{Con: item}, true)
-				if i < len(con.List)-1 {
-					pp.write(",")
-				}
-				pp.write("\n")
-			}
-			pp.decreaseIndent()
-			pp.writeIndent()
-			pp.write("]")
+		pp.printConstantCollection(con.List)
+	case *ProtoArray:
+		if !inCollection {
+			pp.write("(array ")
+			pp.printType(con.ATyp)
+			pp.write(") ")
 		}
+		pp.printConstantCollection(con.Array)
+	case *Value:
+		if !inCollection {
+			pp.write("value ")
+		}
+		pp.printConstantCollection(con.Entries)
 	case *ProtoPair:
 		if !inCollection {
 			pp.write("(pair ")
@@ -333,8 +330,9 @@ func (pp *PrettyPrinter) printConstant(c *Constant, inCollection bool) {
 		}
 	case *Bls12_381G1Element:
 		if !inCollection {
-			pp.write("bls12_381_G1_element 0x")
+			pp.write("bls12_381_G1_element ")
 		}
+		pp.write("0x")
 
 		affine := new(bls.G1Affine).FromJacobian(con.Inner)
 
@@ -343,8 +341,9 @@ func (pp *PrettyPrinter) printConstant(c *Constant, inCollection bool) {
 		}
 	case *Bls12_381G2Element:
 		if !inCollection {
-			pp.write("bls12_381_G2_element 0x")
+			pp.write("bls12_381_G2_element ")
 		}
+		pp.write("0x")
 
 		affine := new(bls.G2Affine).FromJacobian(con.Inner)
 
@@ -358,6 +357,26 @@ func (pp *PrettyPrinter) printConstant(c *Constant, inCollection bool) {
 	if !inCollection {
 		pp.write(")")
 	}
+}
+
+func (pp *PrettyPrinter) printConstantCollection(items []IConstant) {
+	if len(items) == 0 {
+		pp.write("[]")
+		return
+	}
+	pp.write("[\n")
+	pp.increaseIndent()
+	for i, item := range items {
+		pp.writeIndent()
+		pp.printConstant(&Constant{Con: item}, true)
+		if i < len(items)-1 {
+			pp.write(",")
+		}
+		pp.write("\n")
+	}
+	pp.decreaseIndent()
+	pp.writeIndent()
+	pp.write("]")
 }
 
 // printType formats a Typ interface
@@ -375,8 +394,18 @@ func (pp *PrettyPrinter) printType(typ Typ) {
 		pp.write("bool")
 	case *TData:
 		pp.write("data")
+	case *TBls12_381G1Element:
+		pp.write("bls12_381_G1_element")
+	case *TBls12_381G2Element:
+		pp.write("bls12_381_G2_element")
+	case *TBls12_381MlResult:
+		pp.write("bls12_381_mlresult")
 	case *TList:
 		pp.write("(list ")
+		pp.printType(t.Typ)
+		pp.write(")")
+	case *TArray:
+		pp.write("(array ")
 		pp.printType(t.Typ)
 		pp.write(")")
 	case *TPair:
@@ -385,6 +414,8 @@ func (pp *PrettyPrinter) printType(typ Typ) {
 		pp.write(" ")
 		pp.printType(t.Second)
 		pp.write(")")
+	case *TValue:
+		pp.write("value")
 	default:
 		pp.write(fmt.Sprintf("unknown type: %v", typ))
 	}

--- a/syn/tag.go
+++ b/syn/tag.go
@@ -29,6 +29,11 @@ const (
 	UnitTag           byte = 3
 	BoolTag           byte = 4
 	DataTag           byte = 8
+	Bls12_381G1Tag    byte = 9
+	Bls12_381G2Tag    byte = 10
+	Bls12_381MlTag    byte = 11
+	ProtoArrayTag     byte = 12
+	ValueTag          byte = 13
 	ProtoListOneTag   byte = 7
 	ProtoListTwoTag   byte = 5
 	ProtoPairOneTag   byte = 7

--- a/syn/typ.go
+++ b/syn/typ.go
@@ -30,6 +30,12 @@ type TList struct {
 
 func (t TList) isTyp() {}
 
+type TArray struct {
+	Typ
+}
+
+func (t TArray) isTyp() {}
+
 type TPair struct {
 	First  Typ
 	Second Typ
@@ -93,6 +99,9 @@ func EqualType(a, b Typ) bool {
 		return ok
 	case *TList:
 		tb, ok := b.(*TList)
+		return ok && EqualType(ta.Typ, tb.Typ)
+	case *TArray:
+		tb, ok := b.(*TArray)
 		return ok && EqualType(ta.Typ, tb.Typ)
 	case *TPair:
 		tb, ok := b.(*TPair)


### PR DESCRIPTION
## Summary

- Decode and re-encode the stable BLS, Array, and Value FLAT universe tags.
- Preserve Array and Value type identity through CEK evaluation, discharge, parser, and pretty-printer paths.
- Validate canonical Value payload constraints and reject unsupported standalone BLS payloads cleanly.
- Use the reference Array and Value dimensions for execution-memory costing.

Fixes #380

## Validation

- exact-base FLAT regression fails on all new universe tags;
- focused `syn` and `cek` race tests, 10 repetitions;
- `go test -race -count=1 ./...`;
- `go vet ./...`;
- `golangci-lint run ./...`;
- NilAway;
- bounded FLAT decoder fuzzing and the large-word benchmark;
- `gofmt` and `git diff --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for typed arrays and value constants.
  * Added parsing, encoding, decoding, type checking, and pretty-printing for arrays and values.
  * Added support for recognizing BLS12-381-related constant types.

* **Bug Fixes**
  * Improved preservation of array and value types through evaluation and serialization.
  * Added validation for value entries, including key ordering, quantity limits, and invalid zero quantities.
  * Unsupported BLS12-381 constant values now fail clearly instead of being processed incorrectly.

* **Tests**
  * Expanded coverage for round-trip serialization, evaluation, formatting, and memory-cost calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->