### PR TITLE
fix(data): chunk bignum magnitudes in Data encoding

### DIFF
--- a/cek/builtins_test.go
+++ b/cek/builtins_test.go
@@ -5515,3 +5515,25 @@ func TestDropListUnListDataEndToEnd(t *testing.T) {
 		)
 	}
 }
+
+// TestSerialiseDataBuiltinChunksBignum drives the serialiseData builtin, the
+// path a validator uses, over an integer whose magnitude exceeds
+// MaxByteStringLeafSize. The magnitude must be emitted as an
+// indefinite-length byte string of 64-byte chunks, matching the reference
+// implementation.
+func TestSerialiseDataBuiltinChunksBignum(t *testing.T) {
+	m := newTestMachine()
+	b := newTestBuiltin(builtin.SerialiseData)
+
+	// 2^512, whose magnitude is 65 bytes.
+	n := new(big.Int).Lsh(big.NewInt(1), 512)
+	b = b.ApplyArg(&Constant{&syn.Data{Inner: &data.Integer{Inner: n}}})
+
+	val := evalBuiltin(t, m, b)
+	bs := expectByteString(t, expectConstant(t, val))
+
+	const want = "c25f5840010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004100ff"
+	if got := hex.EncodeToString(bs.Inner); got != want {
+		t.Fatalf("serialiseData(2^512):\n got %s\nwant %s", got, want)
+	}
+}

--- a/data/data.go
+++ b/data/data.go
@@ -393,7 +393,29 @@ func (i *Integer) UnmarshalCBOR(data []byte) error {
 }
 
 func (i Integer) MarshalCBOR() ([]byte, error) {
-	return cborMarshal(i.Inner)
+	// Plutus encodes an integer inside the Word64 range, or its negative
+	// mirror, as a plain CBOR integer, and any other integer as a CBOR bignum
+	// whose magnitude byte string obeys the same MaxByteStringLeafSize
+	// chunking rule as a Plutus byte string. See PlutusCore.Data.encodeInteger.
+	if i.Inner == nil {
+		return cborMarshal(i.Inner)
+	}
+	tag := byte(cborTagPositiveBignum)
+	magnitude := i.Inner
+	if i.Inner.Sign() < 0 {
+		// A negative bignum encodes -1 - i, which is big.Int.Not for a
+		// negative operand.
+		tag = byte(cborTagNegativeBignum)
+		magnitude = new(big.Int).Not(i.Inner)
+	}
+	if magnitude.BitLen() <= 64 {
+		return cborMarshal(i.Inner)
+	}
+	body, err := marshalDataByteString(magnitude.Bytes())
+	if err != nil {
+		return nil, err
+	}
+	return append([]byte{tag}, body...), nil
 }
 
 func (i Integer) Clone() PlutusData {
@@ -438,23 +460,27 @@ func (b *ByteString) UnmarshalCBOR(data []byte) error {
 }
 
 func (b ByteString) MarshalCBOR() ([]byte, error) {
-	// Haskell's Plutus encodes ByteStrings <= 64 bytes as definite-length,
-	// and ByteStrings > 64 bytes as indefinite-length with 64-byte chunks.
-	if len(b.Inner) <= MaxByteStringLeafSize {
-		if b.Inner == nil {
+	return marshalDataByteString(b.Inner)
+}
+
+// marshalDataByteString encodes a byte string the way Plutus' Data encoding
+// does: definite-length up to MaxByteStringLeafSize bytes, and otherwise an
+// indefinite-length byte string split into chunks of that size. This applies
+// both to a ByteString and to the magnitude of a bignum-encoded Integer. See
+// PlutusCore.Data.encodeBs.
+func marshalDataByteString(b []byte) ([]byte, error) {
+	if len(b) <= MaxByteStringLeafSize {
+		if b == nil {
 			return cborMarshal([]byte{})
 		}
-		return cborMarshal(b.Inner)
+		return cborMarshal(b)
 	}
-	// Indefinite-length byte string with 64-byte chunks
+	// Indefinite-length byte string with MaxByteStringLeafSize chunks
 	var buf bytes.Buffer
 	buf.WriteByte(0x5f) // Start indefinite-length byte string
-	for i := 0; i < len(b.Inner); i += MaxByteStringLeafSize {
-		end := i + MaxByteStringLeafSize
-		if end > len(b.Inner) {
-			end = len(b.Inner)
-		}
-		chunk, err := cborMarshal(b.Inner[i:end])
+	for i := 0; i < len(b); i += MaxByteStringLeafSize {
+		end := min(i+MaxByteStringLeafSize, len(b))
+		chunk, err := cborMarshal(b[i:end])
 		if err != nil {
 			return nil, fmt.Errorf("failed to encode byte string chunk: %w", err)
 		}

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -1105,3 +1105,88 @@ func contains(s, substr string) bool {
 	}
 	return false
 }
+
+// TestIntegerEncodeBignumChunking pins the Plutus rule that a bignum's
+// magnitude byte string is chunked at MaxByteStringLeafSize exactly like any
+// other Data byte string, so serialiseData output matches the reference
+// implementation. See PlutusCore.Data.encodeInteger and encodeBs.
+func TestIntegerEncodeBignumChunking(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{
+			name:  "max word64 stays a plain integer",
+			value: "18446744073709551615",
+			want:  "1bffffffffffffffff",
+		},
+		{
+			name:  "min negative word64 mirror stays a plain integer",
+			value: "-18446744073709551616",
+			want:  "3bffffffffffffffff",
+		},
+		{
+			name:  "positive bignum with a short magnitude is definite-length",
+			value: "18446744073709551616",
+			want:  "c249010000000000000000",
+		},
+		{
+			name:  "negative bignum with a short magnitude is definite-length",
+			value: "-18446744073709551617",
+			want:  "c349010000000000000000",
+		},
+		{
+			name:  "positive bignum with a 64-byte magnitude is definite-length",
+			value: "6703903964971298549787012499102923063739682910296196688861780721860882015036773488400937149083451713845015929093243025426876941405973284973216824503042048",
+			want:  "c2584080000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+		},
+		{
+			name:  "positive bignum with a 65-byte magnitude is chunked",
+			value: "13407807929942597099574024998205846127479365820592393377723561443721764030073546976801874298166903427690031858186486050853753882811946569946433649006084096",
+			want:  "c25f5840010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004100ff",
+		},
+		{
+			name:  "negative bignum with a 65-byte magnitude is chunked",
+			value: "-13407807929942597099574024998205846127479365820592393377723561443721764030073546976801874298166903427690031858186486050853753882811946569946433649006084097",
+			want:  "c35f5840010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004100ff",
+		},
+		{
+			// First price entry of the Plutus V3 withdrawal-oracle redeemer in
+			// preview transaction
+			// e8691d7c4003815928bc9de9017a3388d7fc0a168383c08d14633732a7c0bb33,
+			// whose 101-byte magnitude spans two chunks. The oracle validator
+			// verifies an Ed25519 signature over serialiseData of this payload,
+			// so a definite-length magnitude makes the signature check fail.
+			name:  "preview oracle payload entry is chunked",
+			value: "14307982583752985658271223448243037119817804983377071162983785513529273357775729074921515035965054912256372993647494147331015372835925768221100844299446692925637888529339416296811677652394714000000000000000000000000000000000000000000000000000",
+			want:  "c25f5840022550c33979cc6deb880a0a98f5af61ad8f42412df920e76ca5a75353579ae4ed4ca74ecea3059ffecf8388c02786f18842b7b7347bc03763bc3c9eeb048a835825f09f4d60db400f1d750ed8bce177cb85f1d98970f3d7668d1887c077997790000000000000ff",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n, ok := new(big.Int).SetString(tt.value, 10)
+			if !ok {
+				t.Fatalf("invalid big.Int literal %q", tt.value)
+			}
+			encoded, err := Encode(NewInteger(n))
+			if err != nil {
+				t.Fatalf("Encode: %v", err)
+			}
+			if got := hex.EncodeToString(encoded); got != tt.want {
+				t.Fatalf("Encode(%s):\n got %s\nwant %s", tt.name, got, tt.want)
+			}
+			decoded, err := Decode(encoded)
+			if err != nil {
+				t.Fatalf("Decode: %v", err)
+			}
+			roundTripped, ok := decoded.(*Integer)
+			if !ok {
+				t.Fatalf("Decode returned %T, want *Integer", decoded)
+			}
+			if roundTripped.Inner.Cmp(n) != 0 {
+				t.Fatalf("round trip got %s, want %s", roundTripped.Inner, n)
+			}
+		})
+	}
+}

--- a/data/decode.go
+++ b/data/decode.go
@@ -25,6 +25,11 @@ const (
 	CborIndefFlag uint8 = 0x1f
 
 	MaxByteStringLeafSize = 64
+
+	// CBOR bignum tags, used for any integer outside the Word64 range and its
+	// negative mirror.
+	cborTagPositiveBignum = 0xc2
+	cborTagNegativeBignum = 0xc3
 	MaxDecodeNestingDepth = 256
 	MaxDecodeNodes        = 1_000_000
 )


### PR DESCRIPTION
## Problem

`Integer.MarshalCBOR` delegated the bignum case to the CBOR library, which
emits a definite-length magnitude byte string. Plutus routes a bignum
magnitude through the same 64-byte chunking rule as a `Data` byte string
(`PlutusCore.Data.encodeInteger` -> `encodeBs`), so `serialiseData` diverged
from the reference for any integer whose magnitude exceeds 64 bytes
(`|i| >= 2^512`).

A validator that verifies an Ed25519 signature or a hash over
`serialiseData` output therefore fails on a canonical transaction.
Reproduced on preview transaction
`e8691d7c4003815928bc9de9017a3388d7fc0a168383c08d14633732a7c0bb33`
(block slot 121707875), whose Plutus V3 withdrawal validator
`473da51f9b910d257655e18d57ee6454ee345cb8d674d120ffd8f9c1` returns `error
explicitly called`. The oracle payload it signs over contains integers with
101-byte magnitudes.

## Change

- `Integer.MarshalCBOR` emits tag 2/3 plus a chunked magnitude byte string
  for any integer outside the Word64 range and its negative mirror.
- The chunking is factored into `marshalDataByteString`, shared with
  `ByteString.MarshalCBOR`.
- Integers inside the Word64 range and its negative mirror, and bignums with
  magnitudes up to 64 bytes, are unchanged.

## Verification

With the fix, `serialiseData` over that redeemer payload is byte-identical to
the reference encoding, the Ed25519 signature verifies, and the validator
succeeds consuming exactly the block's declared ex-units
(mem 28782, cpu 122798017).

Refs blinklabs-io/dingo#3780

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved serialization of very large positive and negative integers using Plutus-compatible bignum encoding.
  * Large integer magnitudes and byte strings are now encoded in correctly sized chunks.
  * Preserved native CBOR integer encoding for values within the supported 64-bit range.
  * Added coverage for large-value serialization and decoding, including extended real-world payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `serialiseData` for large integers so it matches the Plutus reference encoding, addressing `blinklabs-io/dingo#3780`. Previously, bignums with magnitudes over 64 bytes were emitted as definite-length byte strings, which made validators that verify signatures or hashes over `serialiseData` output reject canonical transactions. Now they use the same 64-byte chunking as other `Data` byte strings.

- `Integer.MarshalCBOR` now emits CBOR tag 2/3 plus a chunked magnitude for integers outside the Word64 range, using `marshalDataByteString` shared with `ByteString.MarshalCBOR`.
- Integers inside the Word64 range and bignums with magnitudes up to 64 bytes are unchanged.

<sup>Written for commit 0a18b8b1473eff174188154e61ecbcad539f3e6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/plutigo/pull/391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

