### PR TITLE
fix(cek): enforce valueData entry limit

### DIFF
--- a/cek/builtins.go
+++ b/cek/builtins.go
@@ -56,6 +56,7 @@ const (
 	ed25519VerifyMaxCacheMsg = 64
 	ed25519VerifyCacheShards = 64
 	ed25519VerifyShardLimit  = ed25519VerifyCacheLimit / ed25519VerifyCacheShards
+	valueDataMaxSize         = 40_000
 )
 
 type ed25519VerifyCacheKey struct {
@@ -4914,6 +4915,13 @@ func valueData[T syn.Eval](m *Machine[T], b *Builtin[T]) (Value[T], error) {
 	// Cost model uses linear_in_x with max(outer, inner) size
 	if err := m.CostOne(&b.Func, valueMaxCountExMem(plist.List)); err != nil {
 		return nil, err
+	}
+	if valueInnerCountExMem(plist.List)() > valueDataMaxSize {
+		return nil, &BuiltinError{
+			Code:    ErrCodeInvalidArgument,
+			Builtin: "valueData",
+			Message: "maximum input size (40000) exceeded",
+		}
 	}
 
 	// Convert value to data map

--- a/cek/builtins_test.go
+++ b/cek/builtins_test.go
@@ -4768,6 +4768,63 @@ func TestValueDataEntryLimit(t *testing.T) {
 	}
 }
 
+func TestValueDataEntryLimitChargesCostFirst(t *testing.T) {
+	oversizedValue := newValueDataBoundaryInput(valueDataMaxSize + 1)
+	tests := []struct {
+		name       string
+		version    lang.LanguageVersion
+		protoMajor uint
+	}{
+		{name: "V1 PV11", version: lang.LanguageVersionV1, protoMajor: 11},
+		{name: "V2 PV11", version: lang.LanguageVersionV2, protoMajor: 11},
+		{name: "V3 PV11", version: lang.LanguageVersionV3, protoMajor: 11},
+		{name: "V4 PV12", version: lang.LanguageVersionV4, protoMajor: 12},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := NewDefaultEvalContext(
+				tt.version,
+				ProtoVersion{Major: tt.protoMajor},
+			)
+			m := NewMachine[syn.DeBruijn](tt.version, 0, ctx)
+			m.ExBudget = ExBudget{}
+			b := newTestBuiltin(builtin.ValueData).ApplyArg(oversizedValue)
+
+			_, err := evalBuiltinWithError(t, m, b)
+			if err == nil {
+				t.Fatal("expected insufficient budget to reject oversized valueData input")
+			}
+			var budgetErr *BudgetError
+			if !errors.As(err, &budgetErr) {
+				t.Fatalf(
+					"expected valueData cost to be charged before the size check, got %T: %v",
+					err,
+					err,
+				)
+			}
+			if budgetErr.Code != ErrCodeBudgetExhausted {
+				t.Fatalf(
+					"expected ErrCodeBudgetExhausted, got %d",
+					budgetErr.Code,
+				)
+			}
+			if budgetErr.Requested.Cpu <= 0 || budgetErr.Requested.Mem <= 0 {
+				t.Fatalf(
+					"expected positive valueData cost, got %+v",
+					budgetErr.Requested,
+				)
+			}
+			if budgetErr.Available != (ExBudget{}) {
+				t.Fatalf(
+					"expected zero available budget, got %+v",
+					budgetErr.Available,
+				)
+			}
+		})
+	}
+}
+
 func TestBigIntMod256Byte(t *testing.T) {
 	hugePlus5 := new(big.Int).Lsh(big.NewInt(1), 4096)
 	hugePlus5.Add(hugePlus5, big.NewInt(5))

--- a/cek/builtins_test.go
+++ b/cek/builtins_test.go
@@ -4661,6 +4661,113 @@ func TestDataBuiltinsRejectMalformedElements(t *testing.T) {
 	}
 }
 
+// newValueDataBoundaryInput builds a normalized value with one policy and the
+// requested number of distinct token entries. The count matches Plutus's
+// totalSize, which is the number of (policy, token) pairs.
+func newValueDataBoundaryInput(tokenCount int) *Constant {
+	tokens := make([]syn.IConstant, tokenCount)
+	for i := range tokens {
+		tokens[i] = &syn.ProtoPair{
+			FstType: &syn.TByteString{},
+			SndType: &syn.TInteger{},
+			First: &syn.ByteString{Inner: []byte{
+				byte(i >> 24),
+				byte(i >> 16),
+				byte(i >> 8),
+				byte(i),
+			}},
+			Second: &syn.Integer{Inner: big.NewInt(1)},
+		}
+	}
+
+	return &Constant{&syn.ProtoList{
+		LTyp: &syn.TPair{
+			First: &syn.TByteString{},
+			Second: &syn.TList{Typ: &syn.TPair{
+				First:  &syn.TByteString{},
+				Second: &syn.TInteger{},
+			}},
+		},
+		List: []syn.IConstant{
+			&syn.ProtoPair{
+				FstType: &syn.TByteString{},
+				SndType: &syn.TList{Typ: &syn.TPair{
+					First:  &syn.TByteString{},
+					Second: &syn.TInteger{},
+				}},
+				First: &syn.ByteString{Inner: []byte{}},
+				Second: &syn.ProtoList{
+					LTyp: &syn.TPair{
+						First:  &syn.TByteString{},
+						Second: &syn.TInteger{},
+					},
+					List: tokens,
+				},
+			},
+		},
+	}}
+}
+
+// TestValueDataEntryLimit follows the upstream Plutus boundary: valueData
+// accepts exactly 40,000 entries and rejects larger values. The reference
+// implementation is PlutusCore.Value.valueDataMaxSize/valueData:
+// https://github.com/IntersectMBO/plutus/blob/master/plutus-core/plutus-core/src/PlutusCore/Value.hs
+func TestValueDataEntryLimit(t *testing.T) {
+	const maxEntries = 40_000
+	tests := []struct {
+		name       string
+		entries    int
+		wantErr    bool
+		wantOutput int
+	}{
+		{name: "below limit", entries: maxEntries - 1, wantOutput: maxEntries - 1},
+		{name: "at limit", entries: maxEntries, wantOutput: maxEntries},
+		{name: "above limit", entries: maxEntries + 1, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newTestMachineV4()
+			b := newTestBuiltin(builtin.ValueData)
+			b = b.ApplyArg(newValueDataBoundaryInput(tt.entries))
+
+			val, err := evalBuiltinWithError(t, m, b)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected oversized valueData input to fail")
+				}
+				var builtinErr *BuiltinError
+				if !errors.As(err, &builtinErr) {
+					t.Fatalf("expected BuiltinError, got %T: %v", err, err)
+				}
+				if builtinErr.Code != ErrCodeInvalidArgument {
+					t.Fatalf("expected ErrCodeInvalidArgument, got %d", builtinErr.Code)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("valueData(%d entries) returned error: %v", tt.entries, err)
+			}
+			result := expectMaterializedData(t, val)
+			resultMap, ok := result.Inner.(*data.Map)
+			if !ok {
+				t.Fatalf("expected data map, got %T", result.Inner)
+			}
+			if len(resultMap.Pairs) != 1 {
+				t.Fatalf("expected one policy entry, got %d", len(resultMap.Pairs))
+			}
+			tokens, ok := resultMap.Pairs[0][1].(*data.Map)
+			if !ok {
+				t.Fatalf("expected token data map, got %T", resultMap.Pairs[0][1])
+			}
+			if len(tokens.Pairs) != tt.wantOutput {
+				t.Fatalf("expected %d token entries, got %d", tt.wantOutput, len(tokens.Pairs))
+			}
+		})
+	}
+}
+
 func TestBigIntMod256Byte(t *testing.T) {
 	hugePlus5 := new(big.Int).Lsh(big.NewInt(1), 4096)
 	hugePlus5.Add(hugePlus5, big.NewInt(5))


### PR DESCRIPTION
## Summary

- enforce the upstream 40,000-entry `valueData` limit
- charge the existing builtin cost before rejecting oversized values
- preserve the exact boundary and valid conversion behavior
- cover cost-before-rejection across V1/PV11 through V4/PV12

## Checks

- `go test -race -count=3 -run '^(TestValueDataEntryLimit|TestValueDataEntryLimitChargesCostFirst)$' ./cek`
- fail-before proof with the size guard moved ahead of cost charging
- `go test -race ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `nilaway ./...`
- formatting and diff checks

Fixes #386
