### PR TITLE
fix(syn): validate Plutus programs

### DIFF
--- a/replay/corpus.go
+++ b/replay/corpus.go
@@ -201,14 +201,21 @@ func (c *Case) validate() (decodedCase, error) {
 	if c.ProtocolVersion.Major == 0 {
 		return decodedCase{}, errors.New("protocol major version must be positive")
 	}
-	if _, err := c.Language.Version(); err != nil {
+	languageVersion, err := c.Language.Version()
+	if err != nil {
 		return decodedCase{}, err
 	}
 	flatProgram, err := decodeHex("flat program", c.FlatProgramHex)
 	if err != nil {
 		return decodedCase{}, err
 	}
-	program, err := syn.Decode[syn.DeBruijn](flatProgram)
+	program, err := syn.DecodeDeBruijnWithContext(
+		flatProgram,
+		syn.ProgramContext{
+			LedgerLanguage: languageVersion,
+			ProtocolMajor:  c.ProtocolVersion.Major,
+		},
+	)
 	if err != nil {
 		return decodedCase{}, fmt.Errorf("decode FLAT program: %w", err)
 	}

--- a/replay/replay_test.go
+++ b/replay/replay_test.go
@@ -135,9 +135,10 @@ func TestRunCaseUsesLedgerLanguageInsteadOfUPLCVersion(t *testing.T) {
 			Con: &syn.Data{Inner: data.NewInteger(big.NewInt(42))},
 		},
 	}
-	replayCase := baseCaseWithVersion(t, lang.LanguageVersionV2, term, nil)
-	// The UPLC header identifies this as a V2 program. The ledger language must
-	// still control builtin availability, so the same program is rejected as V1.
+	// The UPLC header is 1.0.0, which is valid for both ledger languages at PV10.
+	// The selected ledger language must control builtin availability, so the
+	// same program is accepted as V2 and rejected as V1.
+	replayCase := baseCaseWithVersion(t, lang.LanguageVersionV1, term, nil)
 	replayCase.Language = PlutusV2
 	v2Result := RunCase(&replayCase)
 	if !v2Result.Actual.Success {
@@ -149,8 +150,8 @@ func TestRunCaseUsesLedgerLanguageInsteadOfUPLCVersion(t *testing.T) {
 	if v1Result.Actual.Success {
 		t.Fatal("Plutus V1 evaluation unexpectedly accepted a V2 builtin")
 	}
-	if v1Result.Actual.SetupError {
-		t.Fatalf("Plutus V1 evaluation setup failed: %s", v1Result.Actual.Error)
+	if !v1Result.Actual.SetupError {
+		t.Fatalf("Plutus V1 evaluation did not reject the invalid program during setup: %s", v1Result.Actual.Error)
 	}
 }
 

--- a/syn/doc.go
+++ b/syn/doc.go
@@ -53,6 +53,9 @@
 //
 //   - Text format via [Parse] and [PrettyTerm]
 //   - FLAT binary format via [Decode] (used on-chain)
+//   - Validated text and FLAT entry points via [ParseWithContext] and
+//     [DecodeWithContext], which require the selected ledger language and
+//     protocol version
 //
 // # Binder Interface
 //

--- a/syn/flat_decode.go
+++ b/syn/flat_decode.go
@@ -45,14 +45,14 @@ func decodeDeBruijn(bytes []byte) (*Program[DeBruijn], error) {
 	d := newDecoder(bytes)
 	arena := newTermArena[DeBruijn]()
 	consts := &constantArena{}
-	return decodeDeBruijnProgram(d, arena, consts)
+	return decodeDeBruijnProgram(d, arena, consts, nil)
 }
 
 func (d *DeBruijnDecoder) Decode(bytes []byte) (*Program[DeBruijn], error) {
 	d.decoder.reset(bytes)
 	d.arena.reset()
 	d.consts.reset()
-	return decodeDeBruijnProgram(&d.decoder, &d.arena, &d.consts)
+	return decodeDeBruijnProgram(&d.decoder, &d.arena, &d.consts, nil)
 }
 
 func Decode[T Binder](bytes []byte) (*Program[T], error) {
@@ -66,49 +66,43 @@ func Decode[T Binder](bytes []byte) (*Program[T], error) {
 		return any(program).(*Program[T]), nil
 	}
 
+	return decodeProgram[T](bytes, nil)
+}
+
+func decodeWithContext[T Binder](bytes []byte, context ProgramContext) (*Program[T], error) {
+	return decodeProgram[T](bytes, &context)
+}
+
+func decodeProgram[T Binder](bytes []byte, context *ProgramContext) (*Program[T], error) {
+	var zero T
+	if _, ok := any(zero).(DeBruijn); ok {
+		d := newDecoder(bytes)
+		arena := newTermArena[DeBruijn]()
+		consts := &constantArena{}
+		program, err := decodeDeBruijnProgram(d, arena, consts, context)
+		if err != nil {
+			return nil, err
+		}
+		return any(program).(*Program[T]), nil
+	}
+
 	d := newDecoder(bytes)
 	arena := newTermArena[T]()
-
-	major, err := d.word()
+	version, err := decodeProgramVersion(d, context)
 	if err != nil {
 		return nil, err
 	}
-
-	minor, err := d.word()
-	if err != nil {
-		return nil, err
-	}
-
-	patch, err := d.word()
-	if err != nil {
-		return nil, err
-	}
-
-	if major > math.MaxUint32 || minor > math.MaxUint32 ||
-		patch > math.MaxUint32 {
-		return nil, errors.New("version numbers too large")
-	}
-
 	terms, err := decodeTermWithArena[T](d, arena)
 	if err != nil {
 		return nil, err
 	}
-
-	version := lang.LanguageVersion{uint32(major), uint32(minor), uint32(patch)}
-
-	program := &Program[T]{
-		Version: version,
-		Term:    terms,
-	}
-
+	program := &Program[T]{Version: version, Term: terms}
 	if err := d.filler(); err != nil {
 		return nil, err
 	}
-
 	if err := d.ensureFullyConsumed(); err != nil {
 		return nil, err
 	}
-
 	return program, nil
 }
 
@@ -116,25 +110,11 @@ func decodeDeBruijnProgram(
 	d *decoder,
 	arena *termArena[DeBruijn],
 	consts *constantArena,
+	context *ProgramContext,
 ) (*Program[DeBruijn], error) {
-	major, err := d.word()
+	version, err := decodeProgramVersion(d, context)
 	if err != nil {
 		return nil, err
-	}
-
-	minor, err := d.word()
-	if err != nil {
-		return nil, err
-	}
-
-	patch, err := d.word()
-	if err != nil {
-		return nil, err
-	}
-
-	if major > math.MaxUint32 || minor > math.MaxUint32 ||
-		patch > math.MaxUint32 {
-		return nil, errors.New("version numbers too large")
 	}
 
 	terms, err := decodeTermDeBruijnWithArena(d, arena, consts, 0)
@@ -143,7 +123,7 @@ func decodeDeBruijnProgram(
 	}
 
 	program := &Program[DeBruijn]{
-		Version: lang.LanguageVersion{uint32(major), uint32(minor), uint32(patch)},
+		Version: version,
 		Term:    terms,
 	}
 
@@ -160,6 +140,35 @@ func decodeDeBruijnProgram(
 
 func DecodeTerm[T Binder](d *decoder) (Term[T], error) {
 	return decodeTermWithArena(d, newTermArena[T]())
+}
+
+func decodeProgramVersion(
+	d *decoder,
+	context *ProgramContext,
+) (lang.LanguageVersion, error) {
+	major, err := d.word()
+	if err != nil {
+		return lang.LanguageVersion{}, err
+	}
+	minor, err := d.word()
+	if err != nil {
+		return lang.LanguageVersion{}, err
+	}
+	patch, err := d.word()
+	if err != nil {
+		return lang.LanguageVersion{}, err
+	}
+	if major > math.MaxUint32 || minor > math.MaxUint32 ||
+		patch > math.MaxUint32 {
+		return lang.LanguageVersion{}, errors.New("version numbers too large")
+	}
+	version := lang.LanguageVersion{uint32(major), uint32(minor), uint32(patch)}
+	if context != nil {
+		if err := validateProgramVersion(version, *context); err != nil {
+			return lang.LanguageVersion{}, err
+		}
+	}
+	return version, nil
 }
 
 func decodeTermDeBruijnWithArena(

--- a/syn/flat_decode.go
+++ b/syn/flat_decode.go
@@ -56,16 +56,6 @@ func (d *DeBruijnDecoder) Decode(bytes []byte) (*Program[DeBruijn], error) {
 }
 
 func Decode[T Binder](bytes []byte) (*Program[T], error) {
-	var zero T
-	switch any(zero).(type) {
-	case DeBruijn:
-		program, err := decodeDeBruijn(bytes)
-		if err != nil {
-			return nil, err
-		}
-		return any(program).(*Program[T]), nil
-	}
-
 	return decodeProgram[T](bytes, nil)
 }
 

--- a/syn/program_validation.go
+++ b/syn/program_validation.go
@@ -23,6 +23,8 @@ var (
 	uplcVersion110 = lang.LanguageVersion{1, 1, 0}
 )
 
+const maxConstrFieldsPV11 = 1024
+
 // ValidateProgram checks a decoded program against the selected ledger
 // language and protocol version. Validation walks every term, including
 // branches which evaluation might not reach.
@@ -77,6 +79,14 @@ func ValidateProgram[T any](program *Program[T], context ProgramContext) error {
 		case *Constr[T]:
 			if !supportsConstructors(program.Version) {
 				return fmt.Errorf("constr is not available in UPLC version %s", formatVersion(program.Version))
+			}
+			if context.ProtocolMajor >= builtin.VanRossemProtoVersion &&
+				len(t.Fields) > maxConstrFieldsPV11 {
+				return fmt.Errorf(
+					"constr with %d fields is not available in protocol version %d",
+					len(t.Fields),
+					context.ProtocolMajor,
+				)
 			}
 			terms = append(terms, t.Fields...)
 		case *Case[T]:

--- a/syn/program_validation.go
+++ b/syn/program_validation.go
@@ -18,6 +18,11 @@ type ProgramContext struct {
 	ProtocolMajor  uint
 }
 
+var (
+	uplcVersion100 = lang.LanguageVersion{1, 0, 0}
+	uplcVersion110 = lang.LanguageVersion{1, 1, 0}
+)
+
 // ValidateProgram checks a decoded program against the selected ledger
 // language and protocol version. Validation walks every term, including
 // branches which evaluation might not reach.
@@ -140,7 +145,7 @@ func plutusVersionForLedgerLanguage(version lang.LanguageVersion) (builtin.Plutu
 }
 
 func validateProgramVersion(version lang.LanguageVersion, context ProgramContext) error {
-	if version != lang.LanguageVersionV1 && version != lang.LanguageVersionV2 {
+	if version != uplcVersion100 && version != uplcVersion110 {
 		return fmt.Errorf(
 			"unsupported UPLC program version %s; supported versions are 1.0.0 and 1.1.0",
 			formatVersion(version),
@@ -168,7 +173,7 @@ func validateProgramVersion(version lang.LanguageVersion, context ProgramContext
 			context.ProtocolMajor,
 		)
 	}
-	if version == lang.LanguageVersionV2 &&
+	if version == uplcVersion110 &&
 		(plutusVersion == builtin.PlutusV1 || plutusVersion == builtin.PlutusV2) &&
 		context.ProtocolMajor < builtin.VanRossemProtoVersion {
 		return fmt.Errorf(
@@ -181,7 +186,7 @@ func validateProgramVersion(version lang.LanguageVersion, context ProgramContext
 }
 
 func supportsConstructors(version lang.LanguageVersion) bool {
-	return version == lang.LanguageVersionV2
+	return version == uplcVersion110
 }
 
 func formatVersion(version lang.LanguageVersion) string {

--- a/syn/program_validation.go
+++ b/syn/program_validation.go
@@ -1,0 +1,216 @@
+package syn
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/blinklabs-io/plutigo/builtin"
+	"github.com/blinklabs-io/plutigo/lang"
+)
+
+// ProgramContext identifies the ledger language and protocol version against
+// which a UPLC program is to be decoded and validated.
+//
+// The program header is a Plutus Core language version. It is not a ledger
+// language identifier: the ledger language is selected by the caller.
+type ProgramContext struct {
+	LedgerLanguage lang.LanguageVersion
+	ProtocolMajor  uint
+}
+
+// ValidateProgram checks a decoded program against the selected ledger
+// language and protocol version. Validation walks every term, including
+// branches which evaluation might not reach.
+func ValidateProgram[T any](program *Program[T], context ProgramContext) error {
+	if program == nil {
+		return errors.New("program is required")
+	}
+	if err := validateProgramVersion(program.Version, context); err != nil {
+		return err
+	}
+
+	plutusVersion, err := plutusVersionForLedgerLanguage(context.LedgerLanguage)
+	if err != nil {
+		return err
+	}
+
+	terms := []Term[T]{program.Term}
+	for len(terms) > 0 {
+		last := len(terms) - 1
+		term := terms[last]
+		terms = terms[:last]
+		if isNilTerm[T](term) {
+			return errors.New("program contains a nil term")
+		}
+
+		switch t := term.(type) {
+		case *Var[T], *Constant, *Error:
+			// No version-dependent validation is needed for these terms.
+		case *Delay[T]:
+			terms = append(terms, t.Term)
+		case *Force[T]:
+			terms = append(terms, t.Term)
+		case *Lambda[T]:
+			terms = append(terms, t.Body)
+		case *Apply[T]:
+			terms = append(terms, t.Function, t.Argument)
+		case *Builtin:
+			if t.DefaultFunction > builtin.MaxDefaultFunction {
+				return fmt.Errorf("builtin tag %d is invalid", t.DefaultFunction)
+			}
+			if !t.IsAvailableInWithProto(
+				plutusVersion,
+				context.ProtocolMajor,
+			) {
+				return fmt.Errorf(
+					"builtin %s is not available in Plutus V%d at protocol version %d",
+					t.String(),
+					plutusVersion,
+					context.ProtocolMajor,
+				)
+			}
+		case *Constr[T]:
+			if !supportsConstructors(program.Version) {
+				return fmt.Errorf("constr is not available in UPLC version %s", formatVersion(program.Version))
+			}
+			terms = append(terms, t.Fields...)
+		case *Case[T]:
+			if !supportsConstructors(program.Version) {
+				return fmt.Errorf("case is not available in UPLC version %s", formatVersion(program.Version))
+			}
+			terms = append(terms, t.Constr)
+			terms = append(terms, t.Branches...)
+		default:
+			return fmt.Errorf("unsupported term type %T", term)
+		}
+	}
+	return nil
+}
+
+// DecodeWithContext decodes and validates a FLAT-encoded UPLC program before
+// returning it. The encoded program version is checked immediately after its
+// header is read; terms are then checked exhaustively before the program is
+// returned.
+func DecodeWithContext[T Binder](bytes []byte, context ProgramContext) (*Program[T], error) {
+	program, err := decodeWithContext[T](bytes, context)
+	if err != nil {
+		return nil, err
+	}
+	if err := ValidateProgram(program, context); err != nil {
+		return nil, err
+	}
+	return program, nil
+}
+
+// ParseWithContext parses and validates a textual UPLC program against the
+// selected ledger language and protocol version.
+func ParseWithContext(input string, context ProgramContext) (*Program[Name], error) {
+	program, err := Parse(input)
+	if err != nil {
+		return nil, err
+	}
+	if err := ValidateProgram(program, context); err != nil {
+		return nil, err
+	}
+	return program, nil
+}
+
+// DecodeDeBruijnWithContext is the De Bruijn-specialized form of
+// [DecodeWithContext].
+func DecodeDeBruijnWithContext(
+	bytes []byte,
+	context ProgramContext,
+) (*Program[DeBruijn], error) {
+	return DecodeWithContext[DeBruijn](bytes, context)
+}
+
+func plutusVersionForLedgerLanguage(version lang.LanguageVersion) (builtin.PlutusVersion, error) {
+	switch version {
+	case lang.LanguageVersionV1:
+		return builtin.PlutusV1, nil
+	case lang.LanguageVersionV2:
+		return builtin.PlutusV2, nil
+	case lang.LanguageVersionV3:
+		return builtin.PlutusV3, nil
+	case lang.LanguageVersionV4:
+		return builtin.PlutusV4, nil
+	default:
+		return 0, fmt.Errorf("unsupported Plutus ledger language version %s", formatVersion(version))
+	}
+}
+
+func validateProgramVersion(version lang.LanguageVersion, context ProgramContext) error {
+	if version != lang.LanguageVersionV1 && version != lang.LanguageVersionV2 {
+		return fmt.Errorf(
+			"unsupported UPLC program version %s; supported versions are 1.0.0 and 1.1.0",
+			formatVersion(version),
+		)
+	}
+
+	plutusVersion, err := plutusVersionForLedgerLanguage(context.LedgerLanguage)
+	if err != nil {
+		return err
+	}
+	if context.ProtocolMajor == 0 {
+		return errors.New("protocol major version must be positive")
+	}
+
+	introduced := map[builtin.PlutusVersion]uint{
+		builtin.PlutusV1: 5,
+		builtin.PlutusV2: 7,
+		builtin.PlutusV3: 9,
+		builtin.PlutusV4: 12,
+	}
+	if context.ProtocolMajor < introduced[plutusVersion] {
+		return fmt.Errorf(
+			"plutus ledger language V%d is not available at protocol version %d",
+			plutusVersion,
+			context.ProtocolMajor,
+		)
+	}
+	if version == lang.LanguageVersionV2 &&
+		(plutusVersion == builtin.PlutusV1 || plutusVersion == builtin.PlutusV2) &&
+		context.ProtocolMajor < builtin.VanRossemProtoVersion {
+		return fmt.Errorf(
+			"UPLC version 1.1.0 is not available for Plutus V%d at protocol version %d",
+			plutusVersion,
+			context.ProtocolMajor,
+		)
+	}
+	return nil
+}
+
+func supportsConstructors(version lang.LanguageVersion) bool {
+	return version == lang.LanguageVersionV2
+}
+
+func formatVersion(version lang.LanguageVersion) string {
+	return fmt.Sprintf("%d.%d.%d", version[0], version[1], version[2])
+}
+
+func isNilTerm[T any](term Term[T]) bool {
+	switch t := term.(type) {
+	case *Var[T]:
+		return t == nil
+	case *Delay[T]:
+		return t == nil
+	case *Force[T]:
+		return t == nil
+	case *Lambda[T]:
+		return t == nil
+	case *Apply[T]:
+		return t == nil
+	case *Builtin:
+		return t == nil
+	case *Constr[T]:
+		return t == nil
+	case *Case[T]:
+		return t == nil
+	case *Error:
+		return t == nil
+	case *Constant:
+		return t == nil
+	default:
+		return term == nil
+	}
+}

--- a/syn/program_validation_test.go
+++ b/syn/program_validation_test.go
@@ -217,3 +217,122 @@ func TestParseWithContextRejectsUnavailableSyntaxAndBuiltin(t *testing.T) {
 		t.Fatalf("ParseWithContext() builtin error = %v", err)
 	}
 }
+
+func TestContextualValidationConstrFieldLimit(t *testing.T) {
+	tests := []struct {
+		name       string
+		protocol   uint
+		fieldCount int
+		wantErr    string
+	}{
+		{
+			name:       "pre-PV11 remains unbounded",
+			protocol:   10,
+			fieldCount: 1025,
+		},
+		{
+			name:       "PV11 below limit",
+			protocol:   11,
+			fieldCount: 1023,
+		},
+		{
+			name:       "PV11 at limit",
+			protocol:   11,
+			fieldCount: 1024,
+		},
+		{
+			name:       "PV11 above limit",
+			protocol:   11,
+			fieldCount: 1025,
+			wantErr:    "constr with 1025 fields is not available in protocol version 11",
+		},
+		{
+			name:       "post-PV11 above limit",
+			protocol:   12,
+			fieldCount: 1025,
+			wantErr:    "constr with 1025 fields is not available in protocol version 12",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fields := make([]Term[DeBruijn], tt.fieldCount)
+			for i := range fields {
+				fields[i] = &Error{}
+			}
+			program := &Program[DeBruijn]{
+				Version: uplcVersion110,
+				Term: &Constr[DeBruijn]{
+					Tag:    0,
+					Fields: fields,
+				},
+			}
+			context := ProgramContext{
+				LedgerLanguage: lang.LanguageVersionV3,
+				ProtocolMajor:  tt.protocol,
+			}
+			encoded, err := Encode(program)
+			if err != nil {
+				t.Fatalf("Encode() failed: %v", err)
+			}
+
+			entryPoints := []struct {
+				name string
+				run  func() (int, error)
+			}{
+				{
+					name: "ValidateProgram",
+					run: func() (int, error) {
+						return len(fields), ValidateProgram(program, context)
+					},
+				},
+				{
+					name: "DecodeWithContext generic",
+					run: func() (int, error) {
+						decoded, err := DecodeWithContext[Name](encoded, context)
+						if err != nil {
+							return 0, err
+						}
+						constr, ok := decoded.Term.(*Constr[Name])
+						if !ok {
+							return -1, nil
+						}
+						return len(constr.Fields), nil
+					},
+				},
+				{
+					name: "DecodeDeBruijnWithContext",
+					run: func() (int, error) {
+						decoded, err := DecodeDeBruijnWithContext(encoded, context)
+						if err != nil {
+							return 0, err
+						}
+						constr, ok := decoded.Term.(*Constr[DeBruijn])
+						if !ok {
+							return -1, nil
+						}
+						return len(constr.Fields), nil
+					},
+				},
+			}
+
+			for _, entryPoint := range entryPoints {
+				t.Run(entryPoint.name, func(t *testing.T) {
+					gotFields, err := entryPoint.run()
+					if tt.wantErr != "" {
+						if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+							t.Fatalf("error = %v, want %q", err, tt.wantErr)
+						}
+						return
+					}
+					if err != nil {
+						t.Fatalf("unexpected error: %v", err)
+					}
+					if gotFields != tt.fieldCount {
+						t.Fatalf("decoded field count = %d, want %d", gotFields, tt.fieldCount)
+					}
+				})
+			}
+		})
+	}
+}

--- a/syn/program_validation_test.go
+++ b/syn/program_validation_test.go
@@ -1,0 +1,219 @@
+package syn
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/plutigo/builtin"
+	"github.com/blinklabs-io/plutigo/lang"
+)
+
+func TestDecodeWithContextPreservesAndValidatesProgramVersion(t *testing.T) {
+	program := &Program[DeBruijn]{
+		Version: lang.LanguageVersionV2,
+		Term:    &Error{},
+	}
+	encoded, err := Encode(program)
+	if err != nil {
+		t.Fatalf("Encode() failed: %v", err)
+	}
+
+	decoded, err := DecodeWithContext[DeBruijn](encoded, ProgramContext{
+		LedgerLanguage: lang.LanguageVersionV3,
+		ProtocolMajor:  9,
+	})
+	if err != nil {
+		t.Fatalf("DecodeWithContext() failed: %v", err)
+	}
+	if decoded.Version != program.Version {
+		t.Fatalf("decoded version = %v, want %v", decoded.Version, program.Version)
+	}
+
+	program.Version = lang.LanguageVersionV3
+	encoded, err = Encode(program)
+	if err != nil {
+		t.Fatalf("Encode() with unsupported version failed: %v", err)
+	}
+	_, err = DecodeWithContext[DeBruijn](encoded, ProgramContext{
+		LedgerLanguage: lang.LanguageVersionV3,
+		ProtocolMajor:  9,
+	})
+	if err == nil || !strings.Contains(err.Error(), "unsupported UPLC program version") {
+		t.Fatalf("DecodeWithContext() error = %v, want unsupported-version error", err)
+	}
+}
+
+func TestValidateProgramUsesLedgerLanguageAndProtocol(t *testing.T) {
+	tests := []struct {
+		name       string
+		language   lang.LanguageVersion
+		protocol   uint
+		programVer lang.LanguageVersion
+		term       Term[DeBruijn]
+		wantErr    string
+	}{
+		{
+			name:       "V2 batch two builtin at Vasil protocol",
+			language:   lang.LanguageVersionV2,
+			protocol:   10,
+			programVer: lang.LanguageVersionV1,
+			term:       &Builtin{DefaultFunction: builtin.SerialiseData},
+		},
+		{
+			name:       "dead branch builtin is still rejected",
+			language:   lang.LanguageVersionV1,
+			protocol:   10,
+			programVer: lang.LanguageVersionV1,
+			term: &Delay[DeBruijn]{Term: &Builtin{
+				DefaultFunction: builtin.SerialiseData,
+			}},
+			wantErr: "builtin serialiseData is not available",
+		},
+		{
+			name:       "PLC 1.1 is not available to V2 before van Rossem",
+			language:   lang.LanguageVersionV2,
+			protocol:   10,
+			programVer: lang.LanguageVersionV2,
+			term:       &Error{},
+			wantErr:    "UPLC version 1.1.0 is not available",
+		},
+		{
+			name:       "constructors require PLC 1.1",
+			language:   lang.LanguageVersionV3,
+			protocol:   9,
+			programVer: lang.LanguageVersionV1,
+			term:       &Constr[DeBruijn]{Tag: 0},
+			wantErr:    "constr is not available",
+		},
+		{
+			name:       "PLC 1.1 constructors are accepted",
+			language:   lang.LanguageVersionV3,
+			protocol:   9,
+			programVer: lang.LanguageVersionV2,
+			term:       &Constr[DeBruijn]{Tag: 0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateProgram(&Program[DeBruijn]{
+				Version: tt.programVer,
+				Term:    tt.term,
+			}, ProgramContext{
+				LedgerLanguage: tt.language,
+				ProtocolMajor:  tt.protocol,
+			})
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ValidateProgram() failed: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("ValidateProgram() error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateProgramVersionMatrix(t *testing.T) {
+	tests := []struct {
+		name     string
+		language lang.LanguageVersion
+		protocol uint
+		version  lang.LanguageVersion
+		wantErr  bool
+	}{
+		{"V1 at Alonzo with PLC 1.0", lang.LanguageVersionV1, 5, lang.LanguageVersionV1, false},
+		{"V1 at zero protocol", lang.LanguageVersionV1, 0, lang.LanguageVersionV1, true},
+		{"V1 before van Rossem with PLC 1.1", lang.LanguageVersionV1, 10, lang.LanguageVersionV2, true},
+		{"V1 at van Rossem with PLC 1.1", lang.LanguageVersionV1, 11, lang.LanguageVersionV2, false},
+		{"V2 at Vasil with PLC 1.0", lang.LanguageVersionV2, 7, lang.LanguageVersionV1, false},
+		{"V2 before van Rossem with PLC 1.1", lang.LanguageVersionV2, 10, lang.LanguageVersionV2, true},
+		{"V2 at van Rossem with PLC 1.1", lang.LanguageVersionV2, 11, lang.LanguageVersionV2, false},
+		{"V3 at Chang with PLC 1.0", lang.LanguageVersionV3, 9, lang.LanguageVersionV1, false},
+		{"V3 at Chang with PLC 1.1", lang.LanguageVersionV3, 9, lang.LanguageVersionV2, false},
+		{"V4 before Dijkstra", lang.LanguageVersionV4, 11, lang.LanguageVersionV1, true},
+		{"V4 at Dijkstra with PLC 1.1", lang.LanguageVersionV4, 12, lang.LanguageVersionV2, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateProgram(&Program[DeBruijn]{
+				Version: tt.version,
+				Term:    &Error{},
+			}, ProgramContext{
+				LedgerLanguage: tt.language,
+				ProtocolMajor:  tt.protocol,
+			})
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateProgram() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDecodeWithContextRejectsDeadBranchBuiltin(t *testing.T) {
+	program := &Program[DeBruijn]{
+		Version: lang.LanguageVersionV1,
+		Term: &Apply[DeBruijn]{
+			Function: &Builtin{DefaultFunction: builtin.IfThenElse},
+			Argument: &Delay[DeBruijn]{Term: &Builtin{
+				DefaultFunction: builtin.SerialiseData,
+			}},
+		},
+	}
+	encoded, err := Encode(program)
+	if err != nil {
+		t.Fatalf("Encode() failed: %v", err)
+	}
+	_, err = DecodeWithContext[DeBruijn](encoded, ProgramContext{
+		LedgerLanguage: lang.LanguageVersionV1,
+		ProtocolMajor:  10,
+	})
+	if err == nil || !strings.Contains(err.Error(), "builtin serialiseData is not available") {
+		t.Fatalf("DecodeWithContext() error = %v, want dead-branch builtin error", err)
+	}
+}
+
+func TestDecodeWithContextRejectsSyntaxBeforeProgramVersion(t *testing.T) {
+	program := &Program[DeBruijn]{
+		Version: lang.LanguageVersionV1,
+		Term:    &Constr[DeBruijn]{Tag: 0},
+	}
+	encoded, err := Encode(program)
+	if err != nil {
+		t.Fatalf("Encode() failed: %v", err)
+	}
+	_, err = DecodeWithContext[DeBruijn](encoded, ProgramContext{
+		LedgerLanguage: lang.LanguageVersionV3,
+		ProtocolMajor:  9,
+	})
+	if err == nil || !strings.Contains(err.Error(), "constr is not available") {
+		t.Fatalf("DecodeWithContext() error = %v, want unavailable-syntax error", err)
+	}
+}
+
+func TestParseWithContextRejectsUnavailableSyntaxAndBuiltin(t *testing.T) {
+	_, err := ParseWithContext(
+		"(program 1.0.0 (constr 0))",
+		ProgramContext{
+			LedgerLanguage: lang.LanguageVersionV3,
+			ProtocolMajor:  9,
+		},
+	)
+	if err == nil || !strings.Contains(err.Error(), "constr can't be used before 1.1.0") {
+		t.Fatalf("ParseWithContext() syntax error = %v", err)
+	}
+
+	_, err = ParseWithContext(
+		"(program 1.0.0 (delay (builtin serialiseData)))",
+		ProgramContext{
+			LedgerLanguage: lang.LanguageVersionV1,
+			ProtocolMajor:  10,
+		},
+	)
+	if err == nil || !strings.Contains(err.Error(), "builtin serialiseData is not available") {
+		t.Fatalf("ParseWithContext() builtin error = %v", err)
+	}
+}

--- a/syn/program_validation_test.go
+++ b/syn/program_validation_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestDecodeWithContextPreservesAndValidatesProgramVersion(t *testing.T) {
 	program := &Program[DeBruijn]{
-		Version: lang.LanguageVersionV2,
+		Version: uplcVersion110,
 		Term:    &Error{},
 	}
 	encoded, err := Encode(program)
@@ -29,7 +29,7 @@ func TestDecodeWithContextPreservesAndValidatesProgramVersion(t *testing.T) {
 		t.Fatalf("decoded version = %v, want %v", decoded.Version, program.Version)
 	}
 
-	program.Version = lang.LanguageVersionV3
+	program.Version = lang.LanguageVersion{1, 2, 0}
 	encoded, err = Encode(program)
 	if err != nil {
 		t.Fatalf("Encode() with unsupported version failed: %v", err)
@@ -56,14 +56,14 @@ func TestValidateProgramUsesLedgerLanguageAndProtocol(t *testing.T) {
 			name:       "V2 batch two builtin at Vasil protocol",
 			language:   lang.LanguageVersionV2,
 			protocol:   10,
-			programVer: lang.LanguageVersionV1,
+			programVer: uplcVersion100,
 			term:       &Builtin{DefaultFunction: builtin.SerialiseData},
 		},
 		{
 			name:       "dead branch builtin is still rejected",
 			language:   lang.LanguageVersionV1,
 			protocol:   10,
-			programVer: lang.LanguageVersionV1,
+			programVer: uplcVersion100,
 			term: &Delay[DeBruijn]{Term: &Builtin{
 				DefaultFunction: builtin.SerialiseData,
 			}},
@@ -73,7 +73,7 @@ func TestValidateProgramUsesLedgerLanguageAndProtocol(t *testing.T) {
 			name:       "PLC 1.1 is not available to V2 before van Rossem",
 			language:   lang.LanguageVersionV2,
 			protocol:   10,
-			programVer: lang.LanguageVersionV2,
+			programVer: uplcVersion110,
 			term:       &Error{},
 			wantErr:    "UPLC version 1.1.0 is not available",
 		},
@@ -81,7 +81,7 @@ func TestValidateProgramUsesLedgerLanguageAndProtocol(t *testing.T) {
 			name:       "constructors require PLC 1.1",
 			language:   lang.LanguageVersionV3,
 			protocol:   9,
-			programVer: lang.LanguageVersionV1,
+			programVer: uplcVersion100,
 			term:       &Constr[DeBruijn]{Tag: 0},
 			wantErr:    "constr is not available",
 		},
@@ -89,7 +89,7 @@ func TestValidateProgramUsesLedgerLanguageAndProtocol(t *testing.T) {
 			name:       "PLC 1.1 constructors are accepted",
 			language:   lang.LanguageVersionV3,
 			protocol:   9,
-			programVer: lang.LanguageVersionV2,
+			programVer: uplcVersion110,
 			term:       &Constr[DeBruijn]{Tag: 0},
 		},
 	}
@@ -124,17 +124,17 @@ func TestValidateProgramVersionMatrix(t *testing.T) {
 		version  lang.LanguageVersion
 		wantErr  bool
 	}{
-		{"V1 at Alonzo with PLC 1.0", lang.LanguageVersionV1, 5, lang.LanguageVersionV1, false},
-		{"V1 at zero protocol", lang.LanguageVersionV1, 0, lang.LanguageVersionV1, true},
-		{"V1 before van Rossem with PLC 1.1", lang.LanguageVersionV1, 10, lang.LanguageVersionV2, true},
-		{"V1 at van Rossem with PLC 1.1", lang.LanguageVersionV1, 11, lang.LanguageVersionV2, false},
-		{"V2 at Vasil with PLC 1.0", lang.LanguageVersionV2, 7, lang.LanguageVersionV1, false},
-		{"V2 before van Rossem with PLC 1.1", lang.LanguageVersionV2, 10, lang.LanguageVersionV2, true},
-		{"V2 at van Rossem with PLC 1.1", lang.LanguageVersionV2, 11, lang.LanguageVersionV2, false},
-		{"V3 at Chang with PLC 1.0", lang.LanguageVersionV3, 9, lang.LanguageVersionV1, false},
-		{"V3 at Chang with PLC 1.1", lang.LanguageVersionV3, 9, lang.LanguageVersionV2, false},
-		{"V4 before Dijkstra", lang.LanguageVersionV4, 11, lang.LanguageVersionV1, true},
-		{"V4 at Dijkstra with PLC 1.1", lang.LanguageVersionV4, 12, lang.LanguageVersionV2, false},
+		{"V1 at Alonzo with PLC 1.0", lang.LanguageVersionV1, 5, uplcVersion100, false},
+		{"V1 at zero protocol", lang.LanguageVersionV1, 0, uplcVersion100, true},
+		{"V1 before van Rossem with PLC 1.1", lang.LanguageVersionV1, 10, uplcVersion110, true},
+		{"V1 at van Rossem with PLC 1.1", lang.LanguageVersionV1, 11, uplcVersion110, false},
+		{"V2 at Vasil with PLC 1.0", lang.LanguageVersionV2, 7, uplcVersion100, false},
+		{"V2 before van Rossem with PLC 1.1", lang.LanguageVersionV2, 10, uplcVersion110, true},
+		{"V2 at van Rossem with PLC 1.1", lang.LanguageVersionV2, 11, uplcVersion110, false},
+		{"V3 at Chang with PLC 1.0", lang.LanguageVersionV3, 9, uplcVersion100, false},
+		{"V3 at Chang with PLC 1.1", lang.LanguageVersionV3, 9, uplcVersion110, false},
+		{"V4 before Dijkstra", lang.LanguageVersionV4, 11, uplcVersion100, true},
+		{"V4 at Dijkstra with PLC 1.1", lang.LanguageVersionV4, 12, uplcVersion110, false},
 	}
 
 	for _, tt := range tests {
@@ -155,7 +155,7 @@ func TestValidateProgramVersionMatrix(t *testing.T) {
 
 func TestDecodeWithContextRejectsDeadBranchBuiltin(t *testing.T) {
 	program := &Program[DeBruijn]{
-		Version: lang.LanguageVersionV1,
+		Version: uplcVersion100,
 		Term: &Apply[DeBruijn]{
 			Function: &Builtin{DefaultFunction: builtin.IfThenElse},
 			Argument: &Delay[DeBruijn]{Term: &Builtin{
@@ -178,7 +178,7 @@ func TestDecodeWithContextRejectsDeadBranchBuiltin(t *testing.T) {
 
 func TestDecodeWithContextRejectsSyntaxBeforeProgramVersion(t *testing.T) {
 	program := &Program[DeBruijn]{
-		Version: lang.LanguageVersionV1,
+		Version: uplcVersion100,
 		Term:    &Constr[DeBruijn]{Tag: 0},
 	}
 	encoded, err := Encode(program)


### PR DESCRIPTION
## Summary

- add contextual FLAT and text validation for ledger language and protocol version
- preserve and enforce the encoded UPLC version before accepting a program
- reject unavailable builtins and syntax across every term branch
- enforce the PV11+ limit of 1,024 constructor fields across direct validation and both generic and optimized decoding
- use validated decoding in replay

## Validation

- fail-before constructor-bound regressions across direct, generic, and optimized paths
- full race suites with Go 1.25.8 and Go 1.26.7
- conformance tests and focused fuzz smoke
- `./scripts/validate.sh --quick`
- vet, golangci-lint, NilAway, module verification, and tidy diff

Closes #384

