### PR TITLE
feat(data): add Normalize to reset script-visible PlutusData encoding

### DIFF
--- a/data/normalize.go
+++ b/data/normalize.go
@@ -1,0 +1,47 @@
+package data
+
+// Normalize returns a deep copy of pd with every Constr, Map, and List node's
+// definite/indefinite-length CBOR array encoding reset to the package default
+// (see MarshalCBOR on each type: indefinite for non-empty, definite for
+// empty), discarding whatever encoding style the value originally carried
+// from Decode.
+//
+// Decode preserves the original wire's definite/indefinite-length choice on
+// each node so that re-encoding a decoded value reproduces the original
+// bytes. That fidelity is correct when verifying something against its own
+// original bytes (e.g. a script-data hash), but cardano-ledger's reference
+// implementation does not carry that fidelity through when it builds values
+// for a Plutus script to observe (redeemer data, datums): it always
+// constructs them fresh, which is equivalent to always using the package
+// default encoding. A value decoded from on-chain bytes and then handed to a
+// script unchanged can therefore serialise to different bytes than the
+// reference implementation's for the same semantic value whenever the
+// original encoder chose definite-length arrays, and a script that hashes or
+// compares serialised bytes (via SerialiseData) sees that difference.
+// Callers building script-visible values from decoded data (redeemer data,
+// inline or witness datums) should call Normalize first.
+func Normalize(pd PlutusData) PlutusData {
+	switch v := pd.(type) {
+	case *Constr:
+		fields := make([]PlutusData, len(v.Fields))
+		for i, f := range v.Fields {
+			fields[i] = Normalize(f)
+		}
+		return &Constr{Tag: v.Tag, Fields: fields}
+	case *Map:
+		pairs := make([][2]PlutusData, len(v.Pairs))
+		for i, p := range v.Pairs {
+			pairs[i] = [2]PlutusData{Normalize(p[0]), Normalize(p[1])}
+		}
+		return &Map{Pairs: pairs}
+	case *List:
+		items := make([]PlutusData, len(v.Items))
+		for i, item := range v.Items {
+			items[i] = Normalize(item)
+		}
+		return &List{Items: items}
+	default:
+		// Integer and ByteString carry no encoding-style state.
+		return pd
+	}
+}

--- a/data/normalize.go
+++ b/data/normalize.go
@@ -31,7 +31,9 @@ import "math/big"
 // Every container node is rebuilt, so resetting the encoding never writes
 // through to the input. Integer and ByteString leaves are returned as-is:
 // they hold no encoding state, and this package treats their contents as
-// read-only.
+// read-only. Container nodes held in their value form rather than as a
+// pointer are normalized too, and come back as pointers, the same
+// conversion Clone makes.
 func Normalize(pd PlutusData) PlutusData {
 	switch v := pd.(type) {
 	case *Constr:
@@ -59,6 +61,22 @@ func Normalize(pd PlutusData) PlutusData {
 			items[i] = Normalize(item)
 		}
 		return &List{Items: items}
+	// The value forms satisfy PlutusData as well: isPlutusData, Clone, Equal
+	// and String all take value receivers. Nothing in this package produces
+	// one -- Decode and Clone both yield pointers, and Equal only ever
+	// asserts to the pointer forms -- but a caller can construct one, and
+	// falling through to the default case would hand it back with its
+	// original encoding intact and no error. A silently unnormalized node is
+	// the one result this function must never return, so delegate to the
+	// pointer branches above. v is already a copy, so taking its address
+	// aliases nothing the caller holds, and that branch deep-copies from
+	// there. Like Clone, this converts a value form to a pointer form.
+	case Constr:
+		return Normalize(&v)
+	case Map:
+		return Normalize(&v)
+	case List:
+		return Normalize(&v)
 	default:
 		// Integer and ByteString carry no encoding-style state.
 		return pd

--- a/data/normalize.go
+++ b/data/normalize.go
@@ -1,5 +1,7 @@
 package data
 
+import "math/big"
+
 // Normalize returns a deep copy of pd with every Constr, Map, and List node's
 // definite/indefinite-length CBOR array encoding reset to the package default
 // (see MarshalCBOR on each type: indefinite for non-empty, definite for
@@ -20,6 +22,11 @@ package data
 // compares serialised bytes (via SerialiseData) sees that difference.
 // Callers building script-visible values from decoded data (redeemer data,
 // inline or witness datums) should call Normalize first.
+//
+// Every container node is rebuilt, so resetting the encoding never writes
+// through to the input. Integer and ByteString leaves are returned as-is:
+// they hold no encoding state, and this package treats their contents as
+// read-only.
 func Normalize(pd PlutusData) PlutusData {
 	switch v := pd.(type) {
 	case *Constr:
@@ -27,7 +34,14 @@ func Normalize(pd PlutusData) PlutusData {
 		for i, f := range v.Fields {
 			fields[i] = Normalize(f)
 		}
-		return &Constr{Tag: v.Tag, Fields: fields}
+		// Copy the tag rather than aliasing it: big.Int is mutable, so
+		// sharing the pointer would let a write through one value reach
+		// the other. A nil tag stays nil; MarshalCBOR treats it as zero.
+		tag := v.Tag
+		if tag != nil {
+			tag = new(big.Int).Set(tag)
+		}
+		return &Constr{Tag: tag, Fields: fields}
 	case *Map:
 		pairs := make([][2]PlutusData, len(v.Pairs))
 		for i, p := range v.Pairs {

--- a/data/normalize.go
+++ b/data/normalize.go
@@ -3,10 +3,15 @@ package data
 import "math/big"
 
 // Normalize returns a deep copy of pd with every Constr, Map, and List node's
-// definite/indefinite-length CBOR array encoding reset to the package default
-// (see MarshalCBOR on each type: indefinite for non-empty, definite for
-// empty), discarding whatever encoding style the value originally carried
-// from Decode.
+// definite/indefinite-length CBOR encoding reset to the package default,
+// discarding whatever encoding style the value originally carried from
+// Decode.
+//
+// The default is per type, and Map is not like the other two: Constr and
+// List encode indefinite when non-empty and definite when empty, while Map
+// always encodes definite, matching Haskell's canonical CBOR. See MarshalCBOR
+// on each type. So normalizing a map decoded from indefinite-length bytes
+// moves it to definite, the opposite direction from the others.
 //
 // Decode preserves the original wire's definite/indefinite-length choice on
 // each node so that re-encoding a decoded value reproduces the original

--- a/data/normalize_corpus_test.go
+++ b/data/normalize_corpus_test.go
@@ -1,0 +1,112 @@
+package data
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// corpusPath is the real mainnet script-argument capture that the replay
+// tests run against. It is read directly rather than through the replay
+// package because replay imports this one, so importing it back would be a
+// cycle.
+const corpusPath = "../replay/testdata/mainnet.json"
+
+type corpusFile struct {
+	Network   string `json:"network"`
+	Reference struct {
+		Implementation string `json:"implementation"`
+		Version        string `json:"version"`
+	} `json:"reference"`
+	Cases []struct {
+		ID           string   `json:"id"`
+		Language     string   `json:"language"`
+		ArgumentsHex []string `json:"arguments_cbor_hex"`
+	} `json:"cases"`
+}
+
+// TestNormalizeIsIdentityOnReferenceEncodedArguments is the empirical proof
+// that this package's default encoding is the one cardano-ledger produces,
+// which is the entire premise Normalize rests on.
+//
+// The arguments in replay/testdata/mainnet.json were captured from
+// cardano-node (via Ogmios) for real mainnet script evaluations. That
+// matters because Haskell's Data type carries no definite/indefinite
+// fidelity of its own -- it is a plain algebraic data type -- so anything
+// the node emits for a Data value is necessarily its canonical encoding,
+// not a replay of some original wire bytes. These bytes are therefore a
+// reference-implementation oracle for the canonical form.
+//
+// Normalize resets every container to this package's default. So on input
+// that is already canonical, Normalize must be a byte-exact no-op. If any
+// default were wrong in either direction -- a non-empty Constr or List
+// defaulting to definite, an empty one defaulting to indefinite, or a Map
+// defaulting to indefinite -- re-encoding would differ from the captured
+// bytes and this test would fail.
+//
+// This is the test that would have caught a Normalize that "worked" while
+// normalizing toward the wrong encoding, which no round-trip test against
+// hand-written fixtures can rule out.
+func TestNormalizeIsIdentityOnReferenceEncodedArguments(t *testing.T) {
+	buf, err := os.ReadFile(filepath.Clean(corpusPath))
+	if err != nil {
+		t.Fatalf("read corpus %s: %v", corpusPath, err)
+	}
+	var corpus corpusFile
+	if err := json.Unmarshal(buf, &corpus); err != nil {
+		t.Fatalf("parse corpus: %v", err)
+	}
+	if len(corpus.Cases) == 0 {
+		t.Fatal("corpus has no cases; the oracle would be vacuous")
+	}
+	t.Logf(
+		"oracle: %s capture from %s (%s), %d cases",
+		corpus.Network,
+		corpus.Reference.Implementation,
+		corpus.Reference.Version,
+		len(corpus.Cases),
+	)
+
+	checked := 0
+	for _, tc := range corpus.Cases {
+		for i, argHex := range tc.ArgumentsHex {
+			raw, err := hex.DecodeString(argHex)
+			if err != nil {
+				t.Fatalf("%s arg %d: bad hex: %v", tc.ID, i, err)
+			}
+			pd, err := Decode(raw)
+			if err != nil {
+				// Not every script argument is required to be
+				// PlutusData this package can decode; skip rather
+				// than fail, but keep counting what was checked so a
+				// corpus that stopped decoding entirely cannot make
+				// this test silently vacuous.
+				continue
+			}
+			got, err := Encode(Normalize(pd))
+			if err != nil {
+				t.Fatalf("%s arg %d: encode normalized: %v", tc.ID, i, err)
+			}
+			if hex.EncodeToString(got) != argHex {
+				t.Errorf(
+					"%s arg %d (%s): Normalize changed reference-canonical bytes\n"+
+						" reference: %s\n normalized: %s",
+					tc.ID, i, tc.Language,
+					argHex, hex.EncodeToString(got),
+				)
+				continue
+			}
+			checked++
+		}
+	}
+
+	if checked == 0 {
+		t.Fatal(
+			"no corpus argument decoded as PlutusData;" +
+				" the oracle proved nothing",
+		)
+	}
+	t.Logf("Normalize is byte-identity on %d reference-encoded arguments", checked)
+}

--- a/data/normalize_corpus_test.go
+++ b/data/normalize_corpus_test.go
@@ -3,8 +3,10 @@ package data
 import (
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -139,8 +141,13 @@ func TestNormalizeIsIdentityOnReferenceEncodedArguments(t *testing.T) {
 // evaluator boundary.
 //
 // The ScriptContext is the last argument in every case: [datum, redeemer,
-// context] for a spend, [redeemer, context] for mint and reward, and
-// [context] alone for PlutusV3.
+// context] for a PlutusV1/V2 spend, [redeemer, context] for other V1/V2
+// purposes, and [context] alone for PlutusV3. That position is verified
+// per case rather than assumed. A case with an unexpected argument count
+// would otherwise slide the check onto a submitter-supplied datum or
+// redeemer -- values a submitter is free to encode canonically -- and the
+// test would report having verified node-constructed contexts while
+// actually proving the strong claim on the wrong data.
 func TestNormalizeIsIdentityOnNodeConstructedScriptContexts(t *testing.T) {
 	buf, err := os.ReadFile(filepath.Clean(corpusPath))
 	if err != nil {
@@ -151,10 +158,25 @@ func TestNormalizeIsIdentityOnNodeConstructedScriptContexts(t *testing.T) {
 		t.Fatalf("parse corpus: %v", err)
 	}
 
-	checked := 0
+	// decoded counts contexts that reached the comparison, identity counts
+	// the ones that matched. Kept separate so the vacuity guard can tell
+	// "nothing decoded" apart from "everything failed the check" -- the
+	// latter being precisely the failure this test exists to report.
+	decoded := 0
+	identity := 0
 	for _, tc := range corpus.Cases {
-		if len(tc.ArgumentsHex) == 0 {
-			t.Errorf("%s: case has no arguments", tc.ID)
+		wantArgs, err := scriptContextArgCount(tc.ID, tc.Language)
+		if err != nil {
+			t.Errorf("%s: %v", tc.ID, err)
+			continue
+		}
+		if len(tc.ArgumentsHex) != wantArgs {
+			t.Errorf(
+				"%s (%s): expected %d arguments, got %d;"+
+					" the last argument may not be the ScriptContext,"+
+					" so this case is not safe to check",
+				tc.ID, tc.Language, wantArgs, len(tc.ArgumentsHex),
+			)
 			continue
 		}
 		ctxHex := tc.ArgumentsHex[len(tc.ArgumentsHex)-1]
@@ -167,6 +189,18 @@ func TestNormalizeIsIdentityOnNodeConstructedScriptContexts(t *testing.T) {
 			t.Errorf("%s: ScriptContext did not decode: %v", tc.ID, err)
 			continue
 		}
+		// Every ScriptContext is a Constr in all Plutus versions. A bare
+		// leaf here would mean the position check above let something
+		// through that is not a context at all.
+		if _, ok := pd.(*Constr); !ok {
+			t.Errorf(
+				"%s (%s): last argument decoded as %T, not a Constr;"+
+					" it is not a ScriptContext",
+				tc.ID, tc.Language, pd,
+			)
+			continue
+		}
+		decoded++
 		got, err := Encode(Normalize(pd))
 		if err != nil {
 			t.Fatalf("%s: encode normalized context: %v", tc.ID, err)
@@ -179,11 +213,44 @@ func TestNormalizeIsIdentityOnNodeConstructedScriptContexts(t *testing.T) {
 			)
 			continue
 		}
-		checked++
+		identity++
 	}
 
-	if checked == 0 {
-		t.Fatal("no ScriptContext was verified; the check proved nothing")
+	if decoded == 0 {
+		t.Fatal("no ScriptContext decoded; the check proved nothing")
 	}
-	t.Logf("Normalize is byte-identity on %d node-constructed ScriptContexts", checked)
+	t.Logf(
+		"Normalize is byte-identity on %d of %d node-constructed ScriptContexts",
+		identity, decoded,
+	)
+}
+
+// scriptContextArgCount returns how many arguments a case must have for
+// its last one to be the ScriptContext. PlutusV3 unified the arguments
+// into a single ScriptContext value; before that a spend script also
+// received its datum, and every other purpose received only the redeemer
+// alongside the context.
+//
+// The purpose is the part of the corpus case ID between "#" and ":", as
+// in "<txid>#spend:1".
+func scriptContextArgCount(id, language string) (int, error) {
+	if language == "PlutusV3" {
+		return 1, nil
+	}
+	_, rest, ok := strings.Cut(id, "#")
+	if !ok {
+		return 0, fmt.Errorf("case ID %q has no purpose suffix", id)
+	}
+	purpose, _, ok := strings.Cut(rest, ":")
+	if !ok {
+		return 0, fmt.Errorf("case ID %q has no purpose index", id)
+	}
+	switch purpose {
+	case "spend":
+		return 3, nil
+	case "mint", "reward", "cert", "vote", "propose":
+		return 2, nil
+	default:
+		return 0, fmt.Errorf("unrecognized script purpose %q", purpose)
+	}
 }

--- a/data/normalize_corpus_test.go
+++ b/data/normalize_corpus_test.go
@@ -27,28 +27,27 @@ type corpusFile struct {
 	} `json:"cases"`
 }
 
-// TestNormalizeIsIdentityOnReferenceEncodedArguments is the empirical proof
-// that this package's default encoding is the one cardano-ledger produces,
-// which is the entire premise Normalize rests on.
+// TestNormalizeIsIdentityOnReferenceEncodedArguments checks this package's
+// default encoding against every script argument cardano-node passed to a
+// real mainnet evaluation, as captured in replay/testdata/mainnet.json.
 //
-// The arguments in replay/testdata/mainnet.json were captured from
-// cardano-node (via Ogmios) for real mainnet script evaluations. That
-// matters because Haskell's Data type carries no definite/indefinite
-// fidelity of its own -- it is a plain algebraic data type -- so anything
-// the node emits for a Data value is necessarily its canonical encoding,
-// not a replay of some original wire bytes. These bytes are therefore a
-// reference-implementation oracle for the canonical form.
+// Normalize resets every container to the package default, so on input
+// already in that form it must be a byte-exact no-op. If a default were
+// wrong in either direction -- a non-empty Constr or List defaulting to
+// definite, an empty one defaulting to indefinite, or a Map defaulting to
+// indefinite -- re-encoding would differ from the captured bytes and this
+// test would fail. No round-trip test against hand-written fixtures can
+// rule that out, because such a test only shows Normalize is
+// self-consistent, not that it normalizes toward the right encoding.
 //
-// Normalize resets every container to this package's default. So on input
-// that is already canonical, Normalize must be a byte-exact no-op. If any
-// default were wrong in either direction -- a non-empty Constr or List
-// defaulting to definite, an empty one defaulting to indefinite, or a Map
-// defaulting to indefinite -- re-encoding would differ from the captured
-// bytes and this test would fail.
-//
-// This is the test that would have caught a Normalize that "worked" while
-// normalizing toward the wrong encoding, which no round-trip test against
-// hand-written fixtures can rule out.
+// Be careful about what this proves on its own. Redeemers and datums
+// reach the node as submitter-supplied bytes, so finding them already in
+// canonical form is also consistent with the node having passed those
+// bytes through untouched -- a submitter is free to encode canonically.
+// This test therefore pins agreement with the reference for these values;
+// it is not by itself evidence that the node re-encodes what it receives.
+// TestNormalizeIsIdentityOnNodeConstructedScriptContexts below carries
+// that stronger claim, on the arguments that can actually support it.
 func TestNormalizeIsIdentityOnReferenceEncodedArguments(t *testing.T) {
 	buf, err := os.ReadFile(filepath.Clean(corpusPath))
 	if err != nil {
@@ -120,4 +119,71 @@ func TestNormalizeIsIdentityOnReferenceEncodedArguments(t *testing.T) {
 		"Normalize is byte-identity on %d of %d reference-encoded arguments",
 		identity, decoded,
 	)
+}
+
+// TestNormalizeIsIdentityOnNodeConstructedScriptContexts pins the stronger
+// half of the claim above, on the only corpus arguments that can support
+// it.
+//
+// Redeemers and datums start life as submitter-supplied bytes, so finding
+// them already in canonical form proves nothing about what the node does
+// -- the submitter may simply have encoded them that way. The
+// ScriptContext is different in kind: the node builds it from ledger
+// state, so no submitter bytes influence it and there is no original
+// encoding to preserve. Its encoding is therefore purely the reference
+// implementation's canonical Data encoder.
+//
+// Normalize being a byte-identity on those contexts is a direct check
+// that this package's defaults are that canonical encoder, which is the
+// premise Normalize depends on and the reason it is safe to apply at the
+// evaluator boundary.
+//
+// The ScriptContext is the last argument in every case: [datum, redeemer,
+// context] for a spend, [redeemer, context] for mint and reward, and
+// [context] alone for PlutusV3.
+func TestNormalizeIsIdentityOnNodeConstructedScriptContexts(t *testing.T) {
+	buf, err := os.ReadFile(filepath.Clean(corpusPath))
+	if err != nil {
+		t.Fatalf("read corpus %s: %v", corpusPath, err)
+	}
+	var corpus corpusFile
+	if err := json.Unmarshal(buf, &corpus); err != nil {
+		t.Fatalf("parse corpus: %v", err)
+	}
+
+	checked := 0
+	for _, tc := range corpus.Cases {
+		if len(tc.ArgumentsHex) == 0 {
+			t.Errorf("%s: case has no arguments", tc.ID)
+			continue
+		}
+		ctxHex := tc.ArgumentsHex[len(tc.ArgumentsHex)-1]
+		raw, err := hex.DecodeString(ctxHex)
+		if err != nil {
+			t.Fatalf("%s: bad context hex: %v", tc.ID, err)
+		}
+		pd, err := Decode(raw)
+		if err != nil {
+			t.Errorf("%s: ScriptContext did not decode: %v", tc.ID, err)
+			continue
+		}
+		got, err := Encode(Normalize(pd))
+		if err != nil {
+			t.Fatalf("%s: encode normalized context: %v", tc.ID, err)
+		}
+		if hex.EncodeToString(got) != ctxHex {
+			t.Errorf(
+				"%s (%s): Normalize altered a node-constructed ScriptContext;"+
+					" this package's defaults are not the reference encoder",
+				tc.ID, tc.Language,
+			)
+			continue
+		}
+		checked++
+	}
+
+	if checked == 0 {
+		t.Fatal("no ScriptContext was verified; the check proved nothing")
+	}
+	t.Logf("Normalize is byte-identity on %d node-constructed ScriptContexts", checked)
 }

--- a/data/normalize_corpus_test.go
+++ b/data/normalize_corpus_test.go
@@ -69,7 +69,15 @@ func TestNormalizeIsIdentityOnReferenceEncodedArguments(t *testing.T) {
 		len(corpus.Cases),
 	)
 
-	checked := 0
+	// decoded counts arguments that reached the comparison at all, and is
+	// what proves the oracle is non-vacuous. identity counts the ones that
+	// round-tripped unchanged. They must be tracked separately: if every
+	// argument decoded but every comparison failed, a single counter would
+	// still read zero and the vacuity guard below would report that nothing
+	// decoded -- false, and it would bury the real failure this test exists
+	// to surface.
+	decoded := 0
+	identity := 0
 	for _, tc := range corpus.Cases {
 		for i, argHex := range tc.ArgumentsHex {
 			raw, err := hex.DecodeString(argHex)
@@ -79,12 +87,12 @@ func TestNormalizeIsIdentityOnReferenceEncodedArguments(t *testing.T) {
 			pd, err := Decode(raw)
 			if err != nil {
 				// Not every script argument is required to be
-				// PlutusData this package can decode; skip rather
-				// than fail, but keep counting what was checked so a
-				// corpus that stopped decoding entirely cannot make
-				// this test silently vacuous.
+				// PlutusData this package can decode; skip rather than
+				// fail. The vacuity guard below catches a corpus that
+				// stopped decoding entirely.
 				continue
 			}
+			decoded++
 			got, err := Encode(Normalize(pd))
 			if err != nil {
 				t.Fatalf("%s arg %d: encode normalized: %v", tc.ID, i, err)
@@ -98,15 +106,18 @@ func TestNormalizeIsIdentityOnReferenceEncodedArguments(t *testing.T) {
 				)
 				continue
 			}
-			checked++
+			identity++
 		}
 	}
 
-	if checked == 0 {
+	if decoded == 0 {
 		t.Fatal(
 			"no corpus argument decoded as PlutusData;" +
 				" the oracle proved nothing",
 		)
 	}
-	t.Logf("Normalize is byte-identity on %d reference-encoded arguments", checked)
+	t.Logf(
+		"Normalize is byte-identity on %d of %d reference-encoded arguments",
+		identity, decoded,
+	)
 }

--- a/data/normalize_test.go
+++ b/data/normalize_test.go
@@ -143,6 +143,39 @@ func TestNormalizeDoesNotMutateInput(t *testing.T) {
 	}
 }
 
+// TestNormalizeCopiesConstrTag guards the one mutable field a container
+// node owns. big.Int is mutable, so aliasing the tag would let a write
+// through the normalized value reach the original.
+func TestNormalizeCopiesConstrTag(t *testing.T) {
+	original := &Constr{Tag: big.NewInt(3), Fields: []PlutusData{}}
+
+	normalized, ok := Normalize(original).(*Constr)
+	if !ok {
+		t.Fatalf("Normalize returned %T, want *Constr", Normalize(original))
+	}
+	if normalized.Tag == original.Tag {
+		t.Fatal("normalized Constr aliases the original's Tag pointer")
+	}
+
+	normalized.Tag.SetInt64(9)
+	if original.Tag.Int64() != 3 {
+		t.Errorf("mutating the normalized tag changed the original to %d, want 3", original.Tag.Int64())
+	}
+}
+
+// TestNormalizeNilConstrTagStaysNil pins the nil case: MarshalCBOR treats a
+// nil tag as zero, so Normalize must not turn nil into a non-nil zero and
+// must not panic trying to copy it.
+func TestNormalizeNilConstrTagStaysNil(t *testing.T) {
+	normalized, ok := Normalize(&Constr{}).(*Constr)
+	if !ok {
+		t.Fatal("Normalize did not return a *Constr")
+	}
+	if normalized.Tag != nil {
+		t.Errorf("nil Tag became %v, want nil", normalized.Tag)
+	}
+}
+
 // TestNormalizeLeafPassthrough documents that Integer and ByteString carry
 // no encoding-style state, so Normalize returns them untouched.
 func TestNormalizeLeafPassthrough(t *testing.T) {

--- a/data/normalize_test.go
+++ b/data/normalize_test.go
@@ -29,37 +29,42 @@ func mustEncodeHex(t *testing.T, pd PlutusData) string {
 }
 
 // TestNormalizeResetsDefiniteLengthEncoding is the regression test for the
-// mainnet Plutus divergence. Decode preserves the wire's definite-length
-// array choice, so re-encoding a decoded value reproduces the original
-// definite-length bytes. cardano-ledger always rebuilds script-visible
-// values fresh, which is this package's default (indefinite for non-empty),
-// so a script calling serialiseData on pass-through decoded data observed
-// different bytes than the reference implementation and rejected canonical
+// mainnet Plutus divergence. Decode preserves whichever definite/indefinite
+// encoding each node carried on the wire, so re-encoding a decoded value
+// reproduces the original bytes. cardano-ledger always rebuilds
+// script-visible values fresh, i.e. at this package's default, so a script
+// calling serialiseData on pass-through decoded data observed different
+// bytes than the reference implementation and rejected canonical
 // transactions.
 //
-// Each case decodes definite-length input, asserts the round-trip really is
-// byte-identical to that definite input (proving the fidelity that causes
-// the bug, so the test cannot silently pass for the wrong reason), then
-// asserts Normalize re-encodes to the indefinite-length default. Without
-// Normalize the final assertion fails: the value still carries
-// useIndef=false from Decode.
+// Each case decodes wire bytes whose encoding differs from the default,
+// asserts the round-trip really is byte-identical to that input (proving the
+// fidelity that causes the bug, so the test cannot silently pass for the
+// wrong reason), then asserts Normalize re-encodes to the default. Without
+// Normalize the final assertion fails: the value still carries the wire's
+// useIndef from Decode.
+//
+// Note the direction is not the same for every type. Constr and List default
+// to indefinite when non-empty, so their rows go definite -> indefinite; Map
+// always defaults to definite, so its row goes indefinite -> definite. The
+// field is named wire rather than definite for that reason.
 func TestNormalizeResetsDefiniteLengthEncoding(t *testing.T) {
 	tests := []struct {
 		name       string
-		definite   string
+		wire       string
 		wantNormal string
 	}{
 		{
 			// Constr tag 0 (CBOR tag 121 = d879), one field: integer 1.
 			// 81 = definite array(1); 9f..ff = indefinite.
 			name:       "constr one field",
-			definite:   "d8798101",
+			wire:       "d8798101",
 			wantNormal: "d8799f01ff",
 		},
 		{
 			// 82 = definite array(2); 9f..ff = indefinite.
 			name:       "list two items",
-			definite:   "820102",
+			wire:       "820102",
 			wantNormal: "9f0102ff",
 		},
 		{
@@ -69,28 +74,28 @@ func TestNormalizeResetsDefiniteLengthEncoding(t *testing.T) {
 			// reverse: indefinite (bf..ff) on the wire must normalize
 			// back to definite (a1).
 			name:       "map one pair, indefinite on the wire",
-			definite:   "bf0102ff",
+			wire:       "bf0102ff",
 			wantNormal: "a10102",
 		},
 		{
 			// Definite list holding a definite constr: Normalize must
 			// recurse, not just reset the outermost node.
 			name:       "nested list of constr",
-			definite:   "81d8798101",
+			wire:       "81d8798101",
 			wantNormal: "9fd8799f01ffff",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			decoded := mustDecodeHex(t, tc.definite)
+			decoded := mustDecodeHex(t, tc.wire)
 
 			// Guard: if this stops holding, Decode no longer preserves
 			// wire encoding and the rest of this test proves nothing.
-			if got := mustEncodeHex(t, decoded); got != tc.definite {
+			if got := mustEncodeHex(t, decoded); got != tc.wire {
 				t.Fatalf(
 					"precondition failed: decode/encode round-trip = %s, want the original %s",
-					got, tc.definite,
+					got, tc.wire,
 				)
 			}
 

--- a/data/normalize_test.go
+++ b/data/normalize_test.go
@@ -1,0 +1,164 @@
+package data
+
+import (
+	"encoding/hex"
+	"math/big"
+	"testing"
+)
+
+func mustDecodeHex(t *testing.T, s string) PlutusData {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatalf("bad fixture hex %q: %v", s, err)
+	}
+	pd, err := Decode(b)
+	if err != nil {
+		t.Fatalf("Decode(%s): %v", s, err)
+	}
+	return pd
+}
+
+func mustEncodeHex(t *testing.T, pd PlutusData) string {
+	t.Helper()
+	b, err := Encode(pd)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	return hex.EncodeToString(b)
+}
+
+// TestNormalizeResetsDefiniteLengthEncoding is the regression test for the
+// mainnet Plutus divergence. Decode preserves the wire's definite-length
+// array choice, so re-encoding a decoded value reproduces the original
+// definite-length bytes. cardano-ledger always rebuilds script-visible
+// values fresh, which is this package's default (indefinite for non-empty),
+// so a script calling serialiseData on pass-through decoded data observed
+// different bytes than the reference implementation and rejected canonical
+// transactions.
+//
+// Each case decodes definite-length input, asserts the round-trip really is
+// byte-identical to that definite input (proving the fidelity that causes
+// the bug, so the test cannot silently pass for the wrong reason), then
+// asserts Normalize re-encodes to the indefinite-length default. Without
+// Normalize the final assertion fails: the value still carries
+// useIndef=false from Decode.
+func TestNormalizeResetsDefiniteLengthEncoding(t *testing.T) {
+	tests := []struct {
+		name       string
+		definite   string
+		wantNormal string
+	}{
+		{
+			// Constr tag 0 (CBOR tag 121 = d879), one field: integer 1.
+			// 81 = definite array(1); 9f..ff = indefinite.
+			name:       "constr one field",
+			definite:   "d8798101",
+			wantNormal: "d8799f01ff",
+		},
+		{
+			// 82 = definite array(2); 9f..ff = indefinite.
+			name:       "list two items",
+			definite:   "820102",
+			wantNormal: "9f0102ff",
+		},
+		{
+			// Map is the one container whose package default is
+			// DEFINITE ("to match Haskell's canonical CBOR", see
+			// Map.MarshalCBOR), so the meaningful direction here is the
+			// reverse: indefinite (bf..ff) on the wire must normalize
+			// back to definite (a1).
+			name:       "map one pair, indefinite on the wire",
+			definite:   "bf0102ff",
+			wantNormal: "a10102",
+		},
+		{
+			// Definite list holding a definite constr: Normalize must
+			// recurse, not just reset the outermost node.
+			name:       "nested list of constr",
+			definite:   "81d8798101",
+			wantNormal: "9fd8799f01ffff",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			decoded := mustDecodeHex(t, tc.definite)
+
+			// Guard: if this stops holding, Decode no longer preserves
+			// wire encoding and the rest of this test proves nothing.
+			if got := mustEncodeHex(t, decoded); got != tc.definite {
+				t.Fatalf(
+					"precondition failed: decode/encode round-trip = %s, want the original %s",
+					got, tc.definite,
+				)
+			}
+
+			if got := mustEncodeHex(t, Normalize(decoded)); got != tc.wantNormal {
+				t.Errorf("Normalize round-trip = %s, want %s", got, tc.wantNormal)
+			}
+		})
+	}
+}
+
+// TestNormalizeEmptyStaysDefinite pins the other half of the package
+// default: empty containers encode definite-length, so Normalize must not
+// turn them indefinite.
+func TestNormalizeEmptyStaysDefinite(t *testing.T) {
+	tests := []struct {
+		name  string
+		input PlutusData
+		want  string
+	}{
+		{"empty constr", &Constr{Tag: big.NewInt(0)}, "d87980"},
+		{"empty list", &List{}, "80"},
+		{"empty map", &Map{}, "a0"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := mustEncodeHex(t, Normalize(tc.input)); got != tc.want {
+				t.Errorf("Normalize = %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNormalizeDoesNotMutateInput guards the deep copy. The callers added
+// alongside Normalize hand it values that are still referenced elsewhere
+// (witness datums reused across redeemers, for example), so mutating in
+// place would corrupt the script-data hash computed from the original
+// preserved bytes.
+func TestNormalizeDoesNotMutateInput(t *testing.T) {
+	const definite = "81d8798101"
+
+	decoded := mustDecodeHex(t, definite)
+	normalized := Normalize(decoded)
+
+	if got := mustEncodeHex(t, decoded); got != definite {
+		t.Errorf("input mutated by Normalize: re-encodes to %s, want %s", got, definite)
+	}
+	if normalized == decoded {
+		t.Error("Normalize returned the same pointer; it must return a copy")
+	}
+}
+
+// TestNormalizeLeafPassthrough documents that Integer and ByteString carry
+// no encoding-style state, so Normalize returns them untouched.
+func TestNormalizeLeafPassthrough(t *testing.T) {
+	tests := []struct {
+		name  string
+		input PlutusData
+	}{
+		{"integer", &Integer{Inner: big.NewInt(42)}},
+		{"bytestring", &ByteString{Inner: []byte{0xde, 0xad}}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Normalize(tc.input); got != tc.input {
+				t.Errorf("Normalize(%s) returned a copy; leaves should pass through", tc.name)
+			}
+		})
+	}
+}

--- a/data/normalize_test.go
+++ b/data/normalize_test.go
@@ -200,3 +200,114 @@ func TestNormalizeLeafPassthrough(t *testing.T) {
 		})
 	}
 }
+
+// TestNormalizeValueFormContainers covers containers held by value rather
+// than by pointer. The value forms satisfy PlutusData -- isPlutusData,
+// Clone, Equal and String all take value receivers -- so a caller can put
+// one in a PlutusData, even though nothing in this package produces one.
+// Before value forms were handled, Normalize fell through to the default
+// case and returned such a node unchanged: the wire encoding survived,
+// silently, with no error. Each case builds the value form carrying a
+// non-default useIndef and asserts Normalize both resets the encoding and
+// converts to the pointer form, as Clone does.
+func TestNormalizeValueFormContainers(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      PlutusData
+		wantNormal string
+	}{
+		{
+			// Constr defaults to indefinite when non-empty, so a value
+			// form pinned definite must come back indefinite.
+			name: "constr",
+			input: Constr{
+				Tag:      big.NewInt(0),
+				Fields:   []PlutusData{&Integer{Inner: big.NewInt(1)}},
+				useIndef: useIndefPtr(false),
+			},
+			wantNormal: "d8799f01ff",
+		},
+		{
+			// List defaults to indefinite when non-empty.
+			name: "list",
+			input: List{
+				Items: []PlutusData{
+					&Integer{Inner: big.NewInt(1)},
+					&Integer{Inner: big.NewInt(2)},
+				},
+				useIndef: useIndefPtr(false),
+			},
+			wantNormal: "9f0102ff",
+		},
+		{
+			// Map is the exception: it always defaults to definite, so a
+			// value form pinned indefinite must come back definite.
+			name: "map",
+			input: Map{
+				Pairs: [][2]PlutusData{{
+					&Integer{Inner: big.NewInt(1)},
+					&Integer{Inner: big.NewInt(2)},
+				}},
+				useIndef: useIndefPtr(true),
+			},
+			wantNormal: "a10102",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			normalized := Normalize(tc.input)
+			if got := mustEncodeHex(t, normalized); got != tc.wantNormal {
+				t.Errorf(
+					"Normalize(value-form %s) = %s, want %s",
+					tc.name, got, tc.wantNormal,
+				)
+			}
+			switch normalized.(type) {
+			case *Constr, *List, *Map:
+			default:
+				t.Errorf(
+					"Normalize(value-form %s) returned %T, want a pointer form",
+					tc.name, normalized,
+				)
+			}
+		})
+	}
+}
+
+// TestNormalizeValueFormDoesNotAliasInput checks that normalizing a value
+// form does not reach back into the caller's node. Normalize copies the
+// value into a local before taking its address, but the copy still shares
+// the Fields backing array, so the deep copy in the pointer branch is what
+// keeps the input intact.
+func TestNormalizeValueFormDoesNotAliasInput(t *testing.T) {
+	field := &Integer{Inner: big.NewInt(1)}
+	input := Constr{
+		Tag:      big.NewInt(2),
+		Fields:   []PlutusData{field},
+		useIndef: useIndefPtr(false),
+	}
+
+	normalized := Normalize(input)
+
+	if got := mustEncodeHex(t, input); got != "d87b8101" {
+		t.Errorf("input re-encoded as %s after Normalize, want d87b8101", got)
+	}
+	if input.Fields[0] != field {
+		t.Error("Normalize replaced a field in the caller's value")
+	}
+	if input.useIndef == nil || *input.useIndef {
+		t.Error("Normalize cleared useIndef on the caller's value")
+	}
+
+	c, ok := normalized.(*Constr)
+	if !ok {
+		t.Fatalf("Normalize returned %T, want *Constr", normalized)
+	}
+	if c.Tag == input.Tag {
+		t.Error("Normalize aliased the Tag pointer instead of copying it")
+	}
+	if c.Tag.Cmp(input.Tag) != 0 {
+		t.Errorf("Tag = %v, want %v", c.Tag, input.Tag)
+	}
+}


### PR DESCRIPTION
## Problem

`Decode` preserves each `Constr`/`Map`/`List` node's definite/indefinite-length CBOR array choice, so re-encoding a decoded value reproduces the original wire bytes. That fidelity is correct and necessary when verifying a value against its own original bytes — script-data hash verification depends on it.

But `cardano-ledger` does **not** carry that fidelity into the values a Plutus script observes. It rebuilds redeemer data and datums fresh, which is equivalent to always using this package's default encoding. So a value decoded from on-chain bytes and handed to a script unchanged can serialise to different bytes than the reference implementation produces for the *same semantic value* — and any script that hashes or compares serialised bytes via `serialiseData` observes that difference and fails.

This is distinct from the bignum-chunking `serialiseData` divergence fixed in v0.5.1 (#391): it needs no large integers and triggers purely on array encoding style.

## This is a live mainnet failure, and the chain proves the direction

A Blink Labs mainnet block producer has been stuck at slot 196791729 on transaction `deab9ef3ce7415e492dd6f1eb5ff2920b34bccc0dcee8f4bbc76e97736de8a56`.

That transaction is a **one-shot mint**. Its redeemer is a TxOutRef naming one of its own inputs, and its PlutusV3 policy derives the minted asset name as `blake2b_256(serialiseData(txOutRef))` — the script's UPLC contains exactly one `serialiseData` and one `blake2b_256`, composed directly, and I resolved the de Bruijn binder to confirm the hashed value comes from runtime input rather than a compiled-in constant.

So the asset name recorded on chain is the script's own output, and it answers the encoding question directly:

```
d8799f 5820 26f83e51…f878 01 ff   (INDEFINITE) -> eb9ee0fd…  == the minted asset name
d87982 5820 26f83e51…f878 01      (DEFINITE)   -> 127c3faa…  == matches nothing on chain
```

The redeemer arrives **definite** on the wire. The asset name mainnet accepted corresponds to the **indefinite** encoding. Since the script produced that name and consensus accepted it, cardano-node must rebuild script-visible values rather than replay received bytes. `Normalize` is what reproduces that.

The same transaction pins the opposite requirement too: its `script_data_hash` reproduces only from the **preserved wire bytes** (`a742aef0…`; normalizing there instead gives `f2099920…`). So the two paths genuinely have opposite requirements, and `Normalize` belongs at the evaluator boundary and nowhere near hash verification.

## Change

`data.Normalize` returns a deep copy of a `PlutusData` value with every `Constr`, `Map`, and `List` node's encoding state (`useIndef`) reset to the package default, leaving `Integer` and `ByteString` untouched since they carry no encoding-style state. Value-form containers are handled too, delegating to the pointer branches and returning pointers as `Clone` does.

It is deliberately **not** wired into `Decode` — decode-time fidelity is still required for script-data hash verification. Callers building script-visible values from decoded data should call it at that boundary. gouroboros#2262 is the consumer.

## Tests

`data/normalize_test.go` covers the unit behaviour: definite `Constr`/`List` normalizing to the indefinite default including a nested recursion case, indefinite `Map` normalizing back to definite (the meaningful direction is reversed for `Map`, whose default is definite), empty containers staying definite, the deep copy leaving the input unmutated, the `Constr` tag being copied rather than aliased, value-form containers, and `Integer`/`ByteString` passing through.

`data/normalize_corpus_test.go` checks the package defaults against the reference implementation, using the real mainnet capture already in `replay/testdata/mainnet.json`:

- `TestNormalizeIsIdentityOnReferenceEncodedArguments` — `Normalize` must be a byte-exact no-op on every script argument cardano-node passed to a real evaluation.
- `TestNormalizeIsIdentityOnNodeConstructedScriptContexts` — the stronger claim, restricted to ScriptContext arguments. Those are built by the node from ledger state, so no submitter bytes influence them and their encoding is purely the reference canonical encoder. Each case verifies the context's position from its language and purpose rather than assuming it is last.

Both are verified discriminating rather than vacuous: forcing `Constr` to default to definite makes the first report 14 mismatches and the second flag all 8 contexts.

## A retraction, for the record

An earlier comment on this PR argued the direction from a count over *all* corpus arguments (1031/1031 non-empty `Constr` indefinite). That argument does not hold — I checked the three source transactions on chain and every non-empty container was **already indefinite on the wire**, so the count is equally consistent with the node passing bytes through untouched. I withdrew it.

Relatedly, "Haskell's `Data` carries no fidelity" is true of `PlutusCore.Data.Data` but not of `Cardano.Ledger.Plutus.Data.Data era`, a `MemoBytes` that does preserve original CBOR — which is why db-sync reports this transaction's redeemer datum hash in wire form.

The direction now rests on the node-constructed ScriptContexts and the on-chain asset name above, both of which are immune to that objection.

`go vet ./...`, `go test ./...`, and `gofmt -l` are clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `data.Normalize` to reset definite/indefinite-length CBOR array encoding on decoded `PlutusData` values, so scripts observe the same serialized bytes as `cardano-ledger`'s reference implementation. Previously, re-encoding a decoded value preserved the original wire encoding, causing scripts that hash or compare serialized data to reject canonical mainnet transactions.

- Returns a deep copy with every `Constr`, `Map`, and `List` node reset to the package default encoding; the mutable `Constr` tag is copied, `Integer`/`ByteString` pass through untouched, and value-form containers normalize too (returning as pointers, like `Clone`). `Constr` and `List` default to indefinite (definite when empty), while `Map` always defaults to definite.
- Not wired into `Decode`; callers building script-visible values (redeemer data, datums) from decoded data should call it at that boundary, since decode-time fidelity is still required for script-data hash verification.
- Two corpus tests against `replay/testdata/mainnet.json` pin the defaults; the node-constructed `ScriptContext` test verifies the last argument is actually a context (argument count by language/purpose, plus `Constr` type) so it can't silently check submitter-supplied data.

<sup>Written for commit 8bc0f20352272c0e2f75f8d0dfc277125a00312d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/plutigo/pull/397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalizing Plutus data now independently copies mutable constructor tags, preventing changes to normalized values from affecting the original data.
  * Nil constructor tags remain unchanged.
  * Container encoding continues to be standardized while preserving data structure and values.

* **Tests**
  * Expanded coverage for nested containers, empty values, encoding defaults, bidirectional normalization, deep-copy behavior, nil tags, and unchanged leaf values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
