### PR TITLE
fix(cek): preserve evaluator error classes

### DIFF
--- a/cek/errors.go
+++ b/cek/errors.go
@@ -1,6 +1,7 @@
 package cek
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -160,6 +161,39 @@ func internalError(message string) *InternalError {
 	return &InternalError{
 		Code:    ErrCodeInternalError,
 		Message: message,
+	}
+}
+
+// normalizeEvalError preserves an error that already carries evaluator
+// classification and gives unexpected implementation errors a stable type for
+// callers. Errors from the execution context are intentionally left intact so
+// errors.Is continues to identify cancellation and deadlines.
+func normalizeEvalError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var evalErr EvalError
+	if errors.As(err, &evalErr) {
+		return err
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+	return internalError(err.Error())
+}
+
+func normalizeBuiltinError(fn string, err error) error {
+	if err == nil {
+		return nil
+	}
+	var evalErr EvalError
+	if errors.As(err, &evalErr) {
+		return err
+	}
+	return &BuiltinError{
+		Code:    ErrCodeBuiltinFailure,
+		Builtin: fn,
+		Message: err.Error(),
 	}
 }
 

--- a/cek/machine.go
+++ b/cek/machine.go
@@ -1052,7 +1052,7 @@ func (m *Machine[T]) runContext(
 			dbTerm,
 		)
 		if err != nil {
-			return nil, err
+			return nil, normalizeEvalError(err)
 		}
 		result, ok := any(dbResult).(syn.Term[T])
 		if !ok {
@@ -1066,7 +1066,8 @@ func (m *Machine[T]) runContext(
 		}
 		return result, nil
 	}
-	return m.runStack(ctx, checkCancellation, term)
+	result, err := m.runStack(ctx, checkCancellation, term)
+	return result, normalizeEvalError(err)
 }
 
 // compute handles the Compute state of the CEK machine.

--- a/cek/machine_flow_test.go
+++ b/cek/machine_flow_test.go
@@ -1,6 +1,8 @@
 package cek
 
 import (
+	"bytes"
+	"errors"
 	"math/big"
 	"testing"
 
@@ -77,6 +79,62 @@ func TestBuiltinAddInteger(t *testing.T) {
 	out := runTerm(t, m, app2)
 	if out == nil {
 		t.Fatal("expected non-nil output for builtin addInteger")
+	}
+}
+
+func TestRunPreservesEvaluatorErrorClasses(t *testing.T) {
+	invalidG1 := bytes.Repeat([]byte{0}, 48)
+	tests := []struct {
+		name        string
+		term        syn.Term[syn.DeBruijn]
+		wantScript  bool
+		wantBuiltin bool
+		wantType    bool
+	}{
+		{
+			name:       "deliberate script failure",
+			term:       &syn.Error{},
+			wantScript: true,
+		},
+		{
+			name: "invalid BLS point is a builtin failure",
+			term: &syn.Force[syn.DeBruijn]{
+				Term: &syn.Apply[syn.DeBruijn]{
+					Function: &syn.Builtin{DefaultFunction: builtin.Bls12_381_G1_Uncompress},
+					Argument: &syn.Constant{Con: &syn.ByteString{Inner: invalidG1}},
+				},
+			},
+			wantBuiltin: true,
+		},
+		{
+			name: "invalid application is a type failure",
+			term: &syn.Apply[syn.DeBruijn]{
+				Function: &syn.Constant{Con: &syn.Integer{Inner: big.NewInt(1)}},
+				Argument: &syn.Constant{Con: &syn.Integer{Inner: big.NewInt(2)}},
+			},
+			wantType: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := newTestMachineFlow().Run(tt.term)
+			if err == nil {
+				t.Fatal("Run returned nil error")
+			}
+			var scriptErr *ScriptError
+			var builtinErr *BuiltinError
+			var typeErr *TypeError
+			if got := errors.As(err, &scriptErr); got != tt.wantScript {
+				t.Errorf("ScriptError match = %v, want %v (%T: %v)", got, tt.wantScript, err, err)
+			}
+			if got := errors.As(err, &builtinErr); got != tt.wantBuiltin {
+				t.Errorf("BuiltinError match = %v, want %v (%T: %v)", got, tt.wantBuiltin, err, err)
+			}
+			if got := errors.As(err, &typeErr); got != tt.wantType {
+				t.Errorf("TypeError match = %v, want %v (%T: %v)", got, tt.wantType, err, err)
+			}
+		})
 	}
 }
 

--- a/cek/runtime.go
+++ b/cek/runtime.go
@@ -208,7 +208,8 @@ func (m *Machine[T]) evalBuiltinApp(b *Builtin[T]) (Value[T], error) {
 			),
 		}
 	}
-	return fn(m, b)
+	value, err := fn(m, b)
+	return value, normalizeBuiltinError(b.Func.String(), err)
 }
 
 func (m *Machine[T]) evalBuiltinAppReady(


### PR DESCRIPTION
Closes #370.

The CEK evaluator now preserves existing typed evaluation errors and classifies unexpected builtin failures as `BuiltinError`. Unexpected errors escaping the evaluator are classified as `InternalError`, while context cancellation remains discoverable with `errors.Is`.

Regression coverage distinguishes deliberate script failure, malformed BLS point uncompression, and malformed application errors.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CEK evaluator so typed evaluation errors survive execution instead of being stripped into raw errors. Unexpected builtin failures are now classified as `BuiltinError`, unexpected internal errors as `InternalError`, and context cancellation and deadline errors stay intact for `errors.Is`.

- Closes #370.
- Adds regression tests distinguishing deliberate script failure, malformed BLS point uncompression, and malformed application errors.

<sup>Written for commit 5874538131ec6c17503bff031dc9c9ec4ccb8809. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/plutigo/pull/394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during script execution to preserve specific evaluator, cancellation, deadline, builtin, and type error classifications.
  * Added clearer context for errors originating from built-in operations.
  * Ensured invalid operations and malformed inputs return more accurate error types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->