### PR TITLE
build: require Go 1.26

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,7 +11,7 @@ jobs:
     name: benchmark
     strategy:
       matrix:
-        go-version: [1.25.x, 1.26.x]
+        go-version: [1.26.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -16,7 +16,7 @@ jobs:
     name: go-test
     strategy:
       matrix:
-        go-version: [1.25.x, 1.26.x]
+        go-version: [1.26.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This document provides comprehensive guidance for AI agents working on the pluti
 
 ```bash
 # Verify environment
-go version          # Must be 1.25+ (1.26+ recommended)
+go version          # Must be 1.26+
 make test           # Run all tests
 golangci-lint run   # Lint check
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -28,7 +28,7 @@ For organization-wide contributing guidelines (conventional commits, DCO sign-of
 
 ### Prerequisites
 
-- **Go 1.25+** (Go 1.26+ recommended for ~10% better performance)
+- **Go 1.26+**
 - **make** - Build automation
 - **git** - Version control
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ must use the ledger language rather than infer it from the UPLC program header.
 
 ### Prerequisites
 
-- Go 1.25+ (Go 1.26+ recommended for ~10% better performance)
+- Go 1.26+
 - make
 
 ### Setup

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/blinklabs-io/plutigo
 
-go 1.25.7
-
-toolchain go1.25.8
+go 1.26.0
 
 require (
 	github.com/btcsuite/btcd/btcec/v2 v2.5.0


### PR DESCRIPTION
## Summary

- Run test and benchmark workflows on Go 1.26 only.
- Require Go 1.26 in the module and current development prerequisites.

## Validation

- `make test`
- `go test ./...`
- `golangci-lint run ./...`
- `govulncheck ./...`
- `actionlint .github/workflows/go-test.yml .github/workflows/benchmark.yml`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Requires Go 1.26 as the minimum version and runs CI on Go 1.26 only, replacing the previous 1.25+ support.

- Updates `go.mod` to `go 1.26.0` and removes the toolchain directive.
- Changes test and benchmark workflows to only use Go 1.26.x.
- Updates documentation prerequisites to require Go 1.26+.

<sup>Written for commit eaf241909daed60baae690e8ec11ef1bf19e15ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/plutigo/pull/401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated project prerequisites to require Go 1.26 or later.
  - Updated the module configuration to target Go 1.26.

- **Chores**
  - Benchmark and test automation now run against Go 1.26 only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->