### PR TITLE
test: enforce conformance reference boundaries

### DIFF
--- a/tests/conformance_harness_test.go
+++ b/tests/conformance_harness_test.go
@@ -1,0 +1,273 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/plutigo/lang"
+)
+
+// addInteger-01 is copied byte-for-byte from the upstream Plutus conformance
+// corpus at 3109dc1e6501ecbbed0b7ae27361c255d7a16173.
+var (
+	referenceAddIntegerFlat = []byte{
+		0x01, 0x00, 0x00, 0x33, 0x70, 0x09, 0x00, 0x12, 0x40, 0x05,
+	}
+	referenceAddIntegerFlatExpected = []byte{
+		0x01, 0x00, 0x00, 0x48, 0x01, 0x01,
+	}
+)
+
+const (
+	referenceAddIntegerText         = "(program 1.0.0 [ [ (builtin addInteger) (con integer 1)] (con integer 1) ])"
+	referenceAddIntegerTextExpected = "(program 1.0.0 (con integer 2))"
+	referenceAddIntegerBudget       = "({cpu: 181308\n| mem: 602})"
+
+	referenceKeccakText = `-- Test vector from the upstream Plutus conformance corpus
+(program 1.0.0
+ [
+  [
+   (builtin equalsByteString)
+   [
+    (builtin keccak_256)
+    (con bytestring #AAFDC9243D3D4A096558A360CC27C8D862F0BE73DB5E88AA55)
+   ]
+  ]
+  (con bytestring #6FFFA070B865BE3EE766DC2DB49B6AA55C369F7DE3703ADA2612D754145C01E6)
+ ]
+)`
+	referenceKeccakTextExpected = "(program 1.0.0 (con bool True))"
+	referenceKeccakBudget       = "({cpu: 2660757\n| mem: 805})"
+
+	referenceLengthOfArrayText = `-- Measuring the length of an empty array
+(program 1.1.0
+  [
+    (force (builtin lengthOfArray))
+    (con (array bool) [])
+  ]
+)`
+	referenceLengthOfArrayTextExpected = "(program 1.1.0 (con integer 0))"
+	referenceLengthOfArrayBudget       = "({cpu: 295983\n| mem: 510})"
+)
+
+func writeConformanceFixture(
+	t *testing.T,
+	path string,
+	contents []byte,
+) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create fixture directory: %v", err)
+	}
+	if err := os.WriteFile(path, contents, 0o600); err != nil {
+		t.Fatalf("write fixture %s: %v", path, err)
+	}
+}
+
+func writeReferenceAddIntegerCase(t *testing.T, root string) string {
+	t.Helper()
+	caseDir := filepath.Join(
+		root,
+		"builtin",
+		"semantics",
+		"addInteger",
+		"addInteger-01",
+	)
+	stem := filepath.Join(caseDir, "addInteger-01")
+	writeConformanceFixture(t, stem+".uplc", []byte(referenceAddIntegerText))
+	writeConformanceFixture(
+		t,
+		stem+".uplc.expected",
+		[]byte(referenceAddIntegerTextExpected),
+	)
+	writeConformanceFixture(t, stem+".flat", referenceAddIntegerFlat)
+	writeConformanceFixture(
+		t,
+		stem+".flat.expected",
+		referenceAddIntegerFlatExpected,
+	)
+	writeConformanceFixture(
+		t,
+		stem+".budget.expected",
+		[]byte(referenceAddIntegerBudget),
+	)
+	return stem
+}
+
+func TestConformanceHarnessRunsReferenceTextAndFlat(t *testing.T) {
+	root := t.TempDir()
+	stem := writeReferenceAddIntegerCase(t, root)
+
+	cases, err := discoverConformanceCases(root)
+	if err != nil {
+		t.Fatalf("discover reference cases: %v", err)
+	}
+	if len(cases) != 2 {
+		t.Fatalf("discovered %d cases, want text and FLAT cases", len(cases))
+	}
+
+	formats := map[conformanceFormat]bool{}
+	for _, testCase := range cases {
+		formats[testCase.format] = true
+		if testCase.budgetPath != stem+".budget.expected" {
+			t.Fatalf(
+				"budget path = %q, want canonical sidecar",
+				testCase.budgetPath,
+			)
+		}
+		if err := runConformanceCase(testCase); err != nil {
+			t.Fatalf("run %s: %v", filepath.Ext(testCase.inputPath), err)
+		}
+	}
+	if !formats[conformanceText] || !formats[conformanceFlat] {
+		t.Fatalf("discovered formats = %v, want text and FLAT", formats)
+	}
+}
+
+func TestConformanceHarnessRunsV4ReferenceText(t *testing.T) {
+	root := t.TempDir()
+	stem := filepath.Join(
+		root,
+		"builtin",
+		"semantics",
+		"lengthOfArray",
+		"lengthOfArray-01",
+		"lengthOfArray-01",
+	)
+	writeConformanceFixture(
+		t,
+		stem+".uplc",
+		[]byte(referenceLengthOfArrayText),
+	)
+	writeConformanceFixture(
+		t,
+		stem+".uplc.expected",
+		[]byte(referenceLengthOfArrayTextExpected),
+	)
+	writeConformanceFixture(
+		t,
+		stem+".budget.expected",
+		[]byte(referenceLengthOfArrayBudget),
+	)
+
+	cases, err := discoverConformanceCases(root)
+	if err != nil {
+		t.Fatalf("discover V4 case: %v", err)
+	}
+	if len(cases) != 1 {
+		t.Fatalf("discovered %d cases, want 1", len(cases))
+	}
+	if err := runConformanceCase(cases[0]); err != nil {
+		t.Fatalf("run V4 reference case: %v", err)
+	}
+}
+
+func TestConformanceHarnessRunsV3ReferenceText(t *testing.T) {
+	root := t.TempDir()
+	stem := filepath.Join(
+		root,
+		"builtin",
+		"semantics",
+		"keccak_256",
+		"keccak_256-length-200",
+		"keccak_256-length-200",
+	)
+	writeConformanceFixture(t, stem+".uplc", []byte(referenceKeccakText))
+	writeConformanceFixture(
+		t,
+		stem+".uplc.expected",
+		[]byte(referenceKeccakTextExpected),
+	)
+	writeConformanceFixture(
+		t,
+		stem+".uplc.budget.expected",
+		[]byte(referenceKeccakBudget),
+	)
+
+	cases, err := discoverConformanceCases(root)
+	if err != nil {
+		t.Fatalf("discover V3 case: %v", err)
+	}
+	if len(cases) != 1 {
+		t.Fatalf("discovered %d cases, want 1", len(cases))
+	}
+	if version, protocol := conformanceLanguageForPath(cases[0].inputPath); version != lang.LanguageVersionV3 || protocol != 11 {
+		t.Fatalf("V3 language selection = %v/%d, want %v/11", version, protocol, lang.LanguageVersionV3)
+	}
+	if err := runConformanceCase(cases[0]); err != nil {
+		t.Fatalf("run V3 reference case: %v", err)
+	}
+}
+
+func TestConformanceHarnessRejectsWrongFlatResult(t *testing.T) {
+	root := t.TempDir()
+	stem := writeReferenceAddIntegerCase(t, root)
+	if err := os.Remove(stem + ".uplc"); err != nil {
+		t.Fatalf("remove text input: %v", err)
+	}
+	if err := os.Remove(stem + ".uplc.expected"); err != nil {
+		t.Fatalf("remove text expected result: %v", err)
+	}
+
+	wrongExpected := append([]byte(nil), referenceAddIntegerFlatExpected...)
+	wrongExpected[len(wrongExpected)-1] ^= 0x01
+	writeConformanceFixture(t, stem+".flat.expected", wrongExpected)
+
+	cases, err := discoverConformanceCases(root)
+	if err != nil {
+		t.Fatalf("discover mismatched case: %v", err)
+	}
+	if len(cases) != 1 {
+		t.Fatalf("discovered %d cases, want 1", len(cases))
+	}
+	err = runConformanceCase(cases[0])
+	if err == nil || !strings.Contains(err.Error(), "result mismatch") {
+		t.Fatalf("wrong reference result error = %v, want result mismatch", err)
+	}
+}
+
+func TestConformanceHarnessAcceptsReferenceDecodeFailure(t *testing.T) {
+	root := t.TempDir()
+	stem := filepath.Join(root, "term", "truncated", "truncated")
+	writeConformanceFixture(
+		t,
+		stem+".flat",
+		referenceAddIntegerFlat[:len(referenceAddIntegerFlat)-1],
+	)
+	writeConformanceFixture(
+		t,
+		stem+".flat.expected",
+		[]byte("parse/decode error"),
+	)
+	writeConformanceFixture(
+		t,
+		stem+".budget.expected",
+		[]byte("parse/decode error"),
+	)
+
+	cases, err := discoverConformanceCases(root)
+	if err != nil {
+		t.Fatalf("discover decode-failure case: %v", err)
+	}
+	if err := runConformanceCase(cases[0]); err != nil {
+		t.Fatalf("run decode-failure case: %v", err)
+	}
+}
+
+func TestConformanceHarnessRequiresBudgetSidecar(t *testing.T) {
+	root := t.TempDir()
+	stem := filepath.Join(root, "term", "missing-budget", "missing-budget")
+	writeConformanceFixture(t, stem+".uplc", []byte(referenceAddIntegerText))
+	writeConformanceFixture(
+		t,
+		stem+".uplc.expected",
+		[]byte(referenceAddIntegerTextExpected),
+	)
+
+	_, err := discoverConformanceCases(root)
+	if err == nil || !strings.Contains(err.Error(), "budget result") {
+		t.Fatalf("missing budget error = %v, want budget result error", err)
+	}
+}

--- a/tests/conformance_test.go
+++ b/tests/conformance_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"bytes"
 	"fmt"
 	"math"
 	"os"
@@ -172,6 +173,277 @@ func TestParseTerm(t *testing.T) {
 
 // ==================== Conformance Test ====================
 
+type conformanceFormat uint8
+
+const (
+	conformanceText conformanceFormat = iota
+	conformanceFlat
+)
+
+type conformanceFailure uint8
+
+const (
+	conformanceSuccess conformanceFailure = iota
+	conformanceParseFailure
+	conformanceEvaluationFailure
+)
+
+type conformanceCase struct {
+	inputPath    string
+	expectedPath string
+	budgetPath   string
+	format       conformanceFormat
+}
+
+func discoverConformanceCases(root string) ([]conformanceCase, error) {
+	cases := make([]conformanceCase, 0)
+	err := filepath.WalkDir(
+		root,
+		func(path string, entry os.DirEntry, err error) error {
+			if err != nil {
+				return fmt.Errorf("access %q: %w", path, err)
+			}
+			if entry.IsDir() {
+				return nil
+			}
+
+			format, ok := conformanceFormatForPath(path)
+			if !ok {
+				return nil
+			}
+
+			budgetPath, err := conformanceBudgetPath(path)
+			if err != nil {
+				return err
+			}
+			expectedPath := path + ".expected"
+			if _, err := os.Stat(expectedPath); err != nil {
+				return fmt.Errorf(
+					"expected result for %q: %w",
+					path,
+					err,
+				)
+			}
+
+			cases = append(cases, conformanceCase{
+				inputPath:    path,
+				expectedPath: expectedPath,
+				budgetPath:   budgetPath,
+				format:       format,
+			})
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	if len(cases) == 0 {
+		return nil, fmt.Errorf("no conformance inputs found under %q", root)
+	}
+	return cases, nil
+}
+
+func conformanceFormatForPath(path string) (conformanceFormat, bool) {
+	switch filepath.Ext(path) {
+	case ".uplc":
+		return conformanceText, true
+	case ".flat":
+		return conformanceFlat, true
+	default:
+		return conformanceText, false
+	}
+}
+
+func conformanceBudgetPath(inputPath string) (string, error) {
+	ext := filepath.Ext(inputPath)
+	canonicalPath := strings.TrimSuffix(inputPath, ext) + ".budget.expected"
+	if _, err := os.Stat(canonicalPath); err == nil {
+		return canonicalPath, nil
+	} else if !os.IsNotExist(err) {
+		return "", fmt.Errorf("stat budget %q: %w", canonicalPath, err)
+	}
+
+	legacyPath := inputPath + ".budget.expected"
+	if _, err := os.Stat(legacyPath); err == nil {
+		return legacyPath, nil
+	} else if !os.IsNotExist(err) {
+		return "", fmt.Errorf("stat budget %q: %w", legacyPath, err)
+	}
+
+	return "", fmt.Errorf(
+		"budget result for %q not found at %q or %q",
+		inputPath,
+		canonicalPath,
+		legacyPath,
+	)
+}
+
+func conformanceExpectedFailure(contents []byte) conformanceFailure {
+	switch strings.TrimSpace(string(contents)) {
+	case "parse error", "parse/decode error":
+		return conformanceParseFailure
+	case "evaluation failure":
+		return conformanceEvaluationFailure
+	default:
+		return conformanceSuccess
+	}
+}
+
+func decodeConformanceProgram(
+	format conformanceFormat,
+	contents []byte,
+) (*syn.Program[syn.DeBruijn], conformanceFailure, error) {
+	if format == conformanceFlat {
+		program, err := syn.Decode[syn.DeBruijn](contents)
+		return program, conformanceParseFailure, err
+	}
+
+	program, err := syn.Parse(string(contents))
+	if err != nil {
+		return nil, conformanceParseFailure, err
+	}
+	dProgram, err := syn.NameToDeBruijn(program)
+	return dProgram, conformanceEvaluationFailure, err
+}
+
+func conformanceLanguageForPath(
+	path string,
+) (lang.LanguageVersion, uint) {
+	if isV4BuiltinTest(path) {
+		return lang.LanguageVersionV4, 12
+	}
+	return lang.LanguageVersionV3, 11
+}
+
+func conformanceFirstByteMismatch(got, want []byte) int {
+	sharedLen := min(len(got), len(want))
+	for i := range sharedLen {
+		if got[i] != want[i] {
+			return i
+		}
+	}
+	return sharedLen
+}
+
+func runConformanceCase(testCase conformanceCase) error {
+	input, err := os.ReadFile(testCase.inputPath)
+	if err != nil {
+		return fmt.Errorf("read program: %w", err)
+	}
+	expected, err := os.ReadFile(testCase.expectedPath)
+	if err != nil {
+		return fmt.Errorf("read expected result: %w", err)
+	}
+	budget, err := os.ReadFile(testCase.budgetPath)
+	if err != nil {
+		return fmt.Errorf("read expected budget: %w", err)
+	}
+
+	expectedFailure := conformanceExpectedFailure(expected)
+	budgetFailure := conformanceExpectedFailure(budget)
+	program, failureStage, err := decodeConformanceProgram(
+		testCase.format,
+		input,
+	)
+	if err != nil {
+		if expectedFailure == failureStage && budgetFailure == failureStage {
+			return nil
+		}
+		return fmt.Errorf("load program: %w", err)
+	}
+	if expectedFailure == conformanceParseFailure {
+		return fmt.Errorf("expected parse/decode failure, program loaded")
+	}
+	if budgetFailure == conformanceParseFailure {
+		return fmt.Errorf("budget expects parse/decode failure, program loaded")
+	}
+
+	plutusVersion, protocolVersion := conformanceLanguageForPath(
+		testCase.inputPath,
+	)
+	initialBudget := cek.ExBudget{
+		Mem: math.MaxInt64,
+		Cpu: math.MaxInt64,
+	}
+	machine := cek.NewMachine[syn.DeBruijn](
+		plutusVersion,
+		200,
+		cek.NewDefaultEvalContext(
+			plutusVersion,
+			cek.ProtoVersion{Major: protocolVersion},
+		),
+	)
+	machine.ExBudget = initialBudget
+
+	result, err := machine.Run(program.Term)
+	if err != nil {
+		if expectedFailure == conformanceEvaluationFailure &&
+			budgetFailure == conformanceEvaluationFailure {
+			return nil
+		}
+		return fmt.Errorf("evaluate program: %w", err)
+	}
+	if expectedFailure == conformanceEvaluationFailure {
+		return fmt.Errorf("expected evaluation failure, evaluation succeeded")
+	}
+	if budgetFailure == conformanceEvaluationFailure {
+		return fmt.Errorf("budget expects evaluation failure, evaluation succeeded")
+	}
+
+	if testCase.format == conformanceFlat {
+		encodedResult, err := syn.Encode(&syn.Program[syn.DeBruijn]{
+			Version: program.Version,
+			Term:    result,
+		})
+		if err != nil {
+			return fmt.Errorf("encode result: %w", err)
+		}
+		if !bytes.Equal(encodedResult, expected) {
+			return fmt.Errorf(
+				"result mismatch at byte %d: got %d bytes, want %d",
+				conformanceFirstByteMismatch(encodedResult, expected),
+				len(encodedResult),
+				len(expected),
+			)
+		}
+	} else {
+		expectedProgram, _, err := decodeConformanceProgram(
+			conformanceText,
+			expected,
+		)
+		if err != nil {
+			return fmt.Errorf("load expected result: %w", err)
+		}
+		prettyResult := syn.PrettyTerm[syn.DeBruijn](result)
+		prettyExpected := syn.PrettyTerm[syn.DeBruijn](
+			expectedProgram.Term,
+		)
+		if prettyResult != prettyExpected {
+			return fmt.Errorf(
+				"result mismatch: got %s, want %s",
+				prettyResult,
+				prettyExpected,
+			)
+		}
+	}
+
+	consumedBudget := initialBudget.Sub(&machine.ExBudget)
+	formattedBudget := fmt.Sprintf(
+		"({cpu: %d\n| mem: %d})",
+		consumedBudget.Cpu,
+		consumedBudget.Mem,
+	)
+	expectedBudget := strings.TrimSpace(string(budget))
+	if formattedBudget != expectedBudget {
+		return fmt.Errorf(
+			"budget mismatch: got %s, want %s",
+			formattedBudget,
+			expectedBudget,
+		)
+	}
+	return nil
+}
+
 func TestConformance(t *testing.T) {
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
@@ -180,191 +452,22 @@ func TestConformance(t *testing.T) {
 
 	testRoot := filepath.Join(filepath.Dir(filename), "conformance")
 	testRoot = filepath.Clean(testRoot)
-
-	if _, err := os.Stat(testRoot); os.IsNotExist(err) {
-		t.Fatalf("Test directory not found: %s", testRoot)
+	cases, err := discoverConformanceCases(testRoot)
+	if err != nil {
+		t.Fatal(err)
 	}
-
-	categories := []string{"builtin", "example", "term"}
-	for _, category := range categories {
-		categoryDir := filepath.Join(testRoot, category)
-
-		err := filepath.Walk(
-			categoryDir,
-			func(path string, info os.FileInfo, err error) error {
-				if err != nil {
-					return fmt.Errorf("error accessing path %q: %w", path, err)
-				}
-
-				if info.IsDir() || !strings.HasSuffix(path, ".uplc") {
-					return nil
-				}
-
-				relPath, err := filepath.Rel(testRoot, path)
-				if err != nil {
-					return fmt.Errorf("could not get relative path: %w", err)
-				}
-				testName := strings.TrimSuffix(relPath, ".uplc")
-
-				t.Run(testName, func(t *testing.T) {
-					// Skip tests for unreleased builtins (never made it to mainnet)
-					if isUnreleasedBuiltinTest(path) {
-						t.Skip("Skipping unreleased builtin test")
-					}
-
-					// Read program file
-					programText, err := os.ReadFile(path)
-					if err != nil {
-						t.Fatalf("Failed to read program file: %v", err)
-					}
-
-					// Read expected file
-					expectedPath := path + ".expected"
-					expectedText, err := os.ReadFile(expectedPath)
-					if err != nil {
-						t.Fatalf("Failed to read expected file: %v", err)
-					}
-
-					// Handle budget file
-					budgetPath := path + ".budget.expected"
-					var expectedBudget string
-					if _, err := os.Stat(budgetPath); err == nil {
-						budgetText, err := os.ReadFile(budgetPath)
-						if err != nil {
-							t.Logf("Failed to read budget file: %v", err)
-						} else {
-							expectedBudget = strings.TrimSpace(string(budgetText))
-						}
-					}
-
-					// Parse program
-
-					program, err := syn.Parse(string(programText))
-					expectedResult := strings.TrimSpace(string(expectedText))
-					if err != nil {
-						if expectedResult == "parse error" {
-							return
-						}
-
-						t.Fatalf(
-							"Parse failed: %v\nInput: %s",
-							err,
-							programText,
-						)
-					}
-
-					// Convert to NamedDeBruijn
-
-					dProgram, err := syn.NameToDeBruijn(program)
-					if err != nil {
-						if expectedResult == "evaluation failure" {
-							return
-						}
-
-						t.Fatalf(
-							"Failed to convert program to DeBruijn: %v",
-							err,
-						)
-					}
-
-					// Evaluate program
-
-					// Tests need a higher budget than the production default; override explicitly
-					initialBudget := cek.ExBudget{
-						Mem: math.MaxInt64,
-						Cpu: math.MaxInt64,
-					}
-
-					// Determine appropriate Plutus version based on test path
-					// V4 builtins require V4; otherwise use V3
-					plutusVersion := lang.LanguageVersionV3
-					protoVersion := uint(11)
-					if isV4BuiltinTest(path) {
-						plutusVersion = lang.LanguageVersionV4
-						protoVersion = 12
-					}
-
-					machine := cek.NewMachine[syn.DeBruijn](
-						plutusVersion,
-						200,
-						cek.NewDefaultEvalContext(
-							plutusVersion,
-							cek.ProtoVersion{Major: protoVersion},
-						),
-					)
-					machine.ExBudget = initialBudget
-
-					result, err := machine.Run(dProgram.Term)
-					if err != nil {
-						if expectedResult == "evaluation failure" {
-							return
-						}
-
-						t.Fatalf("Failed to evaluate program: %v", err)
-					}
-
-					// Parse expected result
-
-					expected, err := syn.Parse(string(expectedText))
-					if err != nil {
-						t.Fatalf(
-							"Failed to parse expected result: %v\nExpected: %s",
-							err,
-							expectedText,
-						)
-					}
-
-					dExpected, err := syn.NameToDeBruijn(expected)
-					if err != nil {
-						t.Fatalf(
-							"Failed to convert program to DeBruijn: %v",
-							err,
-						)
-					}
-
-					// Compare results
-					prettyResult := syn.PrettyTerm[syn.DeBruijn](result)
-					prettyExpected := syn.PrettyTerm[syn.DeBruijn](
-						dExpected.Term,
-					)
-
-					original := syn.Pretty[syn.Name](program)
-
-					if prettyResult != prettyExpected {
-						t.Errorf(
-							"Result mismatch\nGot:\n%s\nWant:\n%s\nProgram:\n%s",
-							prettyResult,
-							prettyExpected,
-							original,
-						)
-					}
-
-					// Compare budgets if budget file was found
-					if expectedBudget != "" {
-						consumedBudget := initialBudget.Sub(
-							&machine.ExBudget,
-						)
-						fmtBudget := fmt.Sprintf(
-							"({cpu: %d\n| mem: %d})",
-							consumedBudget.Cpu,
-							consumedBudget.Mem,
-						)
-
-						if fmtBudget != expectedBudget {
-							t.Errorf(
-								"Budget mismatch\nGot:\n%s\nWant:\n%s",
-								fmtBudget,
-								expectedBudget,
-							)
-						}
-					}
-				})
-
-				return nil
-			},
-		)
+	for _, testCase := range cases {
+		relPath, err := filepath.Rel(testRoot, testCase.inputPath)
 		if err != nil {
-			t.Errorf("Error walking %s directory: %v", category, err)
+			t.Fatalf("could not get relative path: %v", err)
 		}
+		t.Run(filepath.ToSlash(relPath), func(t *testing.T) {
+			if isUnreleasedBuiltinTest(testCase.inputPath) {
+				t.Skip("Skipping unreleased builtin test")
+			}
+			if err := runConformanceCase(testCase); err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Closes #365. Add conformance coverage for reference-compatible builtin boundaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded conformance coverage for text and binary program formats.
  - Added support for recursively discovering conformance cases across test directories.
  - Improved validation of expected results, execution budgets, language versions, and failure scenarios.
  - Added coverage for V3 and V4 reference cases, malformed binary inputs, mismatched results, and missing budget data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The conformance tests previously ran only text `.uplc` fixtures and treated budget files as optional. They now enforce reference-compatible boundaries for both text and FLAT fixtures, including exact results, budgets, and expected failures; missing sidecars or mismatches fail the suite.

**Conformance Harness**

- Supports canonical and legacy budget sidecar paths.
- Reports the first mismatching byte for FLAT results.
- Distinguishes parse/decode failures from evaluation failures and verifies both expected files agree.

<sup>Written for commit bf4a3667759b438d5ebfaea890b75145791434a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/plutigo/pull/392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

