### PR TITLE
fix(data): bound JSON parse tree

### DIFF
--- a/data/json.go
+++ b/data/json.go
@@ -298,7 +298,16 @@ type jsonParseState struct {
 	nodes int
 }
 
-const maxJSONParseNestingDepth = (MaxDecodeNestingDepth + 1) * 3
+const (
+	maxJSONParseNestingDepth = (MaxDecodeNestingDepth + 1) * 3
+
+	// A canonical detailed-schema Map pair occupies five jsonValue nodes (the
+	// pair object plus two scalar PlutusData objects), while it represents two
+	// PlutusData nodes. Keep the parser cap large enough to admit every
+	// semantically bounded canonical datum, but separate from the semantic
+	// cap because the syntax tree necessarily contains structural nodes too.
+	maxJSONParseNodes = MaxDecodeNodes * 5 / 2
+)
 
 func (st *jsonParseState) enterValue() error {
 	if st.depth >= maxJSONParseNestingDepth {
@@ -310,11 +319,11 @@ func (st *jsonParseState) enterValue() error {
 	st.depth++
 
 	st.nodes++
-	if st.nodes > MaxDecodeNodes {
+	if st.nodes > maxJSONParseNodes {
 		st.depth--
 		return fmt.Errorf(
 			"PlutusData JSON tree exceeds max node count %d",
-			MaxDecodeNodes,
+			maxJSONParseNodes,
 		)
 	}
 	return nil

--- a/data/json.go
+++ b/data/json.go
@@ -287,6 +287,43 @@ func (st *jsonDecodeState) enterNode() error {
 	return nil
 }
 
+// jsonParseState bounds the jsonValue tree while it is being built. A
+// detailed-schema PlutusData value occupies at most three JSON nesting levels:
+// a data object, an enclosing array, and (for Maps) a key/value-pair object.
+// The additional value preserves the existing PlutusData-depth error for
+// one-level-over inputs; arbitrary JSON nesting still cannot grow the parser
+// stack beyond this bound.
+type jsonParseState struct {
+	depth int
+	nodes int
+}
+
+const maxJSONParseNestingDepth = (MaxDecodeNestingDepth + 1) * 3
+
+func (st *jsonParseState) enterValue() error {
+	if st.depth >= maxJSONParseNestingDepth {
+		return fmt.Errorf(
+			"PlutusData JSON tree nesting exceeds max depth %d",
+			maxJSONParseNestingDepth,
+		)
+	}
+	st.depth++
+
+	st.nodes++
+	if st.nodes > MaxDecodeNodes {
+		st.depth--
+		return fmt.Errorf(
+			"PlutusData JSON tree exceeds max node count %d",
+			MaxDecodeNodes,
+		)
+	}
+	return nil
+}
+
+func (st *jsonParseState) leaveValue() {
+	st.depth--
+}
+
 // jsonValueKind identifies the syntactic kind of a parsed JSON value.
 type jsonValueKind uint8
 
@@ -339,7 +376,7 @@ func unmarshalPlutusDataJSON(data json.RawMessage) (PlutusData, error) {
 func parsePlutusDataJSONTree(data []byte) (jsonValue, error) {
 	dec := json.NewDecoder(bytes.NewReader(data))
 	dec.UseNumber()
-	root, err := parsePlutusDataJSONValue(dec, data)
+	root, err := parsePlutusDataJSONValue(dec, data, &jsonParseState{})
 	if err != nil {
 		return jsonValue{}, normalizeJSONStreamError(err)
 	}
@@ -352,7 +389,13 @@ func parsePlutusDataJSONTree(data []byte) (jsonValue, error) {
 func parsePlutusDataJSONValue(
 	dec *json.Decoder,
 	data []byte,
+	st *jsonParseState,
 ) (jsonValue, error) {
+	if err := st.enterValue(); err != nil {
+		return jsonValue{}, err
+	}
+	defer st.leaveValue()
+
 	start := jsonValueStart(data, dec.InputOffset())
 	tok, err := dec.Token()
 	if err != nil {
@@ -364,7 +407,7 @@ func parsePlutusDataJSONValue(
 		case '[':
 			var items []jsonValue
 			for dec.More() {
-				item, err := parsePlutusDataJSONValue(dec, data)
+				item, err := parsePlutusDataJSONValue(dec, data, st)
 				if err != nil {
 					return jsonValue{}, err
 				}
@@ -395,7 +438,7 @@ func parsePlutusDataJSONValue(
 						keyTok,
 					)
 				}
-				val, err := parsePlutusDataJSONValue(dec, data)
+				val, err := parsePlutusDataJSONValue(dec, data, st)
 				if err != nil {
 					return jsonValue{}, err
 				}

--- a/data/json.go
+++ b/data/json.go
@@ -301,12 +301,10 @@ type jsonParseState struct {
 const (
 	maxJSONParseNestingDepth = (MaxDecodeNestingDepth + 1) * 3
 
-	// A canonical detailed-schema Map pair occupies five jsonValue nodes (the
-	// pair object plus two scalar PlutusData objects), while it represents two
-	// PlutusData nodes. Keep the parser cap large enough to admit every
-	// semantically bounded canonical datum, but separate from the semantic
-	// cap because the syntax tree necessarily contains structural nodes too.
-	maxJSONParseNodes = MaxDecodeNodes * 5 / 2
+	// A canonical detailed-schema Map pair with constructor values occupies
+	// seven jsonValue nodes while representing two PlutusData nodes. Keep the
+	// parser cap above that worst-case structural multiplier.
+	maxJSONParseNodes = MaxDecodeNodes * 4
 )
 
 func (st *jsonParseState) enterValue() error {

--- a/data/json_bench_test.go
+++ b/data/json_bench_test.go
@@ -24,20 +24,6 @@ func deepNestedJSONWithSiblings(depth, siblingHexLen int) string {
 	return sb.String()
 }
 
-// wideFlatJSON builds a single List with many small Integer items.
-func wideFlatJSON(items int) string {
-	var sb strings.Builder
-	sb.WriteString(`{"list":[`)
-	for i := 0; i < items; i++ {
-		if i > 0 {
-			sb.WriteByte(',')
-		}
-		sb.WriteString(`{"int":1}`)
-	}
-	sb.WriteString(`]}`)
-	return sb.String()
-}
-
 func BenchmarkDecodeJSONDeepNested(b *testing.B) {
 	input := []byte(deepNestedJSONWithSiblings(240, 4096))
 	b.SetBytes(int64(len(input)))

--- a/data/json_limits_test.go
+++ b/data/json_limits_test.go
@@ -17,6 +17,18 @@ func nestedListJSON(depth int) string {
 	return sb.String()
 }
 
+func nestedMapKeyJSON(depth int) string {
+	var sb strings.Builder
+	for i := 0; i < depth; i++ {
+		sb.WriteString(`{"map":[{"k":`)
+	}
+	sb.WriteString(`{"int":0}`)
+	for i := 0; i < depth; i++ {
+		sb.WriteString(`,"v":{"int":0}}]}`)
+	}
+	return sb.String()
+}
+
 // TestDecodeJSONDepthLimit verifies the JSON PlutusData decoder enforces the
 // same nesting-depth limit as the CBOR decoder, rather than recursing
 // arbitrarily deep on untrusted input.
@@ -28,9 +40,9 @@ func TestDecodeJSONDepthLimit(t *testing.T) {
 	}{
 		{"within limit decodes", nestedListJSON(100), ""},
 		{
-			"beyond limit is rejected",
-			nestedListJSON(MaxDecodeNestingDepth + 50),
-			"depth",
+			"parser rejects nesting before building the full tree",
+			nestedListJSON(MaxDecodeNestingDepth * 2),
+			"PlutusData JSON tree nesting exceeds max depth",
 		},
 	}
 
@@ -53,9 +65,27 @@ func TestDecodeJSONDepthLimit(t *testing.T) {
 	}
 }
 
+func TestDecodeJSONMapDepthBoundary(t *testing.T) {
+	t.Run("exactly at PlutusData limit decodes", func(t *testing.T) {
+		if _, err := DecodeJSON([]byte(nestedMapKeyJSON(MaxDecodeNestingDepth - 1))); err != nil {
+			t.Fatalf("expected success at depth limit, got: %v", err)
+		}
+	})
+	t.Run("one past PlutusData limit preserves semantic error", func(t *testing.T) {
+		_, err := DecodeJSON([]byte(nestedMapKeyJSON(MaxDecodeNestingDepth)))
+		if err == nil {
+			t.Fatal("expected depth error, got nil")
+		}
+		want := "PlutusData JSON nesting exceeds max depth 256"
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error containing %q, got: %v", want, err)
+		}
+	})
+}
+
 func TestDecodeJSONMapPairRejectsUnknownFieldBeforeValueDecode(t *testing.T) {
 	input := `{"map":[{"k":{"int":1},"junk":` +
-		nestedListJSON(MaxDecodeNestingDepth+50) +
+		nestedListJSON(100) +
 		`,"v":{"int":2}}]}`
 
 	_, err := DecodeJSON([]byte(input))
@@ -67,13 +97,14 @@ func TestDecodeJSONMapPairRejectsUnknownFieldBeforeValueDecode(t *testing.T) {
 	}
 }
 
-// TestDecodeJSONNodeLimit verifies the JSON decoder enforces a node-count cap.
+// TestDecodeJSONNodeLimit verifies the JSON parser enforces a node-count cap
+// before it allocates a complete jsonValue tree for an unrecognized payload.
 func TestDecodeJSONNodeLimit(t *testing.T) {
 	if testing.Short() {
 		t.Skip("builds a >1M-node document; skipped in -short mode")
 	}
 	var sb strings.Builder
-	sb.WriteString(`{"list":[`)
+	sb.WriteString(`{"unknown":[`)
 	n := MaxDecodeNodes + 10
 	for i := 0; i < n; i++ {
 		if i > 0 {
@@ -88,7 +119,11 @@ func TestDecodeJSONNodeLimit(t *testing.T) {
 		input            string
 		wantErrSubstring string
 	}{
-		{"beyond limit is rejected", sb.String(), "node"},
+		{
+			"parser rejects before building the full tree",
+			sb.String(),
+			"PlutusData JSON tree exceeds max node count",
+		},
 	}
 
 	for _, tt := range tests {

--- a/data/json_limits_test.go
+++ b/data/json_limits_test.go
@@ -29,6 +29,19 @@ func nestedMapKeyJSON(depth int) string {
 	return sb.String()
 }
 
+func wideFlatJSON(items int) string {
+	var sb strings.Builder
+	sb.WriteString(`{"list":[`)
+	for i := 0; i < items; i++ {
+		if i > 0 {
+			sb.WriteByte(',')
+		}
+		sb.WriteString(`{"int":1}`)
+	}
+	sb.WriteString(`]}`)
+	return sb.String()
+}
+
 // TestDecodeJSONDepthLimit verifies the JSON PlutusData decoder enforces the
 // same nesting-depth limit as the CBOR decoder, rather than recursing
 // arbitrarily deep on untrusted input.
@@ -97,22 +110,26 @@ func TestDecodeJSONMapPairRejectsUnknownFieldBeforeValueDecode(t *testing.T) {
 	}
 }
 
-// TestDecodeJSONNodeLimit verifies the JSON parser enforces a node-count cap
-// before it allocates a complete jsonValue tree for an unrecognized payload.
+// TestDecodeJSONParserNodeAllowance verifies parser accounting leaves room
+// for JSON structural nodes in an otherwise valid datum below the semantic
+// PlutusData node limit.
+func TestDecodeJSONParserNodeAllowance(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds a 500K-item document; skipped in -short mode")
+	}
+
+	_, err := DecodeJSON([]byte(wideFlatJSON(MaxDecodeNodes / 2)))
+	if err != nil {
+		t.Fatalf("DecodeJSON rejected a semantically bounded flat list: %v", err)
+	}
+}
+
+// TestDecodeJSONNodeLimit verifies the JSON parser enforces its node-count cap
+// before it allocates a complete tree for a datum exceeding the semantic cap.
 func TestDecodeJSONNodeLimit(t *testing.T) {
 	if testing.Short() {
-		t.Skip("builds a >1M-node document; skipped in -short mode")
+		t.Skip("builds a >2.5M-node document; skipped in -short mode")
 	}
-	var sb strings.Builder
-	sb.WriteString(`{"unknown":[`)
-	n := MaxDecodeNodes + 10
-	for i := 0; i < n; i++ {
-		if i > 0 {
-			sb.WriteByte(',')
-		}
-		sb.WriteString(`{"int":0}`)
-	}
-	sb.WriteString(`]}`)
 
 	tests := []struct {
 		name             string
@@ -121,7 +138,7 @@ func TestDecodeJSONNodeLimit(t *testing.T) {
 	}{
 		{
 			"parser rejects before building the full tree",
-			sb.String(),
+			wideFlatJSON(maxJSONParseNodes / 2),
 			"PlutusData JSON tree exceeds max node count",
 		},
 	}
@@ -143,4 +160,25 @@ func TestDecodeJSONNodeLimit(t *testing.T) {
 			}
 		})
 	}
+}
+
+func FuzzDecodeJSON(f *testing.F) {
+	for _, input := range []string{
+		`{"int":0}`,
+		`{"list":[{"int":1},{"bytes":"ab"}]}`,
+		`{"map":[{"k":{"int":1},"v":{"int":2}}]}`,
+		`{"constructor":0,"fields":[{"int":1}]}`,
+		`{"int":`,
+		nestedListJSON(MaxDecodeNestingDepth),
+		nestedListJSON(maxJSONParseNestingDepth),
+	} {
+		f.Add([]byte(input))
+	}
+
+	f.Fuzz(func(t *testing.T, input []byte) {
+		if len(input) > 16*1024 {
+			t.Skip()
+		}
+		_, _ = DecodeJSON(input)
+	})
 }

--- a/data/json_limits_test.go
+++ b/data/json_limits_test.go
@@ -42,6 +42,19 @@ func wideFlatJSON(items int) string {
 	return sb.String()
 }
 
+func wideEmptyConstrListJSON(items int) string {
+	var sb strings.Builder
+	sb.WriteString(`{"list":[`)
+	for i := 0; i < items; i++ {
+		if i > 0 {
+			sb.WriteByte(',')
+		}
+		sb.WriteString(`{"constructor":0,"fields":[]}`)
+	}
+	sb.WriteString(`]}`)
+	return sb.String()
+}
+
 // TestDecodeJSONDepthLimit verifies the JSON PlutusData decoder enforces the
 // same nesting-depth limit as the CBOR decoder, rather than recursing
 // arbitrarily deep on untrusted input.
@@ -121,6 +134,16 @@ func TestDecodeJSONParserNodeAllowance(t *testing.T) {
 	_, err := DecodeJSON([]byte(wideFlatJSON(MaxDecodeNodes / 2)))
 	if err != nil {
 		t.Fatalf("DecodeJSON rejected a semantically bounded flat list: %v", err)
+	}
+}
+
+func TestDecodeJSONParserNodeAllowanceRejectsValidConstrList(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds a ~1M-item document; skipped in -short mode")
+	}
+
+	if _, err := DecodeJSON([]byte(wideEmptyConstrListJSON(MaxDecodeNodes - 10))); err != nil {
+		t.Fatalf("DecodeJSON rejected a semantically bounded Constr list: %v", err)
 	}
 }
 


### PR DESCRIPTION
Fixes #368.

- Bound JSON tree nodes and parser nesting before semantic decoding.
- Preserve detailed-schema depth boundaries for lists and maps.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #368 by bounding JSON tree depth and node count during parsing, so oversized payloads are rejected before building a full tree. The parser budget is separate from the semantic PlutusData limits: the node cap includes a structural allowance so valid datums at the semantic limit still decode, and depth failures preserve the existing semantic error for one-level-over inputs. Limit failures now come from the parser with "PlutusData JSON tree" messages. Adds fuzz coverage for the decoder.

<sup>Written for commit 61c290d25a4ca463f73534e98b115093af92a70f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/plutigo/pull/393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * JSON input with excessive nesting or too many nodes is now rejected during parsing.
  * Improved handling of deeply nested arrays and map keys to prevent oversized JSON documents from being fully built before validation.
  * Boundary cases for JSON depth and node limits now produce clearer parsing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->