### PR TITLE
fix(cek): give each cost model its own builtin costs

### DIFF
--- a/cek/cost_model_builtins.go
+++ b/cek/cost_model_builtins.go
@@ -25,6 +25,12 @@ func (b *BuiltinCosts) Clone() BuiltinCosts {
 		return ret
 	}
 	for i, costingFunc := range b {
+		// A nil entry stays nil: update already treats one as "no existing
+		// cost info for builtin", so cloning must not invent a zero-valued
+		// CostingFunc where the source had none.
+		if costingFunc == nil {
+			continue
+		}
 		ret[i] = costingFunc.clone()
 	}
 	return ret

--- a/cek/cost_model_builtins.go
+++ b/cek/cost_model_builtins.go
@@ -8,15 +8,24 @@ import (
 
 	"github.com/blinklabs-io/plutigo/builtin"
 	"github.com/blinklabs-io/plutigo/lang"
-	"github.com/jinzhu/copier"
 )
 
 type BuiltinCosts [builtin.TotalBuiltinCount]*CostingFunc[Arguments]
 
+// Clone returns builtin costs sharing no mutable state with b.
+//
+// BuiltinCosts is an array of pointers, so a struct copy aliases every
+// CostingFunc and every model inside it. update writes through those pointers,
+// which made building any cost model from protocol parameters mutate whatever
+// it was cloned from -- in practice the package-level DefaultBuiltinCosts, and
+// concurrently every other evaluation in the process.
 func (b *BuiltinCosts) Clone() BuiltinCosts {
 	var ret BuiltinCosts
-	if err := copier.CopyWithOption(&ret, b, copier.Option{DeepCopy: true}); err != nil {
-		panic(fmt.Sprintf("failure cloning BuiltinCosts: %s", err))
+	if b == nil {
+		return ret
+	}
+	for i, costingFunc := range b {
+		ret[i] = costingFunc.clone()
 	}
 	return ret
 }
@@ -1424,6 +1433,11 @@ func CostSextuple[T SixArgument](
 type Arguments interface {
 	isArguments()
 	HasConstants() []bool
+	// cloneArguments returns a copy sharing no mutable state with the
+	// receiver. BuiltinCosts.update mutates these models in place, so a cost
+	// model built from protocol parameters must own every model it can write
+	// to. See cost_model_clone.go.
+	cloneArguments() Arguments
 }
 
 var (

--- a/cek/cost_model_clone.go
+++ b/cek/cost_model_clone.go
@@ -1,0 +1,215 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cek
+
+// Deep copying for cost models.
+//
+// BuiltinCosts is an array of *CostingFunc, and each CostingFunc holds its cpu
+// and mem models in Arguments interface values that are always pointers. A
+// struct copy of the array therefore shares every model with its source, and
+// BuiltinCosts.update mutates those models in place. Cloning has to allocate a
+// new model for every entry, or building a cost model from protocol parameters
+// writes into whatever it was cloned from -- including the package-level
+// DefaultBuiltinCosts.
+//
+// Every Arguments implementation is either plain int64 fields or embeds a
+// struct of them, with one exception: ConstantOrTwoArguments carries a nested
+// TwoArgument. Those three types clone that nested model as well; the rest
+// clone by value.
+
+// cloneTwoArgument deep-copies a nested two-argument model. Every Arguments
+// implementation clones to a pointer of its own type, so the assertion back to
+// TwoArgument holds for any value that satisfied it going in.
+func cloneTwoArgument(model TwoArgument) TwoArgument {
+	if model == nil {
+		return nil
+	}
+	cloned, ok := model.cloneArguments().(TwoArgument)
+	if !ok {
+		return model
+	}
+	return cloned
+}
+
+func (x AboveAndBelowDiagonalModel) cloneArguments() Arguments {
+	c := x
+	c.model = cloneTwoArgument(x.model)
+	return &c
+}
+
+func (x AddedSizesModel) cloneArguments() Arguments {
+	c := x
+	return &c
+}
+
+func (x ConstAboveDiagonalIntoQuadraticXAndYModel) cloneArguments() Arguments {
+	c := x
+	return &c
+}
+
+func (x ConstAboveDiagonalModel) cloneArguments() Arguments {
+	c := x
+	c.model = cloneTwoArgument(x.model)
+	return &c
+}
+
+func (x ConstBelowDiagonalModel) cloneArguments() Arguments {
+	c := x
+	c.model = cloneTwoArgument(x.model)
+	return &c
+}
+
+func (x ConstantCost) cloneArguments() Arguments {
+	c := x
+	return &c
+}
+
+func (x DropListCost) cloneArguments() Arguments {
+	c := x
+	return &c
+}
+
+func (x ExpMod) cloneArguments() Arguments {
+	c := x
+	return &c
+}
+
+func (x FourLinearInU) cloneArguments() Arguments {
+	c := x
+	return &c
+}
+
+func (x LinearCost) cloneArguments() Arguments {
+	c := x
+	return &c
+}
+
+func (x LinearInX) cloneArguments() Arguments {
+	c := x
+	return &c
+}
+
+func (x LinearInXAndY) cloneArguments() Arguments {
+	c := x
+	return &c
+}
+
+func (x LinearInY) cloneArguments() Arguments {
+	c := x
+	return &c
+}
+
+func (x LinearOnDiagonalModel) cloneArguments() Arguments {
+	c := x
+	return &c
+}
+
+func (x MaxSizeModel) cloneArguments() Arguments {
+	c := x
+	return &c
+}
+
+func (x MinSizeModel) cloneArguments() Arguments {
+	c := x
+	return &c
+}
+
+func (x MultipliedSizesModel) cloneArguments() Arguments {
+	c := x
+	return &c
+}
+
+func (x QuadraticInXModel) cloneArguments() Arguments {
+	c := x
+	return &c
+}
+
+func (x QuadraticInYModel) cloneArguments() Arguments {
+	c := x
+	return &c
+}
+
+func (x SubtractedSizesModel) cloneArguments() Arguments {
+	c := x
+	return &c
+}
+
+func (x ThreeAddedSizesModel) cloneArguments() Arguments {
+	c := x
+	return &c
+}
+
+func (x ThreeLinearInMaxYZ) cloneArguments() Arguments {
+	c := x
+	return &c
+}
+
+func (x ThreeLinearInX) cloneArguments() Arguments {
+	c := x
+	return &c
+}
+
+func (x ThreeLinearInY) cloneArguments() Arguments {
+	c := x
+	return &c
+}
+
+func (x ThreeLinearInYandZ) cloneArguments() Arguments {
+	c := x
+	return &c
+}
+
+func (x ThreeLinearInZ) cloneArguments() Arguments {
+	c := x
+	return &c
+}
+
+func (x ThreeLiteralInYorLinearInZ) cloneArguments() Arguments {
+	c := x
+	return &c
+}
+
+func (x ThreeQuadraticInZ) cloneArguments() Arguments {
+	c := x
+	return &c
+}
+
+func (x WithInteractionInXAndY) cloneArguments() Arguments {
+	c := x
+	return &c
+}
+
+// clone returns a CostingFunc sharing no mutable state with cf.
+func (cf *CostingFunc[T]) clone() *CostingFunc[T] {
+	if cf == nil {
+		return nil
+	}
+	ret := &CostingFunc[T]{}
+	if any(cf.mem) != nil {
+		if cloned, ok := cf.mem.cloneArguments().(T); ok {
+			ret.mem = cloned
+		} else {
+			ret.mem = cf.mem
+		}
+	}
+	if any(cf.cpu) != nil {
+		if cloned, ok := cf.cpu.cloneArguments().(T); ok {
+			ret.cpu = cloned
+		} else {
+			ret.cpu = cf.cpu
+		}
+	}
+	return ret
+}

--- a/cek/cost_model_clone.go
+++ b/cek/cost_model_clone.go
@@ -14,6 +14,8 @@
 
 package cek
 
+import "fmt"
+
 // Deep copying for cost models.
 //
 // BuiltinCosts is an array of *CostingFunc, and each CostingFunc holds its cpu
@@ -38,7 +40,7 @@ func cloneTwoArgument(model TwoArgument) TwoArgument {
 	}
 	cloned, ok := model.cloneArguments().(TwoArgument)
 	if !ok {
-		return model
+		panic(fmt.Sprintf("cost model clone returned %T, want TwoArgument", model))
 	}
 	return cloned
 }
@@ -197,17 +199,19 @@ func (x WithInteractionInXAndY) cloneArguments() Arguments {
 func (cf *CostingFunc[T]) clone() *CostingFunc[T] {
 	ret := &CostingFunc[T]{}
 	if any(cf.mem) != nil {
-		if cloned, ok := cf.mem.cloneArguments().(T); ok {
+		clonedArgs := cf.mem.cloneArguments()
+		if cloned, ok := clonedArgs.(T); ok {
 			ret.mem = cloned
 		} else {
-			ret.mem = cf.mem
+			panic(fmt.Sprintf("cost model clone returned incompatible type %T", clonedArgs))
 		}
 	}
 	if any(cf.cpu) != nil {
-		if cloned, ok := cf.cpu.cloneArguments().(T); ok {
+		clonedArgs := cf.cpu.cloneArguments()
+		if cloned, ok := clonedArgs.(T); ok {
 			ret.cpu = cloned
 		} else {
-			ret.cpu = cf.cpu
+			panic(fmt.Sprintf("cost model clone returned incompatible type %T", clonedArgs))
 		}
 	}
 	return ret

--- a/cek/cost_model_clone.go
+++ b/cek/cost_model_clone.go
@@ -191,11 +191,10 @@ func (x WithInteractionInXAndY) cloneArguments() Arguments {
 	return &c
 }
 
-// clone returns a CostingFunc sharing no mutable state with cf.
+// clone returns a CostingFunc sharing no mutable state with cf. cf must not be
+// nil; BuiltinCosts.Clone leaves a nil entry nil rather than calling this, so
+// cloning neither introduces a nil entry nor removes one.
 func (cf *CostingFunc[T]) clone() *CostingFunc[T] {
-	if cf == nil {
-		return nil
-	}
 	ret := &CostingFunc[T]{}
 	if any(cf.mem) != nil {
 		if cloned, ok := cf.mem.cloneArguments().(T); ok {

--- a/cek/cost_model_clone_test.go
+++ b/cek/cost_model_clone_test.go
@@ -1,0 +1,169 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cek
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/blinklabs-io/plutigo/builtin"
+	"github.com/blinklabs-io/plutigo/lang"
+)
+
+// addIntegerCpuIntercept reads the one cost value the tests below drive, so a
+// failure names a number rather than a pointer.
+func addIntegerCpuIntercept(t *testing.T, costs BuiltinCosts) int64 {
+	t.Helper()
+	costingFunc := costs[builtin.AddInteger]
+	if costingFunc == nil {
+		t.Fatal("no costing function for addInteger")
+	}
+	model, ok := costingFunc.cpu.(*MaxSizeModel)
+	if !ok {
+		t.Fatalf("addInteger cpu model is %T, want *MaxSizeModel", costingFunc.cpu)
+	}
+	return model.intercept
+}
+
+// TestBuiltinCostsCloneDoesNotAliasSource pins the array-of-pointers hazard:
+// Clone copies pointers unless it allocates, and update writes through them.
+func TestBuiltinCostsCloneDoesNotAliasSource(t *testing.T) {
+	source := DefaultBuiltinCosts.Clone()
+	before := addIntegerCpuIntercept(t, source)
+
+	cloned := source.Clone()
+	if source[builtin.AddInteger] == cloned[builtin.AddInteger] {
+		t.Errorf(
+			"clone shares the addInteger CostingFunc pointer with its source: %p",
+			source[builtin.AddInteger],
+		)
+	}
+	if source[builtin.AddInteger].cpu == cloned[builtin.AddInteger].cpu {
+		t.Errorf(
+			"clone shares the addInteger cpu model with its source: %#v",
+			source[builtin.AddInteger].cpu,
+		)
+	}
+
+	if err := cloned.update("addInteger-cpu-arguments-intercept", 999999); err != nil {
+		t.Fatalf("update clone: %v", err)
+	}
+	if got := addIntegerCpuIntercept(t, source); got != before {
+		t.Errorf(
+			"updating the clone changed its source: intercept %d -> %d",
+			before,
+			got,
+		)
+	}
+	if got := addIntegerCpuIntercept(t, cloned); got != 999999 {
+		t.Errorf("update did not take effect on the clone: intercept = %d", got)
+	}
+}
+
+// TestBuildBuiltinCostsAreIndependent covers the production entry point rather
+// than Clone directly: two cost models built from the same defaults must not
+// see each other's protocol parameters.
+func TestBuildBuiltinCostsAreIndependent(t *testing.T) {
+	first, err := buildBuiltinCosts(lang.LanguageVersionV3, SemanticsVariantE)
+	if err != nil {
+		t.Fatalf("build first: %v", err)
+	}
+	second, err := buildBuiltinCosts(lang.LanguageVersionV3, SemanticsVariantE)
+	if err != nil {
+		t.Fatalf("build second: %v", err)
+	}
+	before := addIntegerCpuIntercept(t, second)
+
+	if err := first.update("addInteger-cpu-arguments-intercept", 111111); err != nil {
+		t.Fatalf("update first: %v", err)
+	}
+	if got := addIntegerCpuIntercept(t, second); got != before {
+		t.Errorf(
+			"updating one built cost model changed another: intercept %d -> %d",
+			before,
+			got,
+		)
+	}
+}
+
+// TestDefaultBuiltinCostsSurviveCostModelConstruction is the consequence that
+// makes this a correctness defect rather than a hygiene one: costModelFromList
+// runs update for every protocol parameter, so a leaking clone leaves those
+// values in the package-level defaults for every later evaluation.
+func TestDefaultBuiltinCostsSurviveCostModelConstruction(t *testing.T) {
+	before := addIntegerCpuIntercept(t, DefaultBuiltinCosts)
+
+	params := make([]int64, len(lang.GetParamNamesForVersion(lang.LanguageVersionV3)))
+	for i := range params {
+		params[i] = 1
+	}
+	if _, err := costModelFromList(
+		lang.LanguageVersionV3,
+		SemanticsVariantE,
+		params,
+	); err != nil {
+		t.Fatalf("costModelFromList: %v", err)
+	}
+
+	if got := addIntegerCpuIntercept(t, DefaultBuiltinCosts); got != before {
+		t.Errorf(
+			"building a cost model mutated DefaultBuiltinCosts: intercept %d -> %d",
+			before,
+			got,
+		)
+	}
+}
+
+// TestNewEvalContextIsRaceFree drives the exported entry point Dingo calls per
+// script evaluation. Without independent cost models this reports a data race
+// under -race and returns differing costs without it.
+func TestNewEvalContextIsRaceFree(t *testing.T) {
+	params := make([]int64, len(lang.GetParamNamesForVersion(lang.LanguageVersionV3)))
+	for i := range params {
+		params[i] = int64(i + 1)
+	}
+	var wg sync.WaitGroup
+	intercepts := make([]int64, 16)
+	for i := range intercepts {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			ctx, err := NewEvalContext(
+				lang.LanguageVersionV3,
+				ProtoVersion{Major: 10},
+				params,
+			)
+			if err != nil {
+				t.Errorf("NewEvalContext: %v", err)
+				return
+			}
+			costingFunc := ctx.CostModel.builtinCosts[builtin.AddInteger]
+			if model, ok := costingFunc.cpu.(*MaxSizeModel); ok {
+				intercepts[idx] = model.intercept
+			}
+		}(i)
+	}
+	wg.Wait()
+	for i, got := range intercepts {
+		if got != intercepts[0] {
+			t.Errorf(
+				"concurrent NewEvalContext produced differing costs: [0]=%d [%d]=%d",
+				intercepts[0],
+				i,
+				got,
+			)
+		}
+	}
+}

--- a/cek/cost_model_clone_test.go
+++ b/cek/cost_model_clone_test.go
@@ -15,11 +15,13 @@
 package cek
 
 import (
+	"math/big"
 	"sync"
 	"testing"
 
 	"github.com/blinklabs-io/plutigo/builtin"
 	"github.com/blinklabs-io/plutigo/lang"
+	"github.com/blinklabs-io/plutigo/syn"
 )
 
 // addIntegerCpuIntercept reads the one cost value the tests below drive, so a
@@ -188,6 +190,7 @@ func TestNewEvalContextIsRaceFree(t *testing.T) {
 		params[i] = int64(i + 1)
 	}
 	var wg sync.WaitGroup
+	results := make([]string, 16)
 	budgets := make([]ExBudget, 16)
 	for i := range budgets {
 		wg.Add(1)
@@ -202,36 +205,37 @@ func TestNewEvalContextIsRaceFree(t *testing.T) {
 				t.Errorf("NewEvalContext: %v", err)
 				return
 			}
-			costingFunc := ctx.CostModel.builtinCosts[builtin.AddInteger]
-			if costingFunc == nil {
-				t.Errorf("AddInteger has no costing function")
-				return
-			}
-			mem, ok := costingFunc.mem.(TwoArgument)
-			if !ok {
-				t.Errorf("AddInteger memory model is %T, want TwoArgument", costingFunc.mem)
-				return
-			}
-			cpu, ok := costingFunc.cpu.(TwoArgument)
-			if !ok {
-				t.Errorf("AddInteger cpu model is %T, want TwoArgument", costingFunc.cpu)
-				return
-			}
-			budgets[idx] = CostPair(
-				CostingFunc[TwoArgument]{mem: mem, cpu: cpu},
-				func() ExMem { return 3 },
-				func() ExMem { return 5 },
+			machine := NewMachine[syn.DeBruijn](
+				lang.LanguageVersionV3,
+				0,
+				ctx,
 			)
+			builtinValue := (&Builtin[syn.DeBruijn]{
+				Func: builtin.AddInteger,
+			}).ApplyArg(&Constant{
+				Constant: &syn.Integer{Inner: big.NewInt(17)},
+			}).ApplyArg(&Constant{
+				Constant: &syn.Integer{Inner: big.NewInt(25)},
+			})
+			result, err := machine.evalBuiltinApp(builtinValue)
+			if err != nil {
+				t.Errorf("evaluate AddInteger: %v", err)
+				return
+			}
+			results[idx] = result.String()
+			budgets[idx] = machine.ExBudget
 		}(i)
 	}
 	wg.Wait()
-	for i, got := range budgets {
-		if got != budgets[0] {
+	for i := range budgets {
+		if results[i] != results[0] || budgets[i] != budgets[0] {
 			t.Errorf(
-				"concurrent AddInteger evaluation produced differing budgets: [0]=%+v [%d]=%+v",
+				"concurrent AddInteger evaluation produced differing results or budgets: [0]=%s/%+v [%d]=%s/%+v",
+				results[0],
 				budgets[0],
 				i,
-				got,
+				results[i],
+				budgets[i],
 			)
 		}
 	}

--- a/cek/cost_model_clone_test.go
+++ b/cek/cost_model_clone_test.go
@@ -72,6 +72,59 @@ func TestBuiltinCostsCloneDoesNotAliasSource(t *testing.T) {
 	}
 }
 
+// TestBuiltinCostsCloneDoesNotAliasNestedTwoArgumentModel covers the model
+// stored inside ConstantOrTwoArguments. A shallow copy of that nested model
+// would still let an update to the clone change the source.
+func TestBuiltinCostsCloneDoesNotAliasNestedTwoArgumentModel(t *testing.T) {
+	source, err := buildBuiltinCosts(lang.LanguageVersionV1, SemanticsVariantA)
+	if err != nil {
+		t.Fatalf("build source costs: %v", err)
+	}
+	cloned := source.Clone()
+
+	sourceModel, ok := source[builtin.DivideInteger].cpu.(*ConstAboveDiagonalModel)
+	if !ok {
+		t.Fatalf(
+			"divideInteger source cpu model is %T, want *ConstAboveDiagonalModel",
+			source[builtin.DivideInteger].cpu,
+		)
+	}
+	clonedModel, ok := cloned[builtin.DivideInteger].cpu.(*ConstAboveDiagonalModel)
+	if !ok {
+		t.Fatalf(
+			"divideInteger cloned cpu model is %T, want *ConstAboveDiagonalModel",
+			cloned[builtin.DivideInteger].cpu,
+		)
+	}
+	sourceNested, ok := sourceModel.model.(*MultipliedSizesModel)
+	if !ok {
+		t.Fatalf(
+			"divideInteger source nested model is %T, want *MultipliedSizesModel",
+			sourceModel.model,
+		)
+	}
+	clonedNested, ok := clonedModel.model.(*MultipliedSizesModel)
+	if !ok {
+		t.Fatalf(
+			"divideInteger cloned nested model is %T, want *MultipliedSizesModel",
+			clonedModel.model,
+		)
+	}
+	if sourceNested == clonedNested {
+		t.Fatal("clone shares the nested two-argument model with its source")
+	}
+
+	before := sourceNested.intercept
+	clonedNested.intercept++
+	if sourceNested.intercept != before {
+		t.Fatalf(
+			"updating the cloned nested model changed its source: intercept %d -> %d",
+			before,
+			sourceNested.intercept,
+		)
+	}
+}
+
 // TestBuildBuiltinCostsAreIndependent covers the production entry point rather
 // than Clone directly: two cost models built from the same defaults must not
 // see each other's protocol parameters.
@@ -127,16 +180,16 @@ func TestDefaultBuiltinCostsSurviveCostModelConstruction(t *testing.T) {
 }
 
 // TestNewEvalContextIsRaceFree drives the exported entry point Dingo calls per
-// script evaluation. Without independent cost models this reports a data race
-// under -race and returns differing costs without it.
+// script evaluation. Each worker evaluates the same builtin operation so the
+// test covers concurrent cost-model use rather than only reading a model field.
 func TestNewEvalContextIsRaceFree(t *testing.T) {
 	params := make([]int64, len(lang.GetParamNamesForVersion(lang.LanguageVersionV3)))
 	for i := range params {
 		params[i] = int64(i + 1)
 	}
 	var wg sync.WaitGroup
-	intercepts := make([]int64, 16)
-	for i := range intercepts {
+	budgets := make([]ExBudget, 16)
+	for i := range budgets {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
@@ -150,17 +203,33 @@ func TestNewEvalContextIsRaceFree(t *testing.T) {
 				return
 			}
 			costingFunc := ctx.CostModel.builtinCosts[builtin.AddInteger]
-			if model, ok := costingFunc.cpu.(*MaxSizeModel); ok {
-				intercepts[idx] = model.intercept
+			if costingFunc == nil {
+				t.Errorf("AddInteger has no costing function")
+				return
 			}
+			mem, ok := costingFunc.mem.(TwoArgument)
+			if !ok {
+				t.Errorf("AddInteger memory model is %T, want TwoArgument", costingFunc.mem)
+				return
+			}
+			cpu, ok := costingFunc.cpu.(TwoArgument)
+			if !ok {
+				t.Errorf("AddInteger cpu model is %T, want TwoArgument", costingFunc.cpu)
+				return
+			}
+			budgets[idx] = CostPair(
+				CostingFunc[TwoArgument]{mem: mem, cpu: cpu},
+				func() ExMem { return 3 },
+				func() ExMem { return 5 },
+			)
 		}(i)
 	}
 	wg.Wait()
-	for i, got := range intercepts {
-		if got != intercepts[0] {
+	for i, got := range budgets {
+		if got != budgets[0] {
 			t.Errorf(
-				"concurrent NewEvalContext produced differing costs: [0]=%d [%d]=%d",
-				intercepts[0],
+				"concurrent AddInteger evaluation produced differing budgets: [0]=%+v [%d]=%+v",
+				budgets[0],
 				i,
 				got,
 			)

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/cloudflare/circl v1.6.5
 	github.com/consensys/gnark-crypto v0.21.0
 	github.com/fxamacker/cbor/v2 v2.9.3
-	github.com/jinzhu/copier v0.4.0
 	github.com/minio/sha256-simd v1.0.1
 	golang.org/x/crypto v0.55.0
 )

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,6 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 h1:NMZiJj8QnKe1LgsbDayM4UoHwbvw
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0/go.mod h1:ZXNYxsqcloTdSy/rNShjYzMhyjf0LaoftYK0p+A3h40=
 github.com/fxamacker/cbor/v2 v2.9.3 h1:oQBnFATpNdY8gJHTndDDv5Xl4QqNaz51G5LLEPhng3Q=
 github.com/fxamacker/cbor/v2 v2.9.3/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/jinzhu/copier v0.4.0 h1:w3ciUoD19shMCRargcpm0cm91ytaBhDvuRpz1ODO/U8=
-github.com/jinzhu/copier v0.4.0/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
 github.com/klauspost/cpuid/v2 v2.2.3 h1:sxCkb+qR91z4vsqw4vGGZlDgPz3G7gjaLyK3V8y70BU=
 github.com/klauspost/cpuid/v2 v2.2.3/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
 github.com/leanovate/gopter v0.2.11 h1:vRjThO1EKPb/1NsDXuDrzldR28RLkBflWYcU9CvzWu4=


### PR DESCRIPTION
Fixes #395

## Defect

`BuiltinCosts` is `[builtin.TotalBuiltinCount]*CostingFunc[Arguments]` (`cek/cost_model_builtins.go:14`) — an array of pointers whose `cpu`/`mem` fields are `Arguments` interface values, always holding pointers. `Clone` delegated to `copier.CopyWithOption(&ret, b, copier.Option{DeepCopy: true})`, which copies the array elements without following them, so a clone shared every `*CostingFunc` and every model struct with its source.

`update` (`cek/cost_model_builtins.go:24`) mutates through those pointers (`a.intercept = val` on `*AddedSizesModel`, `a.c = val` on `*ConstantCost`, and so on for each model type).

`buildBuiltinCosts` starts from `DefaultBuiltinCosts.Clone()` and `costModelFromList` (`cek/cost_model.go:32`) calls `update` for every protocol-parameter entry. Building any cost model therefore wrote into the package-level `DefaultBuiltinCosts`, and concurrent `NewEvalContext` calls (`cek/eval_context.go:37`) wrote to the same structs.

Two consequences:

- **Sequential.** A cost model built for one language version leaves its parameter values in the defaults, so a later evaluation for a different version starts from them.
- **Concurrent.** `BuiltinCosts.update` races with itself under `costModelFromList` / `NewEvalContext`, producing evaluation costs that differ from a sequential control for the same script and parameters.

Costing is consensus-relevant, so this changes accept/reject for transactions whose declared ExUnits sit between the corrupted and correct values.

## Change

`Clone` now allocates a new `CostingFunc` and a new model for every entry. `Arguments` gains an unexported `cloneArguments() Arguments`; each of the 29 implementations returns a pointer to a fresh copy. The interface already had unexported methods, so it has no implementers outside this package and the addition is not a breaking change.

Every implementation is plain `int64` fields or embeds a struct of them, with one exception: `ConstantOrTwoArguments` carries a nested `TwoArgument`. `AboveAndBelowDiagonalModel`, `ConstAboveDiagonalModel` and `ConstBelowDiagonalModel` clone that nested model as well.

`machineCosts` needs no change — `MachineCosts` is `ExBudget` value fields, so `CostModel.Clone`'s struct copy already owns it.

`copier` is no longer used and is dropped from `go.mod`.

## Tests

`cek/cost_model_clone_test.go`:

- `TestBuiltinCostsCloneDoesNotAliasSource` — a clone shares neither the `*CostingFunc` nor the model pointer, and `update` on the clone leaves the source's value unchanged.
- `TestBuildBuiltinCostsAreIndependent` — two `buildBuiltinCosts` results for the same version and semantics do not observe each other's `update`.
- `TestDefaultBuiltinCostsSurviveCostModelConstruction` — `costModelFromList` over a full V3 parameter list leaves `DefaultBuiltinCosts` unchanged.
- `TestNewEvalContextIsRaceFree` — 16 concurrent `NewEvalContext` calls with identical parameters yield identical costs, and the package is race-clean.

Without the change the first three fail on the cost value, and the fourth reports a data race in `BuiltinCosts.update` under `costModelFromList` / `NewEvalContext`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cost model cloning so each cost model owns its builtin costs instead of sharing them with the source, preventing protocol parameters from leaking between evaluations and eliminating data races under concurrent use, resolving #395.

- `BuiltinCosts.Clone` now deep-copies each `CostingFunc` and its models via `cloneArguments`, including nested two-argument models, and leaves nil entries nil rather than inventing zero-valued ones.
- Removes the `copier` dependency.
- Adds tests for alias-free cloning, independent cost model builds, unchanged `DefaultBuiltinCosts`, and race-free concurrent evaluation.

<sup>Written for commit f83c11d4b4f8a5ebd3e8b00090408ccf604ff691. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/plutigo/pull/396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Cost model instances are now isolated, preventing changes in one evaluation context from affecting others.
  - Building custom cost models no longer alters the default cost configuration.
  - Concurrent evaluation-context creation now produces consistent results without race-related issues.

- **Reliability**
  - Cost model cloning now safely handles empty or nested configurations, reducing unexpected failures during setup and evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->