### PR TITLE
fix(cek): validate all BLS MSM scalars

### DIFF
--- a/cek/builtins.go
+++ b/cek/builtins.go
@@ -57,7 +57,7 @@ func validateBLSMSMScalars(
 ) error {
 	for _, scalar := range scalars {
 		integer, ok := scalar.(*syn.Integer)
-		if !ok {
+		if !ok || integer == nil || integer.Inner == nil {
 			return &BuiltinError{
 				Code:    ErrCodeInvalidArgument,
 				Builtin: builtinName,

--- a/cek/builtins.go
+++ b/cek/builtins.go
@@ -51,6 +51,30 @@ func validBLSMSMScalar(scalar *big.Int) bool {
 	return scalar.Cmp(blsMSMScalarLimit) < 0
 }
 
+func validateBLSMSMScalars(
+	scalars []syn.IConstant,
+	builtinName string,
+) error {
+	for _, scalar := range scalars {
+		integer, ok := scalar.(*syn.Integer)
+		if !ok {
+			return &BuiltinError{
+				Code:    ErrCodeInvalidArgument,
+				Builtin: builtinName,
+				Message: "expected integer list",
+			}
+		}
+		if !validBLSMSMScalar(integer.Inner) {
+			return &BuiltinError{
+				Code:    ErrCodeInvalidArgument,
+				Builtin: builtinName,
+				Message: "scalar is outside the signed 4096-bit range",
+			}
+		}
+	}
+	return nil
+}
+
 const (
 	ed25519VerifyCacheLimit  = 4096
 	ed25519VerifyMaxCacheMsg = 64
@@ -2681,6 +2705,12 @@ func bls12381G1MultiScalarMul[T syn.Eval](
 	if err != nil {
 		return nil, err
 	}
+	if err := validateBLSMSMScalars(
+		ints.List,
+		"bls12_381_G1_multiScalarMul",
+	); err != nil {
+		return nil, err
+	}
 
 	// Compute multi-scalar multiplication: sum_i (n_i * p_i)
 	res := new(bls.G1Jac)
@@ -2694,13 +2724,6 @@ func bls12381G1MultiScalarMul[T syn.Eval](
 				Code:    ErrCodeInvalidArgument,
 				Builtin: "bls12_381_G1_multiScalarMul",
 				Message: "expected integer list",
-			}
-		}
-		if !validBLSMSMScalar(ni.Inner) {
-			return nil, &BuiltinError{
-				Code:    ErrCodeInvalidArgument,
-				Builtin: "bls12_381_G1_multiScalarMul",
-				Message: "scalar is outside the signed 4096-bit range",
 			}
 		}
 		pi, ok := elems.List[i].(*syn.Bls12_381G1Element)
@@ -2747,6 +2770,12 @@ func bls12381G2MultiScalarMul[T syn.Eval](
 	if err != nil {
 		return nil, err
 	}
+	if err := validateBLSMSMScalars(
+		ints.List,
+		"bls12_381_G2_multiScalarMul",
+	); err != nil {
+		return nil, err
+	}
 
 	// Compute multi-scalar multiplication: sum_i (n_i * p_i)
 	res := new(bls.G2Jac)
@@ -2760,13 +2789,6 @@ func bls12381G2MultiScalarMul[T syn.Eval](
 				Code:    ErrCodeInvalidArgument,
 				Builtin: "bls12_381_G2_multiScalarMul",
 				Message: "expected integer list",
-			}
-		}
-		if !validBLSMSMScalar(ni.Inner) {
-			return nil, &BuiltinError{
-				Code:    ErrCodeInvalidArgument,
-				Builtin: "bls12_381_G2_multiScalarMul",
-				Message: "scalar is outside the signed 4096-bit range",
 			}
 		}
 		pi, ok := elems.List[i].(*syn.Bls12_381G2Element)

--- a/cek/builtins_test.go
+++ b/cek/builtins_test.go
@@ -4669,13 +4669,13 @@ func TestBLSMultiScalarMulValidatesUnpairedScalar(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			evaluate := func(secondScalar *big.Int) (Value[syn.DeBruijn], error) {
+			evaluate := func(secondScalar syn.IConstant) (Value[syn.DeBruijn], error) {
 				b := newTestBuiltin(tt.builtinFunc)
 				b = b.ApplyArg(&Constant{&syn.ProtoList{
 					LTyp: &syn.TInteger{},
 					List: []syn.IConstant{
 						&syn.Integer{Inner: big.NewInt(1)},
-						&syn.Integer{Inner: secondScalar},
+						secondScalar,
 					},
 				}})
 				b = b.ApplyArg(&Constant{&syn.ProtoList{
@@ -4685,13 +4685,13 @@ func TestBLSMultiScalarMulValidatesUnpairedScalar(t *testing.T) {
 				return evalBuiltinWithError(t, newTestMachineV4(), b)
 			}
 
-			val, err := evaluate(big.NewInt(2))
+			val, err := evaluate(&syn.Integer{Inner: big.NewInt(2)})
 			if err != nil {
 				t.Fatalf("valid length mismatch returned error: %v", err)
 			}
 			tt.checkResult(t, val)
 
-			_, err = evaluate(limit)
+			_, err = evaluate(&syn.Integer{Inner: limit})
 			var builtinErr *BuiltinError
 			if !errors.As(err, &builtinErr) {
 				t.Fatalf("expected BuiltinError for unpaired out-of-range scalar, got %v", err)
@@ -4703,6 +4703,21 @@ func TestBLSMultiScalarMulValidatesUnpairedScalar(t *testing.T) {
 				t.Fatalf("expected builtin %q, got %q", tt.builtinName, builtinErr.Builtin)
 			}
 			if builtinErr.Message != "scalar is outside the signed 4096-bit range" {
+				t.Fatalf("unexpected error message: %q", builtinErr.Message)
+			}
+
+			_, err = evaluate(&syn.Integer{})
+			builtinErr = nil
+			if !errors.As(err, &builtinErr) {
+				t.Fatalf("expected BuiltinError for unpaired malformed scalar, got %v", err)
+			}
+			if builtinErr.Code != ErrCodeInvalidArgument {
+				t.Fatalf("expected ErrCodeInvalidArgument, got %d", builtinErr.Code)
+			}
+			if builtinErr.Builtin != tt.builtinName {
+				t.Fatalf("expected builtin %q, got %q", tt.builtinName, builtinErr.Builtin)
+			}
+			if builtinErr.Message != "expected integer list" {
 				t.Fatalf("unexpected error message: %q", builtinErr.Message)
 			}
 		})

--- a/cek/builtins_test.go
+++ b/cek/builtins_test.go
@@ -4620,6 +4620,95 @@ func TestBLSMSMScalarBounds(t *testing.T) {
 	}
 }
 
+func TestBLSMultiScalarMulValidatesUnpairedScalar(t *testing.T) {
+	limit := new(big.Int).Lsh(big.NewInt(1), 4095)
+	g1Gen, g2Gen, _, _ := bls.Generators()
+	tests := []struct {
+		name        string
+		builtinFunc builtin.DefaultFunction
+		builtinName string
+		elemType    syn.Typ
+		elem        syn.IConstant
+		checkResult func(*testing.T, Value[syn.DeBruijn])
+	}{
+		{
+			name:        "G1",
+			builtinFunc: builtin.Bls12_381_G1_MultiScalarMul,
+			builtinName: "bls12_381_G1_multiScalarMul",
+			elemType:    &syn.TBls12_381G1Element{},
+			elem:        &syn.Bls12_381G1Element{Inner: &g1Gen},
+			checkResult: func(t *testing.T, val Value[syn.DeBruijn]) {
+				t.Helper()
+				got, ok := expectConstant(t, val).Constant.(*syn.Bls12_381G1Element)
+				if !ok {
+					t.Fatalf("expected G1 result, got %T", val)
+				}
+				if !got.Inner.Equal(&g1Gen) {
+					t.Fatal("valid length mismatch should use the paired G1 prefix")
+				}
+			},
+		},
+		{
+			name:        "G2",
+			builtinFunc: builtin.Bls12_381_G2_MultiScalarMul,
+			builtinName: "bls12_381_G2_multiScalarMul",
+			elemType:    &syn.TBls12_381G2Element{},
+			elem:        &syn.Bls12_381G2Element{Inner: &g2Gen},
+			checkResult: func(t *testing.T, val Value[syn.DeBruijn]) {
+				t.Helper()
+				got, ok := expectConstant(t, val).Constant.(*syn.Bls12_381G2Element)
+				if !ok {
+					t.Fatalf("expected G2 result, got %T", val)
+				}
+				if !got.Inner.Equal(&g2Gen) {
+					t.Fatal("valid length mismatch should use the paired G2 prefix")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			evaluate := func(secondScalar *big.Int) (Value[syn.DeBruijn], error) {
+				b := newTestBuiltin(tt.builtinFunc)
+				b = b.ApplyArg(&Constant{&syn.ProtoList{
+					LTyp: &syn.TInteger{},
+					List: []syn.IConstant{
+						&syn.Integer{Inner: big.NewInt(1)},
+						&syn.Integer{Inner: secondScalar},
+					},
+				}})
+				b = b.ApplyArg(&Constant{&syn.ProtoList{
+					LTyp: tt.elemType,
+					List: []syn.IConstant{tt.elem},
+				}})
+				return evalBuiltinWithError(t, newTestMachineV4(), b)
+			}
+
+			val, err := evaluate(big.NewInt(2))
+			if err != nil {
+				t.Fatalf("valid length mismatch returned error: %v", err)
+			}
+			tt.checkResult(t, val)
+
+			_, err = evaluate(limit)
+			var builtinErr *BuiltinError
+			if !errors.As(err, &builtinErr) {
+				t.Fatalf("expected BuiltinError for unpaired out-of-range scalar, got %v", err)
+			}
+			if builtinErr.Code != ErrCodeInvalidArgument {
+				t.Fatalf("expected ErrCodeInvalidArgument, got %d", builtinErr.Code)
+			}
+			if builtinErr.Builtin != tt.builtinName {
+				t.Fatalf("expected builtin %q, got %q", tt.builtinName, builtinErr.Builtin)
+			}
+			if builtinErr.Message != "scalar is outside the signed 4096-bit range" {
+				t.Fatalf("unexpected error message: %q", builtinErr.Message)
+			}
+		})
+	}
+}
+
 // TestDataBuiltinsRejectMalformedElements verifies constrData/listData/mapData
 // return a typed error rather than panicking when handed a list whose declared
 // element type is Data (or pair-of-Data) but whose actual elements are not.


### PR DESCRIPTION
Validate every BLS12-381 MSM scalar against the signed 4096-bit bound before pairing the scalar and point lists.

Preserve the existing prefix behavior for valid length mismatches while rejecting an out-of-range scalar beyond the paired prefix.

Fixes #399
