### PR TITLE
test: contain 32-bit builtin and flat decoding

### DIFF
--- a/cek/builtins_test.go
+++ b/cek/builtins_test.go
@@ -4092,6 +4092,32 @@ func TestIntegerToByteStringBuiltin(t *testing.T) {
 	}
 }
 
+// TestIntegerToByteStringRejectsUnrepresentableSize verifies that a size
+// outside int64 is rejected before it can be narrowed to int. The ordering is
+// required for 32-bit targets, where narrowing first would turn a large size
+// into a small value and could incorrectly produce an output.
+func TestIntegerToByteStringRejectsUnrepresentableSize(t *testing.T) {
+	m := newTestMachine()
+	b := newTestBuiltin(builtin.IntegerToByteString)
+	b = b.ApplyArg(&Constant{&syn.Bool{Inner: true}})
+	b = b.ApplyArg(&Constant{&syn.Integer{
+		Inner: new(big.Int).Lsh(big.NewInt(1), 63),
+	}})
+	b = b.ApplyArg(&Constant{&syn.Integer{Inner: big.NewInt(1)}})
+
+	value, err := evalBuiltinWithError(t, m, b)
+	if value != nil {
+		t.Fatalf("expected no value, got %v", value)
+	}
+	var builtinErr *BuiltinError
+	if !errors.As(err, &builtinErr) {
+		t.Fatalf("expected BuiltinError, got %T: %v", err, err)
+	}
+	if builtinErr.Code != ErrCodeOverflow {
+		t.Fatalf("error code = %v, want %v", builtinErr.Code, ErrCodeOverflow)
+	}
+}
+
 func TestByteStringToIntegerBuiltin(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/syn/flat_decode_limits_test.go
+++ b/syn/flat_decode_limits_test.go
@@ -221,6 +221,40 @@ func TestWord64Boundary(t *testing.T) {
 	}
 }
 
+// TestDecodeConstrTagPreservesWord64 verifies that constructor tags retain
+// their complete FLAT word on every architecture. In particular, a tag with
+// bit 32 set must not be narrowed through uint on 32-bit targets.
+func TestDecodeConstrTagPreservesWord64(t *testing.T) {
+	const tag = uint64(1)<<32 | 7
+
+	encoded, err := Encode(&Program[DeBruijn]{
+		Version: lang.LanguageVersionV3,
+		Term:    &Constr[DeBruijn]{Tag: tag},
+	})
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	for name, decode := range map[string]func([]byte) (*Program[DeBruijn], error){
+		"generic decoder":  Decode[DeBruijn],
+		"debruijn decoder": DecodeDeBruijn,
+	} {
+		t.Run(name, func(t *testing.T) {
+			program, err := decode(encoded)
+			if err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			constr, ok := program.Term.(*Constr[DeBruijn])
+			if !ok {
+				t.Fatalf("decoded term has type %T, want *Constr", program.Term)
+			}
+			if constr.Tag != tag {
+				t.Fatalf("constructor tag = %d, want %d", constr.Tag, tag)
+			}
+		})
+	}
+}
+
 func TestBigWordSmallLargeValue(t *testing.T) {
 	values := []struct {
 		name string


### PR DESCRIPTION
Closes #366

- Cover integerToByteString rejection of sizes that cannot be represented by int64 before narrowing to int.
- Cover both FLAT decoder paths preserving constructor tags with bit 32 set.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of oversized byte-string conversion sizes by returning an overflow error without producing a value.
  * Preserved full 64-bit constructor tag values during decoding, including tags larger than 32 bits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->